### PR TITLE
Add a meas=0 to all orbit datums

### DIFF
--- a/bmad/conversion/tao/create_vars_and_datums.ipynb
+++ b/bmad/conversion/tao/create_vars_and_datums.ipynb
@@ -397,6 +397,7 @@
       "     'RFBSX35', 'RFBSX36', 'RFBSX37', 'RFBSX38', 'RFBSX39', 'RFBSX40',\n",
       "     'RFBSX41', 'RFBSX42', 'RFBSX43', 'RFBSX44', 'RFBSX45', 'RFBSX46',\n",
       "     'RFBSX47', 'RFBSX51', 'BPMUE1B', 'BPMUE2B', 'BPMQDB', 'BPMDDB'\n",
+      "    datum(1:)%meas = 0\n",
       "/\n",
       "\n",
       "&tao_d1_data\n",
@@ -407,6 +408,7 @@
       "    default_data_source = 'lat'\n",
       "    !search_for_lat_eles = \"monitor::bpm*,monitor::rfb*\" \n",
       "    use_same_lat_eles_as = 'orbit.x'\n",
+      "    datum(1:)%meas = 0\n",
       "/\n",
       "\n",
       "&tao_d1_data\n",
@@ -455,6 +457,7 @@
     "    default_data_source = 'lat'\n",
     "    !search_for_lat_eles = \"{match}\" \n",
     "    datum(1:)%ele_name = {line}\n",
+    "    datum(1:)%meas = 0\n",
     "/\n",
     "\n",
     "&tao_d1_data\n",
@@ -465,6 +468,7 @@
     "    default_data_source = 'lat'\n",
     "    !search_for_lat_eles = \"{match}\" \n",
     "    use_same_lat_eles_as = 'orbit.x'\n",
+    "    datum(1:)%meas = 0\n",
     "/\n",
     "\n",
     "&tao_d1_data\n",
@@ -621,7 +625,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_spec/tao.init\n"
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_spec/tao.init\n"
      ]
     }
    ],
@@ -643,7 +647,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "1cd7f674-1031-42f3-8393-b949c52664ad",
    "metadata": {},
    "outputs": [
@@ -652,19 +656,19 @@
      "output_type": "stream",
      "text": [
       "cu_sxr $LCLS_LATTICE/bmad/models/cu_sxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_sxr/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_sxr/tao.init\n",
       "cu_spec $LCLS_LATTICE/bmad/models/cu_spec/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_spec/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_spec/tao.init\n",
       "sc_diag0 $LCLS_LATTICE/bmad/models/sc_diag0/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_diag0/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/sc_diag0/tao.init\n",
       "cu_hxr $LCLS_LATTICE/bmad/models/cu_hxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_hxr/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_hxr/tao.init\n",
       "sc_sxr $LCLS_LATTICE/bmad/models/sc_sxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_sxr/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/sc_sxr/tao.init\n",
       "sc_hxr $LCLS_LATTICE/bmad/models/sc_hxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_hxr/tao.init\n",
-      "f2e_inj /Users/chrisonian/Code/GitHub/facet2-lattice//bmad/models/f2e_inj/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/facet2-lattice//bmad/models/f2e_inj/tao.init\n"
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/sc_hxr/tao.init\n",
+      "f2e_inj /Users/chrisonian/Code/GitHub/facet2-lattice/bmad/models/f2e_inj/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/facet2-lattice/bmad/models/f2e_inj/tao.init\n"
      ]
     }
    ],
@@ -693,7 +697,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/bmad/models/cu_hxr/tao.init
+++ b/bmad/models/cu_hxr/tao.init
@@ -327,6 +327,7 @@ beam_init%center(6) = 0.0
      'RFBHX36', 'RFBHX37', 'RFBHX38', 'RFBHX39', 'RFBHX40', 'RFBHX41',
      'RFBHX42', 'RFBHX43', 'RFBHX44', 'RFBHX45', 'RFBHX46', 'RFBHX47',
      'RFBHX51', 'BPMUE1', 'BPMUE2', 'BPMQD', 'BPMDD'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -337,6 +338,7 @@ beam_init%center(6) = 0.0
     default_data_source = 'lat'
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data

--- a/bmad/models/cu_spec/tao.init
+++ b/bmad/models/cu_spec/tao.init
@@ -127,6 +127,7 @@ beam_init%center(6) = 0.0
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     datum(1:)%ele_name =  'BPM2', 'BPM3', 'BPM5', 'BPM6', 'BPM8', 'BPM9', 'BPM10', 'BPM11', 'BPM12',
      'BPMS1', 'BPMS2', 'BPMS3'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -137,6 +138,7 @@ beam_init%center(6) = 0.0
     default_data_source = 'lat'
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data

--- a/bmad/models/cu_sxr/tao.init
+++ b/bmad/models/cu_sxr/tao.init
@@ -348,6 +348,7 @@ beam_init%center(6) = 0.0
      'RFBSX35', 'RFBSX36', 'RFBSX37', 'RFBSX38', 'RFBSX39', 'RFBSX40',
      'RFBSX41', 'RFBSX42', 'RFBSX43', 'RFBSX44', 'RFBSX45', 'RFBSX46',
      'RFBSX47', 'RFBSX51', 'BPMUE1B', 'BPMUE2B', 'BPMQDB', 'BPMDDB'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -358,6 +359,7 @@ beam_init%center(6) = 0.0
     default_data_source = 'lat'
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data

--- a/bmad/models/sc_diag0/tao.init
+++ b/bmad/models/sc_diag0/tao.init
@@ -94,6 +94,7 @@
      'BPMH1', 'BPMH2', 'BPMHD01', 'BPMHD02', 'BPMHD03', 'BPMHD04',
      'BPMDG000', 'BPMDG001', 'BPMDG002', 'BPMDG003', 'BPMDG004', 'BPMDG005',
      'BPMDG0RF', 'BPMDG008', 'BPMDG009', 'BPMDG011', 'BPMDG012'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -104,6 +105,7 @@
     default_data_source = 'lat'
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data

--- a/bmad/models/sc_hxr/tao.init
+++ b/bmad/models/sc_hxr/tao.init
@@ -352,6 +352,7 @@ beam_init%center(6) = 0.0
      'RFBHX39', 'RFBHX40', 'RFBHX41', 'RFBHX42', 'RFBHX43', 'RFBHX44',
      'RFBHX45', 'RFBHX46', 'RFBHX47', 'RFBHX51', 'BPMUE1', 'BPMUE2', 'BPMQD',
      'BPMDD'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -362,6 +363,7 @@ beam_init%center(6) = 0.0
     default_data_source = 'lat'
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data

--- a/bmad/models/sc_sxr/tao.init
+++ b/bmad/models/sc_sxr/tao.init
@@ -218,6 +218,7 @@ beam_init%center(6) = 0.0
      'RFBSX34', 'RFBSX35', 'RFBSX36', 'RFBSX37', 'RFBSX38', 'RFBSX39',
      'RFBSX40', 'RFBSX41', 'RFBSX42', 'RFBSX43', 'RFBSX44', 'RFBSX45',
      'RFBSX46', 'RFBSX47', 'RFBSX51', 'BPMUE1B', 'BPMUE2B', 'BPMQDB', 'BPMDDB'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -228,6 +229,7 @@ beam_init%center(6) = 0.0
     default_data_source = 'lat'
     !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
     use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data


### PR DESCRIPTION
This adds `datum(1:)%meas = 0` to all `orbit.x` and `orbit.y` datums, so that `use dat orbit` will give valid data.