### PR TITLE
Add a new 'in_use' overlay variable to klystrons.

### DIFF
--- a/bmad/overlays/cu/klystrons.bmad
+++ b/bmad/overlays/cu/klystrons.bmad
@@ -2,62 +2,62 @@
 !---------------- 
 ! Special X-band klystron
 O_K21_2: overlay = {
-    L1X[gradient]: f*ENLD_MeV*1e6/L1X[L],
-    L1X[gradient_err]: f*ENLD_MeV_err*1e6/L1X[L],
+    L1X[gradient]: f*in_use*ENLD_MeV*1e6/L1X[L],
+    L1X[gradient_err]: f*in_use*ENLD_MeV_err*1e6/L1X[L],
     L1X[phi0]: phase_deg/360,
     L1X[phi0_err]: phase_deg_err/360},  
-    var = { ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, 
-    f=1, ENLD_MeV=20.0, phase_deg=-160.0
+    var = { ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, 
+    f=1, ENLD_MeV=20.0, phase_deg=-160.0, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: BCD
 !
 O_K21_1: overlay = {
-    K21_1B[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/2.8692,
-    K21_1C[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/2.8692,
-    K21_1D[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K21_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/2.8692,
-    K21_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/2.8692,
-    K21_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K21_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/2.8692,
+    K21_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/2.8692,
+    K21_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K21_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/2.8692,
+    K21_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/2.8692,
+    K21_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
     K21_1B[phi0]:phase_deg/360,
     K21_1C[phi0]:phase_deg/360,
     K21_1D[phi0]:phase_deg/360,
     K21_1B[phi0_err]:phase_deg_err/360,
     K21_1C[phi0_err]:phase_deg_err/360,
-    K21_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: BCD
 !
 O_K21_3: overlay = {
-    K21_3B[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K21_3C[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K21_3D[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K21_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
-    K21_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K21_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K21_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K21_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K21_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K21_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K21_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K21_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
     K21_3B[phi0]:phase_deg/360,
     K21_3C[phi0]:phase_deg/360,
     K21_3D[phi0]:phase_deg/360,
     K21_3B[phi0_err]:phase_deg_err/360,
     K21_3C[phi0_err]:phase_deg_err/360,
-    K21_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K21_4: overlay = {
-    K21_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K21_4A[phi0]:phase_deg/360,
     K21_4B[phi0]:phase_deg/360,
     K21_4C[phi0]:phase_deg/360,
@@ -65,21 +65,21 @@ O_K21_4: overlay = {
     K21_4A[phi0_err]:phase_deg_err/360,
     K21_4B[phi0_err]:phase_deg_err/360,
     K21_4C[phi0_err]:phase_deg_err/360,
-    K21_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K21_5: overlay = {
-    K21_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K21_5A[phi0]:phase_deg/360,
     K21_5B[phi0]:phase_deg/360,
     K21_5C[phi0]:phase_deg/360,
@@ -87,21 +87,21 @@ O_K21_5: overlay = {
     K21_5A[phi0_err]:phase_deg_err/360,
     K21_5B[phi0_err]:phase_deg_err/360,
     K21_5C[phi0_err]:phase_deg_err/360,
-    K21_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K21_6: overlay = {
-    K21_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K21_6A[phi0]:phase_deg/360,
     K21_6B[phi0]:phase_deg/360,
     K21_6C[phi0]:phase_deg/360,
@@ -109,21 +109,21 @@ O_K21_6: overlay = {
     K21_6A[phi0_err]:phase_deg_err/360,
     K21_6B[phi0_err]:phase_deg_err/360,
     K21_6C[phi0_err]:phase_deg_err/360,
-    K21_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K21_7: overlay = {
-    K21_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_7D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K21_7A[phi0]:phase_deg/360,
     K21_7B[phi0]:phase_deg/360,
     K21_7C[phi0]:phase_deg/360,
@@ -131,21 +131,21 @@ O_K21_7: overlay = {
     K21_7A[phi0_err]:phase_deg_err/360,
     K21_7B[phi0_err]:phase_deg_err/360,
     K21_7C[phi0_err]:phase_deg_err/360,
-    K21_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K21_8: overlay = {
-    K21_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K21_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K21_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K21_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K21_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K21_8A[phi0]:phase_deg/360,
     K21_8B[phi0]:phase_deg/360,
     K21_8C[phi0]:phase_deg/360,
@@ -153,21 +153,21 @@ O_K21_8: overlay = {
     K21_8A[phi0_err]:phase_deg_err/360,
     K21_8B[phi0_err]:phase_deg_err/360,
     K21_8C[phi0_err]:phase_deg_err/360,
-    K21_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K21_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_1: overlay = {
-    K22_1A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_1B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_1C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_1D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_1A[phi0]:phase_deg/360,
     K22_1B[phi0]:phase_deg/360,
     K22_1C[phi0]:phase_deg/360,
@@ -175,21 +175,21 @@ O_K22_1: overlay = {
     K22_1A[phi0_err]:phase_deg_err/360,
     K22_1B[phi0_err]:phase_deg_err/360,
     K22_1C[phi0_err]:phase_deg_err/360,
-    K22_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_2: overlay = {
-    K22_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_2A[phi0]:phase_deg/360,
     K22_2B[phi0]:phase_deg/360,
     K22_2C[phi0]:phase_deg/360,
@@ -197,21 +197,21 @@ O_K22_2: overlay = {
     K22_2A[phi0_err]:phase_deg_err/360,
     K22_2B[phi0_err]:phase_deg_err/360,
     K22_2C[phi0_err]:phase_deg_err/360,
-    K22_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_3: overlay = {
-    K22_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_3A[phi0]:phase_deg/360,
     K22_3B[phi0]:phase_deg/360,
     K22_3C[phi0]:phase_deg/360,
@@ -219,21 +219,21 @@ O_K22_3: overlay = {
     K22_3A[phi0_err]:phase_deg_err/360,
     K22_3B[phi0_err]:phase_deg_err/360,
     K22_3C[phi0_err]:phase_deg_err/360,
-    K22_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_4: overlay = {
-    K22_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_4A[phi0]:phase_deg/360,
     K22_4B[phi0]:phase_deg/360,
     K22_4C[phi0]:phase_deg/360,
@@ -241,21 +241,21 @@ O_K22_4: overlay = {
     K22_4A[phi0_err]:phase_deg_err/360,
     K22_4B[phi0_err]:phase_deg_err/360,
     K22_4C[phi0_err]:phase_deg_err/360,
-    K22_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_5: overlay = {
-    K22_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_5A[phi0]:phase_deg/360,
     K22_5B[phi0]:phase_deg/360,
     K22_5C[phi0]:phase_deg/360,
@@ -263,21 +263,21 @@ O_K22_5: overlay = {
     K22_5A[phi0_err]:phase_deg_err/360,
     K22_5B[phi0_err]:phase_deg_err/360,
     K22_5C[phi0_err]:phase_deg_err/360,
-    K22_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_6: overlay = {
-    K22_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_6A[phi0]:phase_deg/360,
     K22_6B[phi0]:phase_deg/360,
     K22_6C[phi0]:phase_deg/360,
@@ -285,21 +285,21 @@ O_K22_6: overlay = {
     K22_6A[phi0_err]:phase_deg_err/360,
     K22_6B[phi0_err]:phase_deg_err/360,
     K22_6C[phi0_err]:phase_deg_err/360,
-    K22_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_7: overlay = {
-    K22_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_7D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_7A[phi0]:phase_deg/360,
     K22_7B[phi0]:phase_deg/360,
     K22_7C[phi0]:phase_deg/360,
@@ -307,21 +307,21 @@ O_K22_7: overlay = {
     K22_7A[phi0_err]:phase_deg_err/360,
     K22_7B[phi0_err]:phase_deg_err/360,
     K22_7C[phi0_err]:phase_deg_err/360,
-    K22_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K22_8: overlay = {
-    K22_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K22_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K22_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K22_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K22_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K22_8A[phi0]:phase_deg/360,
     K22_8B[phi0]:phase_deg/360,
     K22_8C[phi0]:phase_deg/360,
@@ -329,21 +329,21 @@ O_K22_8: overlay = {
     K22_8A[phi0_err]:phase_deg_err/360,
     K22_8B[phi0_err]:phase_deg_err/360,
     K22_8C[phi0_err]:phase_deg_err/360,
-    K22_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K22_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_1: overlay = {
-    K23_1A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_1B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_1C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_1D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_1A[phi0]:phase_deg/360,
     K23_1B[phi0]:phase_deg/360,
     K23_1C[phi0]:phase_deg/360,
@@ -351,21 +351,21 @@ O_K23_1: overlay = {
     K23_1A[phi0_err]:phase_deg_err/360,
     K23_1B[phi0_err]:phase_deg_err/360,
     K23_1C[phi0_err]:phase_deg_err/360,
-    K23_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_2: overlay = {
-    K23_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_2A[phi0]:phase_deg/360,
     K23_2B[phi0]:phase_deg/360,
     K23_2C[phi0]:phase_deg/360,
@@ -373,21 +373,21 @@ O_K23_2: overlay = {
     K23_2A[phi0_err]:phase_deg_err/360,
     K23_2B[phi0_err]:phase_deg_err/360,
     K23_2C[phi0_err]:phase_deg_err/360,
-    K23_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_3: overlay = {
-    K23_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_3A[phi0]:phase_deg/360,
     K23_3B[phi0]:phase_deg/360,
     K23_3C[phi0]:phase_deg/360,
@@ -395,21 +395,21 @@ O_K23_3: overlay = {
     K23_3A[phi0_err]:phase_deg_err/360,
     K23_3B[phi0_err]:phase_deg_err/360,
     K23_3C[phi0_err]:phase_deg_err/360,
-    K23_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_4: overlay = {
-    K23_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_4A[phi0]:phase_deg/360,
     K23_4B[phi0]:phase_deg/360,
     K23_4C[phi0]:phase_deg/360,
@@ -417,21 +417,21 @@ O_K23_4: overlay = {
     K23_4A[phi0_err]:phase_deg_err/360,
     K23_4B[phi0_err]:phase_deg_err/360,
     K23_4C[phi0_err]:phase_deg_err/360,
-    K23_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_5: overlay = {
-    K23_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_5A[phi0]:phase_deg/360,
     K23_5B[phi0]:phase_deg/360,
     K23_5C[phi0]:phase_deg/360,
@@ -439,21 +439,21 @@ O_K23_5: overlay = {
     K23_5A[phi0_err]:phase_deg_err/360,
     K23_5B[phi0_err]:phase_deg_err/360,
     K23_5C[phi0_err]:phase_deg_err/360,
-    K23_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_6: overlay = {
-    K23_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_6A[phi0]:phase_deg/360,
     K23_6B[phi0]:phase_deg/360,
     K23_6C[phi0]:phase_deg/360,
@@ -461,21 +461,21 @@ O_K23_6: overlay = {
     K23_6A[phi0_err]:phase_deg_err/360,
     K23_6B[phi0_err]:phase_deg_err/360,
     K23_6C[phi0_err]:phase_deg_err/360,
-    K23_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_7: overlay = {
-    K23_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_7D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_7A[phi0]:phase_deg/360,
     K23_7B[phi0]:phase_deg/360,
     K23_7C[phi0]:phase_deg/360,
@@ -483,21 +483,21 @@ O_K23_7: overlay = {
     K23_7A[phi0_err]:phase_deg_err/360,
     K23_7B[phi0_err]:phase_deg_err/360,
     K23_7C[phi0_err]:phase_deg_err/360,
-    K23_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K23_8: overlay = {
-    K23_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K23_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K23_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K23_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K23_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K23_8A[phi0]:phase_deg/360,
     K23_8B[phi0]:phase_deg/360,
     K23_8C[phi0]:phase_deg/360,
@@ -505,21 +505,21 @@ O_K23_8: overlay = {
     K23_8A[phi0_err]:phase_deg_err/360,
     K23_8B[phi0_err]:phase_deg_err/360,
     K23_8C[phi0_err]:phase_deg_err/360,
-    K23_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K23_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K24_1: overlay = {
-    K24_1A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_1B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_1C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_1D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K24_1A[phi0]:phase_deg/360,
     K24_1B[phi0]:phase_deg/360,
     K24_1C[phi0]:phase_deg/360,
@@ -527,21 +527,21 @@ O_K24_1: overlay = {
     K24_1A[phi0_err]:phase_deg_err/360,
     K24_1B[phi0_err]:phase_deg_err/360,
     K24_1C[phi0_err]:phase_deg_err/360,
-    K24_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K24_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K24_2: overlay = {
-    K24_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K24_2A[phi0]:phase_deg/360,
     K24_2B[phi0]:phase_deg/360,
     K24_2C[phi0]:phase_deg/360,
@@ -549,21 +549,21 @@ O_K24_2: overlay = {
     K24_2A[phi0_err]:phase_deg_err/360,
     K24_2B[phi0_err]:phase_deg_err/360,
     K24_2C[phi0_err]:phase_deg_err/360,
-    K24_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K24_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K24_3: overlay = {
-    K24_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K24_3A[phi0]:phase_deg/360,
     K24_3B[phi0]:phase_deg/360,
     K24_3C[phi0]:phase_deg/360,
@@ -571,21 +571,21 @@ O_K24_3: overlay = {
     K24_3A[phi0_err]:phase_deg_err/360,
     K24_3B[phi0_err]:phase_deg_err/360,
     K24_3C[phi0_err]:phase_deg_err/360,
-    K24_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K24_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K24_4: overlay = {
-    K24_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K24_4A[phi0]:phase_deg/360,
     K24_4B[phi0]:phase_deg/360,
     K24_4C[phi0]:phase_deg/360,
@@ -593,21 +593,21 @@ O_K24_4: overlay = {
     K24_4A[phi0_err]:phase_deg_err/360,
     K24_4B[phi0_err]:phase_deg_err/360,
     K24_4C[phi0_err]:phase_deg_err/360,
-    K24_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K24_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K24_5: overlay = {
-    K24_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K24_5A[phi0]:phase_deg/360,
     K24_5B[phi0]:phase_deg/360,
     K24_5C[phi0]:phase_deg/360,
@@ -615,21 +615,21 @@ O_K24_5: overlay = {
     K24_5A[phi0_err]:phase_deg_err/360,
     K24_5B[phi0_err]:phase_deg_err/360,
     K24_5C[phi0_err]:phase_deg_err/360,
-    K24_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K24_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K24_6: overlay = {
-    K24_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K24_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K24_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K24_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K24_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K24_6A[phi0]:phase_deg/360,
     K24_6B[phi0]:phase_deg/360,
     K24_6C[phi0]:phase_deg/360,
@@ -637,75 +637,75 @@ O_K24_6: overlay = {
     K24_6A[phi0_err]:phase_deg_err/360,
     K24_6B[phi0_err]:phase_deg_err/360,
     K24_6C[phi0_err]:phase_deg_err/360,
-    K24_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K24_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABD
 !
 O_K25_1: overlay = {
-    K25_1A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K25_1B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K25_1D[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K25_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K25_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K25_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K25_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K25_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K25_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K25_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K25_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K25_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K25_1A[phi0]:phase_deg/360,
     K25_1B[phi0]:phase_deg/360,
     K25_1D[phi0]:phase_deg/360,
     K25_1A[phi0_err]:phase_deg_err/360,
     K25_1B[phi0_err]:phase_deg_err/360,
-    K25_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K25_2: overlay = {
-    K25_2A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K25_2B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K25_2C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K25_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K25_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K25_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K25_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K25_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K25_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K25_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K25_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K25_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K25_2A[phi0]:phase_deg/360,
     K25_2B[phi0]:phase_deg/360,
     K25_2C[phi0]:phase_deg/360,
     K25_2A[phi0_err]:phase_deg_err/360,
     K25_2B[phi0_err]:phase_deg_err/360,
-    K25_2C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_2C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K25_3: overlay = {
-    K25_3A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K25_3B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K25_3C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K25_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K25_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K25_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K25_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K25_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K25_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K25_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K25_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K25_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K25_3A[phi0]:phase_deg/360,
     K25_3B[phi0]:phase_deg/360,
     K25_3C[phi0]:phase_deg/360,
     K25_3A[phi0_err]:phase_deg_err/360,
     K25_3B[phi0_err]:phase_deg_err/360,
-    K25_3C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_3C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K25_4: overlay = {
-    K25_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K25_4A[phi0]:phase_deg/360,
     K25_4B[phi0]:phase_deg/360,
     K25_4C[phi0]:phase_deg/360,
@@ -713,21 +713,21 @@ O_K25_4: overlay = {
     K25_4A[phi0_err]:phase_deg_err/360,
     K25_4B[phi0_err]:phase_deg_err/360,
     K25_4C[phi0_err]:phase_deg_err/360,
-    K25_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K25_5: overlay = {
-    K25_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K25_5A[phi0]:phase_deg/360,
     K25_5B[phi0]:phase_deg/360,
     K25_5C[phi0]:phase_deg/360,
@@ -735,21 +735,21 @@ O_K25_5: overlay = {
     K25_5A[phi0_err]:phase_deg_err/360,
     K25_5B[phi0_err]:phase_deg_err/360,
     K25_5C[phi0_err]:phase_deg_err/360,
-    K25_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K25_6: overlay = {
-    K25_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K25_6A[phi0]:phase_deg/360,
     K25_6B[phi0]:phase_deg/360,
     K25_6C[phi0]:phase_deg/360,
@@ -757,21 +757,21 @@ O_K25_6: overlay = {
     K25_6A[phi0_err]:phase_deg_err/360,
     K25_6B[phi0_err]:phase_deg_err/360,
     K25_6C[phi0_err]:phase_deg_err/360,
-    K25_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K25_7: overlay = {
-    K25_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_7D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K25_7A[phi0]:phase_deg/360,
     K25_7B[phi0]:phase_deg/360,
     K25_7C[phi0]:phase_deg/360,
@@ -779,21 +779,21 @@ O_K25_7: overlay = {
     K25_7A[phi0_err]:phase_deg_err/360,
     K25_7B[phi0_err]:phase_deg_err/360,
     K25_7C[phi0_err]:phase_deg_err/360,
-    K25_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K25_8: overlay = {
-    K25_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K25_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K25_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K25_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K25_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K25_8A[phi0]:phase_deg/360,
     K25_8B[phi0]:phase_deg/360,
     K25_8C[phi0]:phase_deg/360,
@@ -801,21 +801,21 @@ O_K25_8: overlay = {
     K25_8A[phi0_err]:phase_deg_err/360,
     K25_8B[phi0_err]:phase_deg_err/360,
     K25_8C[phi0_err]:phase_deg_err/360,
-    K25_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K25_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_1: overlay = {
-    K26_1A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_1B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_1C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_1D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_1A[phi0]:phase_deg/360,
     K26_1B[phi0]:phase_deg/360,
     K26_1C[phi0]:phase_deg/360,
@@ -823,21 +823,21 @@ O_K26_1: overlay = {
     K26_1A[phi0_err]:phase_deg_err/360,
     K26_1B[phi0_err]:phase_deg_err/360,
     K26_1C[phi0_err]:phase_deg_err/360,
-    K26_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_2: overlay = {
-    K26_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_2A[phi0]:phase_deg/360,
     K26_2B[phi0]:phase_deg/360,
     K26_2C[phi0]:phase_deg/360,
@@ -845,21 +845,21 @@ O_K26_2: overlay = {
     K26_2A[phi0_err]:phase_deg_err/360,
     K26_2B[phi0_err]:phase_deg_err/360,
     K26_2C[phi0_err]:phase_deg_err/360,
-    K26_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_3: overlay = {
-    K26_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_3A[phi0]:phase_deg/360,
     K26_3B[phi0]:phase_deg/360,
     K26_3C[phi0]:phase_deg/360,
@@ -867,21 +867,21 @@ O_K26_3: overlay = {
     K26_3A[phi0_err]:phase_deg_err/360,
     K26_3B[phi0_err]:phase_deg_err/360,
     K26_3C[phi0_err]:phase_deg_err/360,
-    K26_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_4: overlay = {
-    K26_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_4A[phi0]:phase_deg/360,
     K26_4B[phi0]:phase_deg/360,
     K26_4C[phi0]:phase_deg/360,
@@ -889,21 +889,21 @@ O_K26_4: overlay = {
     K26_4A[phi0_err]:phase_deg_err/360,
     K26_4B[phi0_err]:phase_deg_err/360,
     K26_4C[phi0_err]:phase_deg_err/360,
-    K26_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_5: overlay = {
-    K26_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_5A[phi0]:phase_deg/360,
     K26_5B[phi0]:phase_deg/360,
     K26_5C[phi0]:phase_deg/360,
@@ -911,21 +911,21 @@ O_K26_5: overlay = {
     K26_5A[phi0_err]:phase_deg_err/360,
     K26_5B[phi0_err]:phase_deg_err/360,
     K26_5C[phi0_err]:phase_deg_err/360,
-    K26_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_6: overlay = {
-    K26_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_6A[phi0]:phase_deg/360,
     K26_6B[phi0]:phase_deg/360,
     K26_6C[phi0]:phase_deg/360,
@@ -933,21 +933,21 @@ O_K26_6: overlay = {
     K26_6A[phi0_err]:phase_deg_err/360,
     K26_6B[phi0_err]:phase_deg_err/360,
     K26_6C[phi0_err]:phase_deg_err/360,
-    K26_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_7: overlay = {
-    K26_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_7D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_7A[phi0]:phase_deg/360,
     K26_7B[phi0]:phase_deg/360,
     K26_7C[phi0]:phase_deg/360,
@@ -955,21 +955,21 @@ O_K26_7: overlay = {
     K26_7A[phi0_err]:phase_deg_err/360,
     K26_7B[phi0_err]:phase_deg_err/360,
     K26_7C[phi0_err]:phase_deg_err/360,
-    K26_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K26_8: overlay = {
-    K26_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K26_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K26_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K26_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K26_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K26_8A[phi0]:phase_deg/360,
     K26_8B[phi0]:phase_deg/360,
     K26_8C[phi0]:phase_deg/360,
@@ -977,21 +977,21 @@ O_K26_8: overlay = {
     K26_8A[phi0_err]:phase_deg_err/360,
     K26_8B[phi0_err]:phase_deg_err/360,
     K26_8C[phi0_err]:phase_deg_err/360,
-    K26_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K26_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_1: overlay = {
-    K27_1A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_1B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_1C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_1D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_1A[phi0]:phase_deg/360,
     K27_1B[phi0]:phase_deg/360,
     K27_1C[phi0]:phase_deg/360,
@@ -999,21 +999,21 @@ O_K27_1: overlay = {
     K27_1A[phi0_err]:phase_deg_err/360,
     K27_1B[phi0_err]:phase_deg_err/360,
     K27_1C[phi0_err]:phase_deg_err/360,
-    K27_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_2: overlay = {
-    K27_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_2A[phi0]:phase_deg/360,
     K27_2B[phi0]:phase_deg/360,
     K27_2C[phi0]:phase_deg/360,
@@ -1021,21 +1021,21 @@ O_K27_2: overlay = {
     K27_2A[phi0_err]:phase_deg_err/360,
     K27_2B[phi0_err]:phase_deg_err/360,
     K27_2C[phi0_err]:phase_deg_err/360,
-    K27_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_3: overlay = {
-    K27_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_3A[phi0]:phase_deg/360,
     K27_3B[phi0]:phase_deg/360,
     K27_3C[phi0]:phase_deg/360,
@@ -1043,21 +1043,21 @@ O_K27_3: overlay = {
     K27_3A[phi0_err]:phase_deg_err/360,
     K27_3B[phi0_err]:phase_deg_err/360,
     K27_3C[phi0_err]:phase_deg_err/360,
-    K27_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_4: overlay = {
-    K27_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_4D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_4A[phi0]:phase_deg/360,
     K27_4B[phi0]:phase_deg/360,
     K27_4C[phi0]:phase_deg/360,
@@ -1065,21 +1065,21 @@ O_K27_4: overlay = {
     K27_4A[phi0_err]:phase_deg_err/360,
     K27_4B[phi0_err]:phase_deg_err/360,
     K27_4C[phi0_err]:phase_deg_err/360,
-    K27_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_5: overlay = {
-    K27_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_5D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_5A[phi0]:phase_deg/360,
     K27_5B[phi0]:phase_deg/360,
     K27_5C[phi0]:phase_deg/360,
@@ -1087,39 +1087,39 @@ O_K27_5: overlay = {
     K27_5A[phi0_err]:phase_deg_err/360,
     K27_5B[phi0_err]:phase_deg_err/360,
     K27_5C[phi0_err]:phase_deg_err/360,
-    K27_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K27_6: overlay = {
-    K27_6A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K27_6B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K27_6C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K27_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K27_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K27_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K27_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K27_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K27_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K27_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K27_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K27_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K27_6A[phi0]:phase_deg/360,
     K27_6B[phi0]:phase_deg/360,
     K27_6C[phi0]:phase_deg/360,
     K27_6A[phi0_err]:phase_deg_err/360,
     K27_6B[phi0_err]:phase_deg_err/360,
-    K27_6C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_6C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_7: overlay = {
-    K27_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_7D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_7A[phi0]:phase_deg/360,
     K27_7B[phi0]:phase_deg/360,
     K27_7C[phi0]:phase_deg/360,
@@ -1127,21 +1127,21 @@ O_K27_7: overlay = {
     K27_7A[phi0_err]:phase_deg_err/360,
     K27_7B[phi0_err]:phase_deg_err/360,
     K27_7C[phi0_err]:phase_deg_err/360,
-    K27_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K27_8: overlay = {
-    K27_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K27_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K27_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K27_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K27_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K27_8A[phi0]:phase_deg/360,
     K27_8B[phi0]:phase_deg/360,
     K27_8C[phi0]:phase_deg/360,
@@ -1149,39 +1149,39 @@ O_K27_8: overlay = {
     K27_8A[phi0_err]:phase_deg_err/360,
     K27_8B[phi0_err]:phase_deg_err/360,
     K27_8C[phi0_err]:phase_deg_err/360,
-    K27_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K27_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K28_1: overlay = {
-    K28_1A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_1B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_1C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K28_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K28_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K28_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K28_1A[phi0]:phase_deg/360,
     K28_1B[phi0]:phase_deg/360,
     K28_1C[phi0]:phase_deg/360,
     K28_1A[phi0_err]:phase_deg_err/360,
     K28_1B[phi0_err]:phase_deg_err/360,
-    K28_1C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_1C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K28_2: overlay = {
-    K28_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K28_2A[phi0]:phase_deg/360,
     K28_2B[phi0]:phase_deg/360,
     K28_2C[phi0]:phase_deg/360,
@@ -1189,21 +1189,21 @@ O_K28_2: overlay = {
     K28_2A[phi0_err]:phase_deg_err/360,
     K28_2B[phi0_err]:phase_deg_err/360,
     K28_2C[phi0_err]:phase_deg_err/360,
-    K28_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K28_3: overlay = {
-    K28_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K28_3A[phi0]:phase_deg/360,
     K28_3B[phi0]:phase_deg/360,
     K28_3C[phi0]:phase_deg/360,
@@ -1211,57 +1211,57 @@ O_K28_3: overlay = {
     K28_3A[phi0_err]:phase_deg_err/360,
     K28_3B[phi0_err]:phase_deg_err/360,
     K28_3C[phi0_err]:phase_deg_err/360,
-    K28_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K28_4: overlay = {
-    K28_4A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_4B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_4C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K28_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K28_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K28_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K28_4A[phi0]:phase_deg/360,
     K28_4B[phi0]:phase_deg/360,
     K28_4C[phi0]:phase_deg/360,
     K28_4A[phi0_err]:phase_deg_err/360,
     K28_4B[phi0_err]:phase_deg_err/360,
-    K28_4C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_4C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K28_5: overlay = {
-    K28_5A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_5B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_5C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K28_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K28_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K28_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K28_5A[phi0]:phase_deg/360,
     K28_5B[phi0]:phase_deg/360,
     K28_5C[phi0]:phase_deg/360,
     K28_5A[phi0_err]:phase_deg_err/360,
     K28_5B[phi0_err]:phase_deg_err/360,
-    K28_5C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_5C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K28_6: overlay = {
-    K28_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K28_6A[phi0]:phase_deg/360,
     K28_6B[phi0]:phase_deg/360,
     K28_6C[phi0]:phase_deg/360,
@@ -1269,39 +1269,39 @@ O_K28_6: overlay = {
     K28_6A[phi0_err]:phase_deg_err/360,
     K28_6B[phi0_err]:phase_deg_err/360,
     K28_6C[phi0_err]:phase_deg_err/360,
-    K28_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K28_7: overlay = {
-    K28_7A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_7B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K28_7C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K28_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K28_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K28_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K28_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K28_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K28_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K28_7A[phi0]:phase_deg/360,
     K28_7B[phi0]:phase_deg/360,
     K28_7C[phi0]:phase_deg/360,
     K28_7A[phi0_err]:phase_deg_err/360,
     K28_7B[phi0_err]:phase_deg_err/360,
-    K28_7C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_7C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K28_8: overlay = {
-    K28_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K28_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K28_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K28_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K28_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K28_8A[phi0]:phase_deg/360,
     K28_8B[phi0]:phase_deg/360,
     K28_8C[phi0]:phase_deg/360,
@@ -1309,39 +1309,39 @@ O_K28_8: overlay = {
     K28_8A[phi0_err]:phase_deg_err/360,
     K28_8B[phi0_err]:phase_deg_err/360,
     K28_8C[phi0_err]:phase_deg_err/360,
-    K28_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K28_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K29_1: overlay = {
-    K29_1A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K29_1B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K29_1C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K29_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K29_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K29_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K29_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K29_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K29_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K29_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K29_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K29_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K29_1A[phi0]:phase_deg/360,
     K29_1B[phi0]:phase_deg/360,
     K29_1C[phi0]:phase_deg/360,
     K29_1A[phi0_err]:phase_deg_err/360,
     K29_1B[phi0_err]:phase_deg_err/360,
-    K29_1C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_1C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K29_2: overlay = {
-    K29_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K29_2A[phi0]:phase_deg/360,
     K29_2B[phi0]:phase_deg/360,
     K29_2C[phi0]:phase_deg/360,
@@ -1349,21 +1349,21 @@ O_K29_2: overlay = {
     K29_2A[phi0_err]:phase_deg_err/360,
     K29_2B[phi0_err]:phase_deg_err/360,
     K29_2C[phi0_err]:phase_deg_err/360,
-    K29_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K29_3: overlay = {
-    K29_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_3D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K29_3A[phi0]:phase_deg/360,
     K29_3B[phi0]:phase_deg/360,
     K29_3C[phi0]:phase_deg/360,
@@ -1371,57 +1371,57 @@ O_K29_3: overlay = {
     K29_3A[phi0_err]:phase_deg_err/360,
     K29_3B[phi0_err]:phase_deg_err/360,
     K29_3C[phi0_err]:phase_deg_err/360,
-    K29_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K29_4: overlay = {
-    K29_4A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K29_4B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K29_4C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K29_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K29_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K29_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K29_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K29_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K29_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K29_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K29_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K29_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K29_4A[phi0]:phase_deg/360,
     K29_4B[phi0]:phase_deg/360,
     K29_4C[phi0]:phase_deg/360,
     K29_4A[phi0_err]:phase_deg_err/360,
     K29_4B[phi0_err]:phase_deg_err/360,
-    K29_4C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_4C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K29_5: overlay = {
-    K29_5A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K29_5B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K29_5C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K29_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K29_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K29_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K29_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K29_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K29_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K29_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K29_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K29_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K29_5A[phi0]:phase_deg/360,
     K29_5B[phi0]:phase_deg/360,
     K29_5C[phi0]:phase_deg/360,
     K29_5A[phi0_err]:phase_deg_err/360,
     K29_5B[phi0_err]:phase_deg_err/360,
-    K29_5C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_5C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K29_6: overlay = {
-    K29_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_6D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K29_6A[phi0]:phase_deg/360,
     K29_6B[phi0]:phase_deg/360,
     K29_6C[phi0]:phase_deg/360,
@@ -1429,21 +1429,21 @@ O_K29_6: overlay = {
     K29_6A[phi0_err]:phase_deg_err/360,
     K29_6B[phi0_err]:phase_deg_err/360,
     K29_6C[phi0_err]:phase_deg_err/360,
-    K29_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K29_7: overlay = {
-    K29_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_7D[gradient]:f*ENLD_MeV*1e6*0.25/2.8692,
-    K29_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.8692,
+    K29_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.8692,
+    K29_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.8692,
     K29_7A[phi0]:phase_deg/360,
     K29_7B[phi0]:phase_deg/360,
     K29_7C[phi0]:phase_deg/360,
@@ -1451,21 +1451,21 @@ O_K29_7: overlay = {
     K29_7A[phi0_err]:phase_deg_err/360,
     K29_7B[phi0_err]:phase_deg_err/360,
     K29_7C[phi0_err]:phase_deg_err/360,
-    K29_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K29_8: overlay = {
-    K29_8A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_8B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_8C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_8D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K29_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K29_8D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_8D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K29_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K29_8D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K29_8A[phi0]:phase_deg/360,
     K29_8B[phi0]:phase_deg/360,
     K29_8C[phi0]:phase_deg/360,
@@ -1473,21 +1473,21 @@ O_K29_8: overlay = {
     K29_8A[phi0_err]:phase_deg_err/360,
     K29_8B[phi0_err]:phase_deg_err/360,
     K29_8C[phi0_err]:phase_deg_err/360,
-    K29_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K29_8D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_1: overlay = {
-    K30_1A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_1B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_1C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_1D[gradient]:f*ENLD_MeV*1e6*0.25/2.1694,
-    K30_1A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_1B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_1C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_1D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.1694,
+    K30_1A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_1B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_1C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_1D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.1694,
+    K30_1A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_1B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_1C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_1D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.1694,
     K30_1A[phi0]:phase_deg/360,
     K30_1B[phi0]:phase_deg/360,
     K30_1C[phi0]:phase_deg/360,
@@ -1495,21 +1495,21 @@ O_K30_1: overlay = {
     K30_1A[phi0_err]:phase_deg_err/360,
     K30_1B[phi0_err]:phase_deg_err/360,
     K30_1C[phi0_err]:phase_deg_err/360,
-    K30_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_1D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_2: overlay = {
-    K30_2A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_2B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_2C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_2D[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_2A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_2B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_2C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_2D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_2A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_2B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_2C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_2D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_2A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_2B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_2C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_2D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
     K30_2A[phi0]:phase_deg/360,
     K30_2B[phi0]:phase_deg/360,
     K30_2C[phi0]:phase_deg/360,
@@ -1517,21 +1517,21 @@ O_K30_2: overlay = {
     K30_2A[phi0_err]:phase_deg_err/360,
     K30_2B[phi0_err]:phase_deg_err/360,
     K30_2C[phi0_err]:phase_deg_err/360,
-    K30_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_2D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_3: overlay = {
-    K30_3A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_3B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_3C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_3D[gradient]:f*ENLD_MeV*1e6*0.25/2.1694,
-    K30_3A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_3B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_3C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_3D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.1694,
+    K30_3A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_3B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_3C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_3D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.1694,
+    K30_3A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_3B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_3C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_3D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.1694,
     K30_3A[phi0]:phase_deg/360,
     K30_3B[phi0]:phase_deg/360,
     K30_3C[phi0]:phase_deg/360,
@@ -1539,21 +1539,21 @@ O_K30_3: overlay = {
     K30_3A[phi0_err]:phase_deg_err/360,
     K30_3B[phi0_err]:phase_deg_err/360,
     K30_3C[phi0_err]:phase_deg_err/360,
-    K30_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_3D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_4: overlay = {
-    K30_4A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_4B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_4C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_4D[gradient]:f*ENLD_MeV*1e6*0.25/2.1694,
-    K30_4A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_4B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_4C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_4D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.1694,
+    K30_4A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_4B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_4C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_4D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.1694,
+    K30_4A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_4B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_4C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_4D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.1694,
     K30_4A[phi0]:phase_deg/360,
     K30_4B[phi0]:phase_deg/360,
     K30_4C[phi0]:phase_deg/360,
@@ -1561,21 +1561,21 @@ O_K30_4: overlay = {
     K30_4A[phi0_err]:phase_deg_err/360,
     K30_4B[phi0_err]:phase_deg_err/360,
     K30_4C[phi0_err]:phase_deg_err/360,
-    K30_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_4D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_5: overlay = {
-    K30_5A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_5B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_5C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_5D[gradient]:f*ENLD_MeV*1e6*0.25/2.1694,
-    K30_5A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_5B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_5C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_5D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.1694,
+    K30_5A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_5B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_5C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_5D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.1694,
+    K30_5A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_5B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_5C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_5D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.1694,
     K30_5A[phi0]:phase_deg/360,
     K30_5B[phi0]:phase_deg/360,
     K30_5C[phi0]:phase_deg/360,
@@ -1583,21 +1583,21 @@ O_K30_5: overlay = {
     K30_5A[phi0_err]:phase_deg_err/360,
     K30_5B[phi0_err]:phase_deg_err/360,
     K30_5C[phi0_err]:phase_deg_err/360,
-    K30_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_5D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_6: overlay = {
-    K30_6A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_6B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_6C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_6D[gradient]:f*ENLD_MeV*1e6*0.25/2.8692,
-    K30_6A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_6B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_6C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_6D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.8692,
+    K30_6A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_6B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_6C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_6D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.8692,
+    K30_6A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_6B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_6C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_6D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.8692,
     K30_6A[phi0]:phase_deg/360,
     K30_6B[phi0]:phase_deg/360,
     K30_6C[phi0]:phase_deg/360,
@@ -1605,21 +1605,21 @@ O_K30_6: overlay = {
     K30_6A[phi0_err]:phase_deg_err/360,
     K30_6B[phi0_err]:phase_deg_err/360,
     K30_6C[phi0_err]:phase_deg_err/360,
-    K30_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_6D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABCD
 !
 O_K30_7: overlay = {
-    K30_7A[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_7B[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_7C[gradient]:f*ENLD_MeV*1e6*0.25/3.0441,
-    K30_7D[gradient]:f*ENLD_MeV*1e6*0.25/2.8692,
-    K30_7A[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_7B[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_7C[gradient_err]:f*ENLD_MeV_err*1e6*0.25/3.0441,
-    K30_7D[gradient_err]:f*ENLD_MeV_err*1e6*0.25/2.8692,
+    K30_7A[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_7B[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_7C[gradient]:f*in_use*ENLD_MeV*1e6*0.25/3.0441,
+    K30_7D[gradient]:f*in_use*ENLD_MeV*1e6*0.25/2.8692,
+    K30_7A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_7B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_7C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/3.0441,
+    K30_7D[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.25/2.8692,
     K30_7A[phi0]:phase_deg/360,
     K30_7B[phi0]:phase_deg/360,
     K30_7C[phi0]:phase_deg/360,
@@ -1627,23 +1627,23 @@ O_K30_7: overlay = {
     K30_7A[phi0_err]:phase_deg_err/360,
     K30_7B[phi0_err]:phase_deg_err/360,
     K30_7C[phi0_err]:phase_deg_err/360,
-    K30_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_7D[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 
 !----------------
 ! Klystron
 ! Configuration: ABC
 !
 O_K30_8: overlay = {
-    K30_8A[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K30_8B[gradient]:f*ENLD_MeV*1e6*0.2928932188134525/3.0441,
-    K30_8C[gradient]:f*ENLD_MeV*1e6*0.4142135623730951/3.0441,
-    K30_8A[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K30_8B[gradient_err]:f*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
-    K30_8C[gradient_err]:f*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
+    K30_8A[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K30_8B[gradient]:f*in_use*ENLD_MeV*1e6*0.2928932188134525/3.0441,
+    K30_8C[gradient]:f*in_use*ENLD_MeV*1e6*0.4142135623730951/3.0441,
+    K30_8A[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K30_8B[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.2928932188134525/3.0441,
+    K30_8C[gradient_err]:f*in_use*ENLD_MeV_err*1e6*0.4142135623730951/3.0441,
     K30_8A[phi0]:phase_deg/360,
     K30_8B[phi0]:phase_deg/360,
     K30_8C[phi0]:phase_deg/360,
     K30_8A[phi0_err]:phase_deg_err/360,
     K30_8B[phi0_err]:phase_deg_err/360,
-    K30_8C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f}, f=1
+    K30_8C[phi0_err]:phase_deg_err/360}, var = {ENLD_MeV, ENLD_MeV_err, phase_deg, phase_deg_err, f, in_use}, f=1, in_use=1
 


### PR DESCRIPTION
This PR adds an 'in_use' overlay variable to klystrons, which provides a way to turn them on/off in a way that will effect the reference energy in the model (the 'is_on' attribute on Lcavity objects does not adjust the reference energy).