### PR TITLE
Fix branch ref on checkout action

### DIFF
--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: main
+          ref: master
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-activate-base: true


### PR DESCRIPTION
Branch ref must be master for checking out repository.