### PR TITLE
Add overlays for sector subbooster phase shifters.

### DIFF
--- a/bmad/models/cu_hxr/cu_hxr.lat.bmad
+++ b/bmad/models/cu_hxr/cu_hxr.lat.bmad
@@ -71,6 +71,7 @@ RWWAKE5H[sr_wake%amp_scale] = 130
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/klystrons.bmad
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/klystron_design_settings.bmad
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_overlays.bmad 
+call, file =  $LCLS_LATTICE/bmad/overlays/cu/sbst_phase_overlays.bmad
 
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_defaults.bmad 
 

--- a/bmad/models/cu_sxr/cu_sxr.lat.bmad
+++ b/bmad/models/cu_sxr/cu_sxr.lat.bmad
@@ -70,7 +70,8 @@ RWWAKE5S[sr_wake%amp_scale] = 110
 ! 
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/klystrons.bmad
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/klystron_design_settings.bmad
-call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_overlays.bmad 
+call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_overlays.bmad
+call, file =  $LCLS_LATTICE/bmad/overlays/cu/sbst_phase_overlays.bmad
 
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_defaults.bmad 
 

--- a/bmad/overlays/cu/sbst_phase_overlays.bmad
+++ b/bmad/overlays/cu/sbst_phase_overlays.bmad
@@ -1,0 +1,112 @@
+!--------------
+!subbooster 21 overlay
+O_SBST_21: overlay = {
+  O_K21_3[phase_deg]:sbst_phase_deg,
+  O_K21_4[phase_deg]:sbst_phase_deg,
+  O_K21_5[phase_deg]:sbst_phase_deg,
+  O_K21_6[phase_deg]:sbst_phase_deg,
+  O_K21_7[phase_deg]:sbst_phase_deg,
+  O_K21_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 22 overlay
+O_SBST_22: overlay = {
+  O_K22_1[phase_deg]:sbst_phase_deg,
+  O_K22_2[phase_deg]:sbst_phase_deg,
+  O_K22_3[phase_deg]:sbst_phase_deg,
+  O_K22_4[phase_deg]:sbst_phase_deg,
+  O_K22_5[phase_deg]:sbst_phase_deg,
+  O_K22_6[phase_deg]:sbst_phase_deg,
+  O_K22_7[phase_deg]:sbst_phase_deg,
+  O_K22_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 23 overlay
+O_SBST_23: overlay = {
+  O_K23_1[phase_deg]:sbst_phase_deg,
+  O_K23_2[phase_deg]:sbst_phase_deg,
+  O_K23_3[phase_deg]:sbst_phase_deg,
+  O_K23_4[phase_deg]:sbst_phase_deg,
+  O_K23_5[phase_deg]:sbst_phase_deg,
+  O_K23_6[phase_deg]:sbst_phase_deg,
+  O_K23_7[phase_deg]:sbst_phase_deg,
+  O_K23_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 24 overlay
+O_SBST_24: overlay = {
+  O_K24_4[phase_deg]:sbst_phase_deg,
+  O_K24_5[phase_deg]:sbst_phase_deg,
+  O_K24_6[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 25 overlay
+O_SBST_25: overlay = {
+  O_K25_1[phase_deg]:sbst_phase_deg,
+  O_K25_2[phase_deg]:sbst_phase_deg,
+  O_K25_3[phase_deg]:sbst_phase_deg,
+  O_K25_4[phase_deg]:sbst_phase_deg,
+  O_K25_5[phase_deg]:sbst_phase_deg,
+  O_K25_6[phase_deg]:sbst_phase_deg,
+  O_K25_7[phase_deg]:sbst_phase_deg,
+  O_K25_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 26 overlay
+O_SBST_26: overlay = {
+  O_K26_1[phase_deg]:sbst_phase_deg,
+  O_K26_2[phase_deg]:sbst_phase_deg,
+  O_K26_3[phase_deg]:sbst_phase_deg,
+  O_K26_4[phase_deg]:sbst_phase_deg,
+  O_K26_5[phase_deg]:sbst_phase_deg,
+  O_K26_6[phase_deg]:sbst_phase_deg,
+  O_K26_7[phase_deg]:sbst_phase_deg,
+  O_K26_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 27 overlay
+O_SBST_27: overlay = {
+  O_K27_1[phase_deg]:sbst_phase_deg,
+  O_K27_2[phase_deg]:sbst_phase_deg,
+  O_K27_3[phase_deg]:sbst_phase_deg,
+  O_K27_4[phase_deg]:sbst_phase_deg,
+  O_K27_5[phase_deg]:sbst_phase_deg,
+  O_K27_6[phase_deg]:sbst_phase_deg,
+  O_K27_7[phase_deg]:sbst_phase_deg,
+  O_K27_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 28 overlay
+O_SBST_28: overlay = {
+  O_K28_1[phase_deg]:sbst_phase_deg,
+  O_K28_2[phase_deg]:sbst_phase_deg,
+  O_K28_3[phase_deg]:sbst_phase_deg,
+  O_K28_4[phase_deg]:sbst_phase_deg,
+  O_K28_5[phase_deg]:sbst_phase_deg,
+  O_K28_6[phase_deg]:sbst_phase_deg,
+  O_K28_7[phase_deg]:sbst_phase_deg,
+  O_K28_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 29 overlay
+O_SBST_29: overlay = {
+  O_K29_1[phase_deg]:sbst_phase_deg,
+  O_K29_2[phase_deg]:sbst_phase_deg,
+  O_K29_3[phase_deg]:sbst_phase_deg,
+  O_K29_4[phase_deg]:sbst_phase_deg,
+  O_K29_5[phase_deg]:sbst_phase_deg,
+  O_K29_6[phase_deg]:sbst_phase_deg,
+  O_K29_7[phase_deg]:sbst_phase_deg,
+  O_K29_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 30 overlay
+O_SBST_30: overlay = {
+  O_K30_1[phase_deg]:sbst_phase_deg,
+  O_K30_2[phase_deg]:sbst_phase_deg,
+  O_K30_3[phase_deg]:sbst_phase_deg,
+  O_K30_4[phase_deg]:sbst_phase_deg,
+  O_K30_5[phase_deg]:sbst_phase_deg,
+  O_K30_6[phase_deg]:sbst_phase_deg,
+  O_K30_7[phase_deg]:sbst_phase_deg,
+  O_K30_8[phase_deg]:sbst_phase_deg}, var = {sbst_phase_deg}

--- a/bmad/overlays/cu/source/klystron_overlays.ipynb
+++ b/bmad/overlays/cu/source/klystron_overlays.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,24 +15,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Initialized Tao with /var/folders/wj/lfgr01993dx79p9cm_skykbw0000gn/T/tmpm_8_s0d3/tao/tao.init\n"
+      "Initialized Tao with /var/folders/29/9rt0s28n40xffr24q_0847tm0000gn/T/tmpu9djy_z8/tao/tao.init\n"
      ]
     }
    ],
    "source": [
-    "M = TaoModel('/Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_linac/tao.init')"
+    "M = TaoModel('../../../models/cu_linac/tao.init', ploton=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +104,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -124,7 +124,7 @@
        "60.4420743449993"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +220,7 @@
        " 'K30_8': ['A', 'B', 'C']}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,119 +248,119 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "OrderedDict([('L', L;REAL;True;2.8692),\n",
-       "             ('units#L', units#L;STR;False;m),\n",
-       "             ('TILT', TILT;REAL;True;0.0),\n",
-       "             ('units#TILT', units#TILT;STR;False;rad),\n",
-       "             ('RF_FREQUENCY', RF_FREQUENCY;REAL;True;2856000000.0),\n",
-       "             ('units#RF_FREQUENCY', units#RF_FREQUENCY;STR;False;Hz),\n",
-       "             ('GRADIENT', GRADIENT;REAL;True;15822375.447498),\n",
-       "             ('units#GRADIENT', units#GRADIENT;STR;False;eV/m),\n",
-       "             ('GRADIENT_ERR', GRADIENT_ERR;REAL;True;0.0),\n",
-       "             ('units#GRADIENT_ERR', units#GRADIENT_ERR;STR;False;eV/m),\n",
-       "             ('VOLTAGE', VOLTAGE;REAL;False;45397559.633962),\n",
-       "             ('units#VOLTAGE', units#VOLTAGE;STR;False;Volt),\n",
-       "             ('VOLTAGE_ERR', VOLTAGE_ERR;REAL;False;0.0),\n",
-       "             ('units#VOLTAGE_ERR', units#VOLTAGE_ERR;STR;False;Volt),\n",
-       "             ('FRINGE_TYPE', FRINGE_TYPE;ENUM;True;Full),\n",
-       "             ('FRINGE_AT', FRINGE_AT;ENUM;True;Both_Ends),\n",
-       "             ('SPIN_FRINGE_ON', SPIN_FRINGE_ON;LOGIC;True;True),\n",
-       "             ('AUTOSCALE_AMPLITUDE', AUTOSCALE_AMPLITUDE;LOGIC;True;True),\n",
-       "             ('AUTOSCALE_PHASE', AUTOSCALE_PHASE;LOGIC;True;True),\n",
-       "             ('LONGITUDINAL_MODE', LONGITUDINAL_MODE;INT;True;1),\n",
-       "             ('E_LOSS', E_LOSS;REAL;True;0.0),\n",
-       "             ('units#E_LOSS', units#E_LOSS;STR;False;eV),\n",
-       "             ('CAVITY_TYPE', CAVITY_TYPE;ENUM;True;Traveling_Wave),\n",
-       "             ('PHI0', PHI0;REAL;True;-0.059722222222222),\n",
-       "             ('units#PHI0', units#PHI0;STR;False;rad/2pi),\n",
-       "             ('PHI0_ERR', PHI0_ERR;REAL;True;0.0),\n",
-       "             ('units#PHI0_ERR', units#PHI0_ERR;STR;False;rad/2pi),\n",
-       "             ('PHI0_MULTIPASS', PHI0_MULTIPASS;REAL;True;0.0),\n",
-       "             ('units#PHI0_MULTIPASS', units#PHI0_MULTIPASS;STR;False;rad/2pi),\n",
-       "             ('PHI0_AUTOSCALE', PHI0_AUTOSCALE;REAL;True;0.0),\n",
-       "             ('units#PHI0_AUTOSCALE', units#PHI0_AUTOSCALE;STR;False;rad/2pi),\n",
-       "             ('FIELD_AUTOSCALE', FIELD_AUTOSCALE;REAL;True;1.0),\n",
-       "             ('units#FIELD_AUTOSCALE', units#FIELD_AUTOSCALE;STR;False;),\n",
-       "             ('L_HARD_EDGE', L_HARD_EDGE;REAL;False;2.8692),\n",
-       "             ('units#L_HARD_EDGE', units#L_HARD_EDGE;STR;False;m),\n",
-       "             ('N_CELL', N_CELL;INT;True;1),\n",
-       "             ('X_PITCH', X_PITCH;REAL;True;0.0),\n",
-       "             ('units#X_PITCH', units#X_PITCH;STR;False;),\n",
-       "             ('Y_PITCH', Y_PITCH;REAL;True;0.0),\n",
-       "             ('units#Y_PITCH', units#Y_PITCH;STR;False;),\n",
-       "             ('X_OFFSET', X_OFFSET;REAL;True;0.0),\n",
-       "             ('units#X_OFFSET', units#X_OFFSET;STR;False;m),\n",
-       "             ('Y_OFFSET', Y_OFFSET;REAL;True;0.0),\n",
-       "             ('units#Y_OFFSET', units#Y_OFFSET;STR;False;m),\n",
-       "             ('Z_OFFSET', Z_OFFSET;REAL;True;0.0),\n",
-       "             ('units#Z_OFFSET', units#Z_OFFSET;STR;False;m),\n",
-       "             ('HKICK', HKICK;REAL;True;0.0),\n",
-       "             ('units#HKICK', units#HKICK;STR;False;),\n",
-       "             ('VKICK', VKICK;REAL;True;0.0),\n",
-       "             ('units#VKICK', units#VKICK;STR;False;),\n",
-       "             ('BL_HKICK', BL_HKICK;REAL;True;-0.0),\n",
-       "             ('units#BL_HKICK', units#BL_HKICK;STR;False;T*m),\n",
-       "             ('BL_VKICK', BL_VKICK;REAL;True;-0.0),\n",
-       "             ('units#BL_VKICK', units#BL_VKICK;STR;False;T*m),\n",
-       "             ('COUPLER_PHASE', COUPLER_PHASE;REAL;True;0.0),\n",
-       "             ('units#COUPLER_PHASE', units#COUPLER_PHASE;STR;False;rad/2pi),\n",
-       "             ('COUPLER_ANGLE', COUPLER_ANGLE;REAL;True;0.0),\n",
-       "             ('units#COUPLER_ANGLE', units#COUPLER_ANGLE;STR;False;rad),\n",
-       "             ('COUPLER_STRENGTH', COUPLER_STRENGTH;REAL;True;0.0),\n",
-       "             ('units#COUPLER_STRENGTH', units#COUPLER_STRENGTH;STR;False;),\n",
-       "             ('COUPLER_AT', COUPLER_AT;ENUM;True;Exit_End),\n",
-       "             ('DELTA_REF_TIME', DELTA_REF_TIME;REAL;False;9.570673242386e-09),\n",
-       "             ('units#DELTA_REF_TIME', units#DELTA_REF_TIME;STR;False;sec),\n",
-       "             ('P0C_START', P0C_START;REAL;True;134999032.8857),\n",
-       "             ('units#P0C_START', units#P0C_START;STR;False;eV),\n",
-       "             ('E_TOT_START', E_TOT_START;REAL;True;135000000.0),\n",
-       "             ('units#E_TOT_START', units#E_TOT_START;STR;False;eV),\n",
-       "             ('P0C', P0C;REAL;False;177237950.39187),\n",
-       "             ('units#P0C', units#P0C;STR;False;eV),\n",
-       "             ('E_TOT', E_TOT;REAL;False;177238687.02695),\n",
-       "             ('units#E_TOT', units#E_TOT;STR;False;eV),\n",
-       "             ('X_PITCH_TOT', X_PITCH_TOT;REAL;False;0.0),\n",
-       "             ('units#X_PITCH_TOT', units#X_PITCH_TOT;STR;False;),\n",
-       "             ('Y_PITCH_TOT', Y_PITCH_TOT;REAL;False;0.0),\n",
-       "             ('units#Y_PITCH_TOT', units#Y_PITCH_TOT;STR;False;),\n",
-       "             ('X_OFFSET_TOT', X_OFFSET_TOT;REAL;False;0.0),\n",
-       "             ('units#X_OFFSET_TOT', units#X_OFFSET_TOT;STR;False;m),\n",
-       "             ('Y_OFFSET_TOT', Y_OFFSET_TOT;REAL;False;0.0),\n",
-       "             ('units#Y_OFFSET_TOT', units#Y_OFFSET_TOT;STR;False;m),\n",
-       "             ('Z_OFFSET_TOT', Z_OFFSET_TOT;REAL;False;0.0),\n",
-       "             ('units#Z_OFFSET_TOT', units#Z_OFFSET_TOT;STR;False;m),\n",
-       "             ('TILT_TOT', TILT_TOT;REAL;False;0.0),\n",
-       "             ('units#TILT_TOT', units#TILT_TOT;STR;False;rad),\n",
-       "             ('MULTIPASS_REF_ENERGY', MULTIPASS_REF_ENERGY;ENUM;True;User_Set),\n",
-       "             ('INTEGRATOR_ORDER', INTEGRATOR_ORDER;INT;True;0),\n",
-       "             ('NUM_STEPS', NUM_STEPS;INT;False;10),\n",
-       "             ('DS_STEP', DS_STEP;REAL;True;0.28692),\n",
-       "             ('units#DS_STEP', units#DS_STEP;STR;False;m),\n",
-       "             ('LORD_PAD1', LORD_PAD1;REAL;True;0.0),\n",
-       "             ('units#LORD_PAD1', units#LORD_PAD1;STR;False;m),\n",
-       "             ('LORD_PAD2', LORD_PAD2;REAL;True;0.0),\n",
-       "             ('units#LORD_PAD2', units#LORD_PAD2;STR;False;m),\n",
-       "             ('X1_LIMIT', X1_LIMIT;REAL;True;0.0),\n",
-       "             ('units#X1_LIMIT', units#X1_LIMIT;STR;False;m),\n",
-       "             ('X2_LIMIT', X2_LIMIT;REAL;True;0.0),\n",
-       "             ('units#X2_LIMIT', units#X2_LIMIT;STR;False;m),\n",
-       "             ('Y1_LIMIT', Y1_LIMIT;REAL;True;0.0),\n",
-       "             ('units#Y1_LIMIT', units#Y1_LIMIT;STR;False;m),\n",
-       "             ('Y2_LIMIT', Y2_LIMIT;REAL;True;0.0),\n",
-       "             ('units#Y2_LIMIT', units#Y2_LIMIT;STR;False;m),\n",
-       "             ('aperture_at', aperture_at;ENUM;True;Exit_End),\n",
-       "             ('offset_moves_aperture', offset_moves_aperture;LOGIC;True;False),\n",
-       "             ('aperture_type', aperture_type;ENUM;True;Rectangular),\n",
-       "             ('field_master', field_master;LOGIC;True;False)])"
+       "OrderedDict([('L', REAL;True;2.8692),\n",
+       "             ('units#L', STR;False;m),\n",
+       "             ('TILT', REAL;True;0.0),\n",
+       "             ('units#TILT', STR;False;rad),\n",
+       "             ('RF_FREQUENCY', REAL;True;2856000000.0),\n",
+       "             ('units#RF_FREQUENCY', STR;False;Hz),\n",
+       "             ('GRADIENT', REAL;True;15822375.447498),\n",
+       "             ('units#GRADIENT', STR;False;eV/m),\n",
+       "             ('GRADIENT_ERR', REAL;True;0.0),\n",
+       "             ('units#GRADIENT_ERR', STR;False;eV/m),\n",
+       "             ('VOLTAGE', REAL;False;45397559.633962),\n",
+       "             ('units#VOLTAGE', STR;False;Volt),\n",
+       "             ('VOLTAGE_ERR', REAL;False;0.0),\n",
+       "             ('units#VOLTAGE_ERR', STR;False;Volt),\n",
+       "             ('FRINGE_TYPE', ENUM;True;Full),\n",
+       "             ('FRINGE_AT', ENUM;True;Both_Ends),\n",
+       "             ('SPIN_FRINGE_ON', LOGIC;True;True),\n",
+       "             ('AUTOSCALE_AMPLITUDE', LOGIC;True;True),\n",
+       "             ('AUTOSCALE_PHASE', LOGIC;True;True),\n",
+       "             ('LONGITUDINAL_MODE', INT;True;1),\n",
+       "             ('E_LOSS', REAL;True;0.0),\n",
+       "             ('units#E_LOSS', STR;False;eV),\n",
+       "             ('CAVITY_TYPE', ENUM;True;Traveling_Wave),\n",
+       "             ('PHI0', REAL;True;-0.059722222222222),\n",
+       "             ('units#PHI0', STR;False;rad/2pi),\n",
+       "             ('PHI0_ERR', REAL;True;0.0),\n",
+       "             ('units#PHI0_ERR', STR;False;rad/2pi),\n",
+       "             ('PHI0_MULTIPASS', REAL;True;0.0),\n",
+       "             ('units#PHI0_MULTIPASS', STR;False;rad/2pi),\n",
+       "             ('PHI0_AUTOSCALE', REAL;True;0.0),\n",
+       "             ('units#PHI0_AUTOSCALE', STR;False;rad/2pi),\n",
+       "             ('FIELD_AUTOSCALE', REAL;True;1.0),\n",
+       "             ('units#FIELD_AUTOSCALE', STR;False;),\n",
+       "             ('L_HARD_EDGE', REAL;False;2.8692),\n",
+       "             ('units#L_HARD_EDGE', STR;False;m),\n",
+       "             ('N_CELL', INT;True;1),\n",
+       "             ('X_PITCH', REAL;True;0.0),\n",
+       "             ('units#X_PITCH', STR;False;),\n",
+       "             ('Y_PITCH', REAL;True;0.0),\n",
+       "             ('units#Y_PITCH', STR;False;),\n",
+       "             ('X_OFFSET', REAL;True;0.0),\n",
+       "             ('units#X_OFFSET', STR;False;m),\n",
+       "             ('Y_OFFSET', REAL;True;0.0),\n",
+       "             ('units#Y_OFFSET', STR;False;m),\n",
+       "             ('Z_OFFSET', REAL;True;0.0),\n",
+       "             ('units#Z_OFFSET', STR;False;m),\n",
+       "             ('HKICK', REAL;True;0.0),\n",
+       "             ('units#HKICK', STR;False;),\n",
+       "             ('VKICK', REAL;True;0.0),\n",
+       "             ('units#VKICK', STR;False;),\n",
+       "             ('BL_HKICK', REAL;True;-0.0),\n",
+       "             ('units#BL_HKICK', STR;False;T*m),\n",
+       "             ('BL_VKICK', REAL;True;-0.0),\n",
+       "             ('units#BL_VKICK', STR;False;T*m),\n",
+       "             ('COUPLER_PHASE', REAL;True;0.0),\n",
+       "             ('units#COUPLER_PHASE', STR;False;rad/2pi),\n",
+       "             ('COUPLER_ANGLE', REAL;True;0.0),\n",
+       "             ('units#COUPLER_ANGLE', STR;False;rad),\n",
+       "             ('COUPLER_STRENGTH', REAL;True;0.0),\n",
+       "             ('units#COUPLER_STRENGTH', STR;False;),\n",
+       "             ('COUPLER_AT', ENUM;True;Exit_End),\n",
+       "             ('DELTA_REF_TIME', REAL;False;9.5706732368096e-09),\n",
+       "             ('units#DELTA_REF_TIME', STR;False;sec),\n",
+       "             ('P0C_START', REAL;True;135007215.17744),\n",
+       "             ('units#P0C_START', STR;False;eV),\n",
+       "             ('E_TOT_START', REAL;True;135008182.23312),\n",
+       "             ('units#E_TOT_START', STR;False;eV),\n",
+       "             ('P0C', REAL;False;177246653.34779),\n",
+       "             ('units#P0C', STR;False;eV),\n",
+       "             ('E_TOT', REAL;False;177247389.94669),\n",
+       "             ('units#E_TOT', STR;False;eV),\n",
+       "             ('X_PITCH_TOT', REAL;False;0.0),\n",
+       "             ('units#X_PITCH_TOT', STR;False;),\n",
+       "             ('Y_PITCH_TOT', REAL;False;0.0),\n",
+       "             ('units#Y_PITCH_TOT', STR;False;),\n",
+       "             ('X_OFFSET_TOT', REAL;False;0.0),\n",
+       "             ('units#X_OFFSET_TOT', STR;False;m),\n",
+       "             ('Y_OFFSET_TOT', REAL;False;0.0),\n",
+       "             ('units#Y_OFFSET_TOT', STR;False;m),\n",
+       "             ('Z_OFFSET_TOT', REAL;False;0.0),\n",
+       "             ('units#Z_OFFSET_TOT', STR;False;m),\n",
+       "             ('TILT_TOT', REAL;False;0.0),\n",
+       "             ('units#TILT_TOT', STR;False;rad),\n",
+       "             ('N_REF_PASS', INT;True;0),\n",
+       "             ('INTEGRATOR_ORDER', INT;True;0),\n",
+       "             ('NUM_STEPS', INT;False;10),\n",
+       "             ('DS_STEP', REAL;True;0.28692),\n",
+       "             ('units#DS_STEP', STR;False;m),\n",
+       "             ('LORD_PAD1', REAL;True;0.0),\n",
+       "             ('units#LORD_PAD1', STR;False;m),\n",
+       "             ('LORD_PAD2', REAL;True;0.0),\n",
+       "             ('units#LORD_PAD2', STR;False;m),\n",
+       "             ('X1_LIMIT', REAL;True;0.0),\n",
+       "             ('units#X1_LIMIT', STR;False;m),\n",
+       "             ('X2_LIMIT', REAL;True;0.0),\n",
+       "             ('units#X2_LIMIT', STR;False;m),\n",
+       "             ('Y1_LIMIT', REAL;True;0.0),\n",
+       "             ('units#Y1_LIMIT', STR;False;m),\n",
+       "             ('Y2_LIMIT', REAL;True;0.0),\n",
+       "             ('units#Y2_LIMIT', STR;False;m),\n",
+       "             ('aperture_at', ENUM;True;Exit_End),\n",
+       "             ('offset_moves_aperture', LOGIC;True;False),\n",
+       "             ('aperture_type', ENUM;True;Rectangular),\n",
+       "             ('field_master', LOGIC;True;False)])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -382,7 +382,7 @@
        "pytao.util.parameters.tao_parameter"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -393,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -402,7 +402,7 @@
        "(45397559.633962, 20000000.0)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -431,7 +431,7 @@
        "True"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -451,7 +451,7 @@
        "(0.25, 0.25, 0.5)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -471,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -480,7 +480,7 @@
        "[0.2928932188134525, 0.2928932188134525, 0.4142135623730951]"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -503,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -2681,7 +2681,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -2690,7 +2690,7 @@
        "(20000000.0, -159.99999999999838)"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2701,7 +2701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -2746,7 +2746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2773,7 +2773,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -2782,7 +2782,7 @@
        "(29.465517944109074, 396.0190743449993, 1027.3396600809867)"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2793,7 +2793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2813,7 +2813,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -2822,7 +2822,7 @@
        "'L1'"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2833,7 +2833,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2846,7 +2846,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -2855,7 +2855,7 @@
        "(['K21_1B', 'K21_1C', 'K21_1D'], 111, 180)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2866,7 +2866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -2875,7 +2875,7 @@
        "(12, 99)"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2895,7 +2895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -2904,7 +2904,7 @@
        "(60, 120)"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2922,7 +2922,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2939,7 +2939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2951,7 +2951,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2966,7 +2966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -2987,7 +2987,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3218,6 +3218,49 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "!--------------\n",
+      "!subbooster 22 overlay\n",
+      "O_SBST_22: overlay = {\n",
+      "  O_K22_1[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_2[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_3[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_4[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_5[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_6[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_7[phase_deg]:sbst_phase_deg,\n",
+      "  O_K22_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Make Subbooster overlays\n",
+    "def sbst_overlay(sector, stations):\n",
+    "    lines = []\n",
+    "    lines.append('!--------------\\n')\n",
+    "    lines.append(f'!subbooster {sector} overlay\\n')\n",
+    "    lines.append(f'O_SBST_{sector}: overlay = {{\\n')\n",
+    "    i=0\n",
+    "    for n in stations:\n",
+    "        i += 1\n",
+    "        lines.append(f'  O_K{sector}_{n}[phase_deg]:sbst_phase_deg,\\n')\n",
+    "    if lines[-1] == '\\n':\n",
+    "        lines.pop()\n",
+    "    lines[-1] = lines[-1][:-1]+'}, var = {sbst_phase_deg}\\n\\n'\n",
+    "    return ''.join(lines)\n",
+    "print(sbst_overlay('22', (1,2,3,4,5,6,7,8)))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -3409,10 +3452,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Subbooster overlays\n",
+    "with open('sbst_phase_overlays.bmad', 'w') as f:\n",
+    "    f.write(sbst_overlay('21', (3,4,5,6,7,8))) #21-1 (L1S) and 21-2 (L1X) dont use the subbooster.\n",
+    "    f.write(sbst_overlay('22', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('23', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('24', (4,5,6))) #1,2,3 are feedback stations, no sbst.  7 is a tcav, 8 doesn't exist.\n",
+    "    f.write(sbst_overlay('25', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('26', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('27', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('28', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('29', (1,2,3,4,5,6,7,8)))\n",
+    "    f.write(sbst_overlay('30', (1,2,3,4,5,6,7,8)))"
+   ]
   },
   {
    "cell_type": "code",
@@ -3438,7 +3494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/bmad/overlays/cu/source/sbst_phase_overlays.bmad
+++ b/bmad/overlays/cu/source/sbst_phase_overlays.bmad
@@ -1,0 +1,113 @@
+!--------------
+!subbooster 21 overlay
+O_SBST_21: overlay = {
+  O_K21_3[phase_deg]:sbst_phase_deg,
+  O_K21_4[phase_deg]:sbst_phase_deg,
+  O_K21_5[phase_deg]:sbst_phase_deg,
+  O_K21_6[phase_deg]:sbst_phase_deg,
+  O_K21_7[phase_deg]:sbst_phase_deg,
+  O_K21_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 22 overlay
+O_SBST_22: overlay = {
+  O_K22_1[phase_deg]:sbst_phase_deg,
+  O_K22_2[phase_deg]:sbst_phase_deg,
+  O_K22_3[phase_deg]:sbst_phase_deg,
+  O_K22_4[phase_deg]:sbst_phase_deg,
+  O_K22_5[phase_deg]:sbst_phase_deg,
+  O_K22_6[phase_deg]:sbst_phase_deg,
+  O_K22_7[phase_deg]:sbst_phase_deg,
+  O_K22_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 23 overlay
+O_SBST_23: overlay = {
+  O_K23_1[phase_deg]:sbst_phase_deg,
+  O_K23_2[phase_deg]:sbst_phase_deg,
+  O_K23_3[phase_deg]:sbst_phase_deg,
+  O_K23_4[phase_deg]:sbst_phase_deg,
+  O_K23_5[phase_deg]:sbst_phase_deg,
+  O_K23_6[phase_deg]:sbst_phase_deg,
+  O_K23_7[phase_deg]:sbst_phase_deg,
+  O_K23_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 24 overlay
+O_SBST_24: overlay = {
+  O_K24_4[phase_deg]:sbst_phase_deg,
+  O_K24_5[phase_deg]:sbst_phase_deg,
+  O_K24_6[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 25 overlay
+O_SBST_25: overlay = {
+  O_K25_1[phase_deg]:sbst_phase_deg,
+  O_K25_2[phase_deg]:sbst_phase_deg,
+  O_K25_3[phase_deg]:sbst_phase_deg,
+  O_K25_4[phase_deg]:sbst_phase_deg,
+  O_K25_5[phase_deg]:sbst_phase_deg,
+  O_K25_6[phase_deg]:sbst_phase_deg,
+  O_K25_7[phase_deg]:sbst_phase_deg,
+  O_K25_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 26 overlay
+O_SBST_26: overlay = {
+  O_K26_1[phase_deg]:sbst_phase_deg,
+  O_K26_2[phase_deg]:sbst_phase_deg,
+  O_K26_3[phase_deg]:sbst_phase_deg,
+  O_K26_4[phase_deg]:sbst_phase_deg,
+  O_K26_5[phase_deg]:sbst_phase_deg,
+  O_K26_6[phase_deg]:sbst_phase_deg,
+  O_K26_7[phase_deg]:sbst_phase_deg,
+  O_K26_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 27 overlay
+O_SBST_27: overlay = {
+  O_K27_1[phase_deg]:sbst_phase_deg,
+  O_K27_2[phase_deg]:sbst_phase_deg,
+  O_K27_3[phase_deg]:sbst_phase_deg,
+  O_K27_4[phase_deg]:sbst_phase_deg,
+  O_K27_5[phase_deg]:sbst_phase_deg,
+  O_K27_6[phase_deg]:sbst_phase_deg,
+  O_K27_7[phase_deg]:sbst_phase_deg,
+  O_K27_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 28 overlay
+O_SBST_28: overlay = {
+  O_K28_1[phase_deg]:sbst_phase_deg,
+  O_K28_2[phase_deg]:sbst_phase_deg,
+  O_K28_3[phase_deg]:sbst_phase_deg,
+  O_K28_4[phase_deg]:sbst_phase_deg,
+  O_K28_5[phase_deg]:sbst_phase_deg,
+  O_K28_6[phase_deg]:sbst_phase_deg,
+  O_K28_7[phase_deg]:sbst_phase_deg,
+  O_K28_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 29 overlay
+O_SBST_29: overlay = {
+  O_K29_1[phase_deg]:sbst_phase_deg,
+  O_K29_2[phase_deg]:sbst_phase_deg,
+  O_K29_3[phase_deg]:sbst_phase_deg,
+  O_K29_4[phase_deg]:sbst_phase_deg,
+  O_K29_5[phase_deg]:sbst_phase_deg,
+  O_K29_6[phase_deg]:sbst_phase_deg,
+  O_K29_7[phase_deg]:sbst_phase_deg,
+  O_K29_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+
+!--------------
+!subbooster 30 overlay
+O_SBST_30: overlay = {
+  O_K30_1[phase_deg]:sbst_phase_deg,
+  O_K30_2[phase_deg]:sbst_phase_deg,
+  O_K30_3[phase_deg]:sbst_phase_deg,
+  O_K30_4[phase_deg]:sbst_phase_deg,
+  O_K30_5[phase_deg]:sbst_phase_deg,
+  O_K30_6[phase_deg]:sbst_phase_deg,
+  O_K30_7[phase_deg]:sbst_phase_deg,
+  O_K30_8[phase_deg]:sbst_phase_deg,}, var = {sbst_phase_deg}
+


### PR DESCRIPTION
Each sector has a 'subbooster' (basically an RF pre-amplifier that boosts the low-level RF before it goes to the klystrons).  Each subbooster has an associated phase shifter that can shift the RF phase of the entire sector.  This PR adds new overlays that represent these phase shifters.