### PR TITLE
Copy tests and CI workflow on publish

### DIFF
--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -29,6 +29,13 @@ jobs:
           export LCLS_LATTICE=$(pwd)
           python python/scripts/export/export_lattice.py --source $(pwd) --dest ${{ github.workspace }}/lattice-data
           echo "lattice_data_dir=${{ github.workspace }}/lattice-data" >> $GITHUB_ENV
+      - name: Copy tests and CI workflow
+        shell: bash -l {0}
+        run: |
+          cp -r tests/ ${{ github.workspace }}/lattice-data/tests
+          mkdir -p ${{ github.workspace }}/lattice-data/.github/worklflows
+          cp .github/worklflows/ci.yml ${{ github.workspace }}/lattice-data/.github/worklflows/ci.yml
+
       - name: Push directory to lcls-lattice-data
         uses: cpina/github-action-push-to-another-repository@v1.4.1
         env:

--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -29,10 +29,10 @@ jobs:
           export LCLS_LATTICE=$(pwd)
           python python/scripts/export/export_lattice.py --source $(pwd) --dest ${{ github.workspace }}/lattice-data
           echo "lattice_data_dir=${{ github.workspace }}/lattice-data" >> $GITHUB_ENV
-      - name: Copy tests and CI workflow
+      - name: Copy Python tests and CI workflow
         shell: bash -l {0}
         run: |
-          cp -r tests/ ${{ github.workspace }}/lattice-data/tests
+          cp -r python/tests/ ${{ github.workspace }}/lattice-data/python/tests
           mkdir -p ${{ github.workspace }}/lattice-data/.github/worklflows
           cp .github/worklflows/ci.yml ${{ github.workspace }}/lattice-data/.github/worklflows/ci.yml
 


### PR DESCRIPTION
This will copy all Python tests and the CI workflow when publishing to lcls-lattice-data