### PR TITLE
Add bpm and corrector data to sc_bsyd and sc_dasel

### DIFF
--- a/bmad/conversion/device_mapping/device_mapping.ipynb
+++ b/bmad/conversion/device_mapping/device_mapping.ipynb
@@ -160,8 +160,10 @@
        " 'sc_dasel': '$LCLS_LATTICE/bmad/models/sc_dasel/tao.init',\n",
        " 'cu_linac': '$LCLS_LATTICE/bmad/models/cu_linac/tao.init',\n",
        " 'sc_sxr': '$LCLS_LATTICE/bmad/models/sc_sxr/tao.init',\n",
+       " '.ipynb_checkpoints': '$LCLS_LATTICE/bmad/models/.ipynb_checkpoints/tao.init',\n",
        " 'sc_hxr': '$LCLS_LATTICE/bmad/models/sc_hxr/tao.init',\n",
-       " 'sc_bsyd': '$LCLS_LATTICE/bmad/models/sc_bsyd/tao.init'}"
+       " 'sc_bsyd': '$LCLS_LATTICE/bmad/models/sc_bsyd/tao.init',\n",
+       " 'sc_inj': '$LCLS_LATTICE/bmad/models/sc_inj/tao.init'}"
       ]
      },
      "execution_count": 8,
@@ -314,7 +316,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad//master/LCLScu_devicenames.bmad\n"
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad//master/LCLScu_devicenames.bmad\n"
      ]
     }
    ],
@@ -348,12 +350,15 @@
      "output_type": "stream",
      "text": [
       "sc_hxr\n",
-      "sc_sxr\n"
+      "sc_sxr\n",
+      "sc_diag0\n",
+      "sc_bsyd\n",
+      "sc_dasel\n"
      ]
     }
    ],
    "source": [
-    "models = ['sc_hxr', 'sc_sxr']\n",
+    "models = ['sc_hxr', 'sc_sxr', 'sc_diag0', 'sc_bsyd', 'sc_dasel']\n",
     "names = []\n",
     "for m in models:\n",
     "    print(m)\n",
@@ -370,7 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad//master/LCLSsc_devicenames.bmad\n"
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad//master/LCLSsc_devicenames.bmad\n"
      ]
     }
    ],
@@ -395,7 +400,7 @@
      "output_type": "stream",
      "text": [
       "f2_elec\n",
-      "Written: /Users/chrisonian/Code/GitHub/facet2-lattice/bmad//master/FACET2e_devicenames.bmad\n"
+      "Written: /Users/chrisonian/Code/GitHub/facet2-lattice//bmad//master/FACET2e_devicenames.bmad\n"
      ]
     }
    ],
@@ -500,7 +505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/bmad/conversion/tao/create_vars_and_datums.ipynb
+++ b/bmad/conversion/tao/create_vars_and_datums.ipynb
@@ -34,7 +34,14 @@
     {
      "data": {
       "text/plain": [
-       "['cu_sxr', 'cu_spec', 'sc_diag0', 'cu_hxr', 'sc_sxr', 'sc_hxr']"
+       "['cu_sxr',\n",
+       " 'cu_spec',\n",
+       " 'cu_hxr',\n",
+       " 'sc_dasel',\n",
+       " 'sc_diag0',\n",
+       " 'sc_sxr',\n",
+       " 'sc_hxr',\n",
+       " 'sc_bsyd']"
       ]
      },
      "execution_count": 2,
@@ -49,13 +56,16 @@
     " #'hxr',\n",
     " 'cu_spec',\n",
     " #'lcls_complex',\n",
-    " 'sc_diag0',\n",
+    "\n",
     " 'cu_hxr',\n",
     " #'cu_inj',\n",
     " #'sc_dasel',\n",
     "# 'cu_linac',\n",
+    " 'sc_dasel',\n",
+    " 'sc_diag0',    \n",
     " 'sc_sxr',\n",
-    " 'sc_hxr']\n",
+    " 'sc_hxr',\n",
+    " 'sc_bsyd']\n",
     "\n",
     "MODELS"
    ]
@@ -89,10 +99,12 @@
       "text/plain": [
        "{'cu_sxr': '$LCLS_LATTICE/bmad/models/cu_sxr/tao.init',\n",
        " 'cu_spec': '$LCLS_LATTICE/bmad/models/cu_spec/tao.init',\n",
-       " 'sc_diag0': '$LCLS_LATTICE/bmad/models/sc_diag0/tao.init',\n",
        " 'cu_hxr': '$LCLS_LATTICE/bmad/models/cu_hxr/tao.init',\n",
+       " 'sc_dasel': '$LCLS_LATTICE/bmad/models/sc_dasel/tao.init',\n",
+       " 'sc_diag0': '$LCLS_LATTICE/bmad/models/sc_diag0/tao.init',\n",
        " 'sc_sxr': '$LCLS_LATTICE/bmad/models/sc_sxr/tao.init',\n",
-       " 'sc_hxr': '$LCLS_LATTICE/bmad/models/sc_hxr/tao.init'}"
+       " 'sc_hxr': '$LCLS_LATTICE/bmad/models/sc_hxr/tao.init',\n",
+       " 'sc_bsyd': '$LCLS_LATTICE/bmad/models/sc_bsyd/tao.init'}"
       ]
      },
      "execution_count": 4,
@@ -625,7 +637,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_spec/tao.init\n"
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_spec/tao.init\n"
      ]
     }
    ],
@@ -656,19 +668,23 @@
      "output_type": "stream",
      "text": [
       "cu_sxr $LCLS_LATTICE/bmad/models/cu_sxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_sxr/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_sxr/tao.init\n",
       "cu_spec $LCLS_LATTICE/bmad/models/cu_spec/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_spec/tao.init\n",
-      "sc_diag0 $LCLS_LATTICE/bmad/models/sc_diag0/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/sc_diag0/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_spec/tao.init\n",
       "cu_hxr $LCLS_LATTICE/bmad/models/cu_hxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/cu_hxr/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/cu_hxr/tao.init\n",
+      "sc_dasel $LCLS_LATTICE/bmad/models/sc_dasel/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_dasel/tao.init\n",
+      "sc_diag0 $LCLS_LATTICE/bmad/models/sc_diag0/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_diag0/tao.init\n",
       "sc_sxr $LCLS_LATTICE/bmad/models/sc_sxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/sc_sxr/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_sxr/tao.init\n",
       "sc_hxr $LCLS_LATTICE/bmad/models/sc_hxr/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice/bmad/models/sc_hxr/tao.init\n",
-      "f2e_inj /Users/chrisonian/Code/GitHub/facet2-lattice/bmad/models/f2e_inj/tao.init\n",
-      "Written: /Users/chrisonian/Code/GitHub/facet2-lattice/bmad/models/f2e_inj/tao.init\n"
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_hxr/tao.init\n",
+      "sc_bsyd $LCLS_LATTICE/bmad/models/sc_bsyd/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/lcls-lattice//bmad/models/sc_bsyd/tao.init\n",
+      "f2e_inj /Users/chrisonian/Code/GitHub/facet2-lattice//bmad/models/f2e_inj/tao.init\n",
+      "Written: /Users/chrisonian/Code/GitHub/facet2-lattice//bmad/models/f2e_inj/tao.init\n"
      ]
     }
    ],

--- a/bmad/master/LCLSsc_devicenames.bmad
+++ b/bmad/master/LCLSsc_devicenames.bmad
@@ -1,7 +1,26 @@
 ! ---------
 ! Device mapping derived from $LCLS_LATTICE/bmad/conversion/from_oracle/lcls_elements.csv
+! No device listed for: A10Y
+! No device listed for: A18Y
+! No device listed for: A28X
+! No device listed for: A29Y
+! No device listed for: A32X
+! No device listed for: A33Y
+! No device listed for: ALWALL
 ! No device listed for: AM00B
 ! No device listed for: ASTRA
+! No device listed for: B11
+! No device listed for: B12
+! No device listed for: B13
+! No device listed for: B14
+! No device listed for: B15
+! No device listed for: B16
+! No device listed for: B21
+! No device listed for: B22
+! No device listed for: B23
+! No device listed for: B24
+! No device listed for: B25
+! No device listed for: B26
 ! No device listed for: BC1BCBEG
 ! No device listed for: BC1BCEND
 ! No device listed for: BC2BCBEG
@@ -72,14 +91,18 @@ BCXXL4[alias]=BEND:LTUS:766
 ! No device listed for: BDBEG
 ! No device listed for: BDEND
 ! No device listed for: BEAM0
+! No device listed for: BEGB
 ! No device listed for: BEGBC1B
 ! No device listed for: BEGBC2B
+! No device listed for: BEGBSYA_2
 ! No device listed for: BEGBSYH_1
 ! No device listed for: BEGBSYH_2
 ! No device listed for: BEGBSYS
 ! No device listed for: BEGBYP
 ! No device listed for: BEGCOL0
 ! No device listed for: BEGCOL1
+! No device listed for: BEGDASEL
+! No device listed for: BEGDIAG0
 ! No device listed for: BEGDMPH_1
 ! No device listed for: BEGDMPH_2
 ! No device listed for: BEGDMPS_1
@@ -96,13 +119,25 @@ BCXXL4[alias]=BEND:LTUS:766
 ! No device listed for: BEGL3B
 ! No device listed for: BEGLTUH
 ! No device listed for: BEGLTUS
+! No device listed for: BEGSLTD
 ! No device listed for: BEGSLTH
 ! No device listed for: BEGSLTS
 ! No device listed for: BEGSPD_1
+! No device listed for: BEGSPD_2
+! No device listed for: BEGSPD_3
 ! No device listed for: BEGSPH
 ! No device listed for: BEGSPS
 ! No device listed for: BEGUNDH
 ! No device listed for: BEGUNDS
+BKRDAS1[alias]=KICK:DASEL:105
+BKRDAS2[alias]=KICK:DASEL:110
+BKRDAS3[alias]=KICK:DASEL:115
+BKRDAS4[alias]=KICK:DASEL:120
+BKRDAS5[alias]=KICK:DASEL:122
+BKRDAS6[alias]=KICK:DASEL:125
+BKRDG0[alias]=KICK:DIAG0:110
+BKXRASD[alias]=XCOR:SLTD:628
+BKYRASD[alias]=YCOR:SLTD:631
 BKYSP0H[alias]=KICK:SPH:105
 BKYSP0S[alias]=KICK:SPS:380
 BKYSP1H[alias]=KICK:SPH:110
@@ -123,6 +158,8 @@ BKYSP5S[alias]=KICK:SPS:410
 ! No device listed for: BLF6
 ! No device listed for: BLFD
 ! No device listed for: BLFU
+BLRDAS[alias]=BEND:DASEL:210
+BLRDG0[alias]=BEND:DIAG0:155
 BLTOF[alias]=GJET:LTU1:927
 BLXSPH[alias]=BEND:SPH:170
 BLXSPS[alias]=BEND:SPS:470
@@ -132,12 +169,19 @@ BPM0H01[alias]=BPMS:HTR:120
 BPM0H04[alias]=BPMS:HTR:320
 BPM0H05[alias]=BPMS:HTR:365
 BPM0H08[alias]=BPMS:HTR:460
+! No device listed for: BPM10A
 BPM11B[alias]=BPMS:BC1B:440
+! No device listed for: BPM12A
+! No device listed for: BPM17
 BPM1B[alias]=BPMS:GUNB:314
 BPM1C01[alias]=BPMS:BC1B:125
 BPM21B[alias]=BPMS:BC2B:530
+! No device listed for: BPM24
+! No device listed for: BPM28
 BPM2B[alias]=BPMS:GUNB:925
 BPM2C01[alias]=BPMS:BC2B:150
+! No device listed for: BPM31
+! No device listed for: BPM32
 BPMBP10[alias]=BPMS:DOG:575
 BPMBP11[alias]=BPMS:DOG:740
 BPMBP12[alias]=BPMS:DOG:910
@@ -191,11 +235,24 @@ BPMC109[alias]=BPMS:COL1:720
 BPMC110[alias]=BPMS:COL1:800
 BPMC111[alias]=BPMS:COL1:880
 BPMC112[alias]=BPMS:COL1:960
+BPMDAS[alias]=BPMS:SPD:570
+BPMDAS1[alias]=BPMS:DASEL:300
+BPMDAS19[alias]=BPMS:DASEL:915
 BPMDBL1[alias]=BPMS:LTUS:110
 BPMDBL2[alias]=BPMS:LTUS:120
 BPMDD[alias]=BPMS:DMPH:693
 BPMDDB[alias]=BPMS:DMPS:693
 BPMDG000[alias]=BPMS:COL0:135
+BPMDG001[alias]=BPMS:DIAG0:190
+BPMDG002[alias]=BPMS:DIAG0:210
+BPMDG003[alias]=BPMS:DIAG0:230
+BPMDG004[alias]=BPMS:DIAG0:270
+BPMDG005[alias]=BPMS:DIAG0:285
+BPMDG008[alias]=BPMS:DIAG0:370
+BPMDG009[alias]=BPMS:DIAG0:390
+BPMDG011[alias]=BPMS:DIAG0:470
+BPMDG012[alias]=BPMS:DIAG0:520
+BPMDG0RF[alias]=BPMS:DIAG0:330
 BPMDL1[alias]=BPMS:LTUH:250
 BPMDL11[alias]=BPMS:LTUS:150
 BPMDL12[alias]=BPMS:LTUS:180
@@ -262,15 +319,20 @@ BPMSP10H[alias]=BPMS:SPH:915
 BPMSP11H[alias]=BPMS:SPH:940
 BPMSP12H[alias]=BPMS:SLTH:200
 BPMSP13H[alias]=BPMS:SLTH:220
+BPMSP1D[alias]=BPMS:SPD:525
 BPMSP1H[alias]=BPMS:SPH:322
 BPMSP1S[alias]=BPMS:SPS:572
 BPMSP2[alias]=BPMS:SPD:340
+BPMSP2D[alias]=BPMS:SPD:700
 BPMSP2H[alias]=BPMS:SPH:345
 BPMSP2S[alias]=BPMS:SPS:580
+BPMSP3D[alias]=BPMS:SPD:955
 BPMSP3H[alias]=BPMS:SPH:420
 BPMSP3S[alias]=BPMS:SPS:640
+BPMSP4D[alias]=BPMS:SLTD:625
 BPMSP4H[alias]=BPMS:SPH:450
 BPMSP4S[alias]=BPMS:SPS:650
+BPMSP5D[alias]=BPMS:SLTD:895
 BPMSP5H[alias]=BPMS:SPH:520
 BPMSP5S[alias]=BPMS:SPS:710
 BPMSP6H[alias]=BPMS:SPH:600
@@ -351,8 +413,11 @@ BPMX02[alias]=BPMS:EXT:748
 ! No device listed for: BPN26END
 ! No device listed for: BPN27BEG
 ! No device listed for: BPN27END
+BRAM1[alias]=BEND:BSYA:975
 BRB1[alias]=BEND:DOG:110
 BRB2[alias]=BEND:DOG:240
+BRDAS1[alias]=BEND:DASEL:415
+BRDAS2[alias]=BEND:DASEL:995
 BRSP1H[alias]=BEND:SPH:370
 BRSP2H[alias]=BEND:SLTH:145
 ! No device listed for: BSYEND
@@ -390,6 +455,7 @@ BTMDUMP[alias]=BTM:DMPH:699
 BTMDUMPB[alias]=BTM:DMPS:699
 BTMQUE[alias]=BTM:DMPH:339
 BTMQUEB[alias]=BTM:DMPS:385
+BTMSPDMP[alias]=BTM:SLTD:932
 BUN1B[alias]=ACCL:GUNB:455
 BX31[alias]=BEND:LTUH:220
 BX31B[alias]=BEND:LTUS:175
@@ -397,6 +463,7 @@ BX32[alias]=BEND:LTUH:280
 BX32B[alias]=BEND:LTUS:460
 BX35[alias]=BEND:LTUH:420
 BX36[alias]=BEND:LTUH:480
+BXDG0[alias]=BEND:DIAG0:260
 BXSP1H[alias]=BEND:SLTH:435
 BXSP1S[alias]=BEND:SPS:610
 BXSP2S[alias]=BEND:SPS:800
@@ -411,20 +478,25 @@ BYD2[alias]=BEND:DMPH:410
 BYD2B[alias]=BEND:DMPS:410
 BYD3[alias]=BEND:DMPH:420
 BYD3B[alias]=BEND:DMPS:420
+BYDG0[alias]=BEND:DIAG0:510
 BYDSH[alias]=BEND:DMPH:395
 BYDSS[alias]=BEND:DMPS:395
 BYKIK1[alias]=KICK:LTUH:320
 BYKIK1S[alias]=KICK:LTUS:350
 BYKIK2[alias]=KICK:LTUH:340
 BYKIK2S[alias]=KICK:LTUS:360
+BYSP1D[alias]=BEND:SPD:719
 BYSP1H[alias]=BEND:SPH:270
 BYSP1S[alias]=BEND:SPS:530
+BYSP2D[alias]=BEND:SPD:960
 BYSP2H[alias]=BEND:SPH:310
 BYSP2S[alias]=BEND:SPS:560
 BZ0H04[alias]=BLEN:HTR:350
 BZ11B[alias]=BLEN:BC1B:850
 BZ21B[alias]=BLEN:BC2B:950
 BZC1[alias]=BLEN:BC1B:851
+! No device listed for: C24
+! No device listed for: C37
 CATHODEB[alias]=CATH:GUNB:100
 CAVC011[alias]=ACCL:L1B:H110
 CAVC012[alias]=ACCL:L1B:H120
@@ -864,6 +936,7 @@ CMBH2[alias]=BPMS:L1B:H283
 ! No device listed for: CMH2END
 ! No device listed for: CNTBC1
 ! No device listed for: CNTBC2
+! No device listed for: CNTDG0
 ! No device listed for: CNTDLD
 ! No device listed for: CNTDLU
 ! No device listed for: CNTDOG
@@ -874,6 +947,7 @@ CMBH2[alias]=BPMS:L1B:H283
 ! No device listed for: CNTLT2S
 ! No device listed for: CNTLT3H
 ! No device listed for: CNTRS
+! No device listed for: CNTSP1D
 ! No device listed for: CNTSP1H
 ! No device listed for: CNTSP1S
 ! No device listed for: CNTSP2H
@@ -979,7 +1053,71 @@ CYDL16[alias]=COLL:LTUS:345
 ! No device listed for: D0H08A
 ! No device listed for: D0H08B
 ! No device listed for: D1
+! No device listed for: D105A
+! No device listed for: D105B
+! No device listed for: D105C
+! No device listed for: D105D
+! No device listed for: D105E
+! No device listed for: D105F
+! No device listed for: D105G
+! No device listed for: D105H
+! No device listed for: D105I
+! No device listed for: D106
+! No device listed for: D107
+! No device listed for: D108A
+! No device listed for: D108B
+! No device listed for: D108C
+! No device listed for: D109
 ! No device listed for: D10CMB
+! No device listed for: D110A
+! No device listed for: D110B
+! No device listed for: D111
+! No device listed for: D112A
+! No device listed for: D112B
+! No device listed for: D112C
+! No device listed for: D112D
+! No device listed for: D112E
+! No device listed for: D112F
+! No device listed for: D112G
+! No device listed for: D113A
+! No device listed for: D113B
+! No device listed for: D113C
+! No device listed for: D114A
+! No device listed for: D114B
+! No device listed for: D114C
+! No device listed for: D115
+! No device listed for: D116A
+! No device listed for: D116B
+! No device listed for: D117
+! No device listed for: D118A
+! No device listed for: D118B
+! No device listed for: D118C
+! No device listed for: D118D
+! No device listed for: D118E
+! No device listed for: D119
+! No device listed for: D120A
+! No device listed for: D120B
+! No device listed for: D120C
+! No device listed for: D121
+! No device listed for: D122
+! No device listed for: D123A
+! No device listed for: D123B
+! No device listed for: D123C
+! No device listed for: D123D
+! No device listed for: D123E
+! No device listed for: D123F
+! No device listed for: D123G
+! No device listed for: D123H
+! No device listed for: D123I
+! No device listed for: D123J
+! No device listed for: D124A
+! No device listed for: D124B
+! No device listed for: D124C
+! No device listed for: D124D
+! No device listed for: D124E
+! No device listed for: D124F
+! No device listed for: D124G
+! No device listed for: D125
 ! No device listed for: D1C00
 ! No device listed for: D1C01A
 ! No device listed for: D1C01B
@@ -1076,6 +1214,11 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: D40CMWA
 ! No device listed for: D40CMWB
 ! No device listed for: D46CM
+! No device listed for: DA04B
+! No device listed for: DA04C
+! No device listed for: DA05
+! No device listed for: DA06
+! No device listed for: DAMQ10
 ! No device listed for: DBD0A
 ! No device listed for: DBD0B
 ! No device listed for: DBD0C
@@ -1116,26 +1259,54 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: DBKRAPM3B
 ! No device listed for: DBKRAPM4A
 ! No device listed for: DBKRAPM4B
+! No device listed for: DBKRDAS1A
+! No device listed for: DBKRDAS1B
+! No device listed for: DBKRDAS2A
+! No device listed for: DBKRDAS2B
+! No device listed for: DBKRDAS3A
+! No device listed for: DBKRDAS3B
+! No device listed for: DBKRDAS4A
+! No device listed for: DBKRDAS4B
+! No device listed for: DBKRDAS5A
+! No device listed for: DBKRDAS5B
+! No device listed for: DBKRDAS6A
+! No device listed for: DBKRDAS6B
 ! No device listed for: DBKRDG0A
 ! No device listed for: DBKRDG0B
 ! No device listed for: DBKXDMPH
 ! No device listed for: DBKXDMPS
 ! No device listed for: DBKYSP0HA
 ! No device listed for: DBKYSP0HB
+! No device listed for: DBKYSP0SA
+! No device listed for: DBKYSP0SB
 ! No device listed for: DBKYSP1HA
 ! No device listed for: DBKYSP1HB
+! No device listed for: DBKYSP1SA
+! No device listed for: DBKYSP1SB
 ! No device listed for: DBKYSP2HA
 ! No device listed for: DBKYSP2HB
+! No device listed for: DBKYSP2SA
+! No device listed for: DBKYSP2SB
 ! No device listed for: DBKYSP3HA
 ! No device listed for: DBKYSP3HB
+! No device listed for: DBKYSP3SA
+! No device listed for: DBKYSP3SB
 ! No device listed for: DBKYSP4HA
 ! No device listed for: DBKYSP4HB
+! No device listed for: DBKYSP4SA
+! No device listed for: DBKYSP4SB
 ! No device listed for: DBKYSP5HA
 ! No device listed for: DBKYSP5HB
+! No device listed for: DBKYSP5SA
+! No device listed for: DBKYSP5SB
+! No device listed for: DBLRDASA
+! No device listed for: DBLRDASB
 ! No device listed for: DBLRDG0A
 ! No device listed for: DBLRDG0B
 ! No device listed for: DBLXSPHA
 ! No device listed for: DBLXSPHB
+! No device listed for: DBLXSPSA
+! No device listed for: DBLXSPSB
 ! No device listed for: DBMARK34
 ! No device listed for: DBMARK34B
 ! No device listed for: DBMARK36
@@ -1385,11 +1556,73 @@ DCHIRPV[alias]=DCHP:LTUH:545
 ! No device listed for: DD2C
 ! No device listed for: DD3A
 ! No device listed for: DD3B
+! No device listed for: DDAS1
+! No device listed for: DDAS11A
+! No device listed for: DDAS11B
+! No device listed for: DDAS12A
+! No device listed for: DDAS12B
+! No device listed for: DDAS12C
+! No device listed for: DDAS13
+! No device listed for: DDAS14AA
+! No device listed for: DDAS14AB
+! No device listed for: DDAS14B
+! No device listed for: DDAS15A
+! No device listed for: DDAS15B
+! No device listed for: DDAS16
+! No device listed for: DDAS17A
+! No device listed for: DDAS17B
+! No device listed for: DDAS17C
+! No device listed for: DDAS18
+! No device listed for: DDAS19
+! No device listed for: DDAS20A
+! No device listed for: DDAS20B
+! No device listed for: DDAS2A
+! No device listed for: DDAS2B
+! No device listed for: DDAS3
+! No device listed for: DDAS4
+! No device listed for: DDAS5A
+! No device listed for: DDAS5B
+! No device listed for: DDAS5C
+! No device listed for: DDASBK1
+! No device listed for: DDASBK2
+! No device listed for: DDASBK3H
+! No device listed for: DDASBK4
+! No device listed for: DDASBK5
+! No device listed for: DDASBLXA
+! No device listed for: DDASBLXB
+! No device listed for: DDASBLXB1
+! No device listed for: DDASBLXB2
+! No device listed for: DDASQQ
 ! No device listed for: DDBLDLA1
 ! No device listed for: DDBLDLA2
 ! No device listed for: DDBLDLB
 ! No device listed for: DDBLDLC
 ! No device listed for: DDBLDLD
+! No device listed for: DDG003
+! No device listed for: DDG004A
+! No device listed for: DDG004B
+! No device listed for: DDG005A
+! No device listed for: DDG005B
+! No device listed for: DDG006A
+! No device listed for: DDG006B
+! No device listed for: DDG006C
+! No device listed for: DDG006D
+! No device listed for: DDG007
+! No device listed for: DDG008A
+! No device listed for: DDG008B
+! No device listed for: DDG009A
+! No device listed for: DDG009B
+! No device listed for: DDG009C
+! No device listed for: DDG009D
+! No device listed for: DDG009E
+! No device listed for: DDG009F
+! No device listed for: DDG010A
+! No device listed for: DDG010B
+! No device listed for: DDG011A
+! No device listed for: DDG011B
+! No device listed for: DDG012A
+! No device listed for: DDG012B
+! No device listed for: DDG012C
 ! No device listed for: DDL0BA
 ! No device listed for: DDL0BB
 ! No device listed for: DDL0BC
@@ -1441,6 +1674,7 @@ DCHIRPV[alias]=DCHP:LTUH:545
 ! No device listed for: DDLWALL
 ! No device listed for: DDLWALLB
 ! No device listed for: DDUMP
+! No device listed for: DDUMPBSY
 ! No device listed for: DE200A
 ! No device listed for: DE200B
 ! No device listed for: DE201A
@@ -1517,6 +1751,8 @@ DCHIRPV[alias]=DCHP:LTUH:545
 ! No device listed for: DHD04A
 ! No device listed for: DHD04B
 DIAMOND[alias]=XTAL:UNDH:2850
+! No device listed for: DKV0A
+! No device listed for: DKV0B
 ! No device listed for: DL0PA
 ! No device listed for: DL0PB
 ! No device listed for: DL1PA
@@ -1597,6 +1833,7 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DPCVV
 ! No device listed for: DPCVVA
 ! No device listed for: DPCVVB
+! No device listed for: DPR2
 ! No device listed for: DPSC1D
 ! No device listed for: DPSC1U
 ! No device listed for: DPSC2D
@@ -1623,6 +1860,15 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DPSSX48
 ! No device listed for: DPSSX49
 ! No device listed for: DPSSX50
+! No device listed for: DQB01A
+! No device listed for: DQB01B
+! No device listed for: DQB01C
+! No device listed for: DQB02A
+! No device listed for: DQB02B
+! No device listed for: DQB03A
+! No device listed for: DQB03B
+! No device listed for: DQB04A
+! No device listed for: DQB04B
 ! No device listed for: DQEA
 ! No device listed for: DQEAA
 ! No device listed for: DQEAB
@@ -1716,12 +1962,21 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DSP16HC
 ! No device listed for: DSP17HA
 ! No device listed for: DSP17HB
+! No device listed for: DSP2DA1
+! No device listed for: DSP2DA2
+! No device listed for: DSP2DB
+! No device listed for: DSP2DC2
+! No device listed for: DSP2DD
 ! No device listed for: DSP2HA
 ! No device listed for: DSP2HB
 ! No device listed for: DSP2HC
 ! No device listed for: DSP2SA
 ! No device listed for: DSP2SB
 ! No device listed for: DSP2SC
+! No device listed for: DSP3DA
+! No device listed for: DSP3DB
+! No device listed for: DSP3DC
+! No device listed for: DSP3DD
 ! No device listed for: DSP3HAA
 ! No device listed for: DSP3HAB
 ! No device listed for: DSP3HB
@@ -1731,6 +1986,8 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DSP3SAB
 ! No device listed for: DSP3SB
 ! No device listed for: DSP3SC
+! No device listed for: DSP4DA
+! No device listed for: DSP4DB
 ! No device listed for: DSP4HA
 ! No device listed for: DSP4HB
 ! No device listed for: DSP4HC
@@ -1738,18 +1995,40 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DSP4SB
 ! No device listed for: DSP4SC
 ! No device listed for: DSP4SD
+! No device listed for: DSP5DA
+! No device listed for: DSP5DB
+! No device listed for: DSP5DC1
+! No device listed for: DSP5DC2
+! No device listed for: DSP5DC3
+! No device listed for: DSP5DD
 ! No device listed for: DSP5HA
 ! No device listed for: DSP5HB
 ! No device listed for: DSP5HCA
 ! No device listed for: DSP5HCB
 ! No device listed for: DSP5SA
 ! No device listed for: DSP5SB
+! No device listed for: DSP6DA
+! No device listed for: DSP6DB
+! No device listed for: DSP6DC
+! No device listed for: DSP6DD
+! No device listed for: DSP6DE
+! No device listed for: DSP6DFA
+! No device listed for: DSP6DFB
+! No device listed for: DSP6DFC
+! No device listed for: DSP6DFD
+! No device listed for: DSP6DG
+! No device listed for: DSP6DH
+! No device listed for: DSP6DI
+! No device listed for: DSP6DJ
 ! No device listed for: DSP6HA
 ! No device listed for: DSP6HB
 ! No device listed for: DSP6HC
 ! No device listed for: DSP6SA
 ! No device listed for: DSP6SB
 ! No device listed for: DSP6SC
+! No device listed for: DSP7DAA
+! No device listed for: DSP7DAB
+! No device listed for: DSP7DB
 ! No device listed for: DSP7HA
 ! No device listed for: DSP7HB
 ! No device listed for: DSP7HC
@@ -1891,8 +2170,10 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DUM3B
 ! No device listed for: DUM4A
 ! No device listed for: DUM4B
+DUMPBSY[alias]=DUMP:SLTD:923
 ! No device listed for: DUMPBSYH
 ! No device listed for: DUMPBSYS
+DUMPDAS[alias]=DUMP:DASEL:470
 DUMPFACE[alias]=DUMP:DMPH:699
 DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: DUMXL12D
@@ -1944,6 +2225,7 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: DW2TDUND
 ! No device listed for: DW2TDUNDB
 ! No device listed for: DWALLA
+! No device listed for: DWALLAD
 ! No device listed for: DWALLB
 ! No device listed for: DWGH
 ! No device listed for: DWIGSA
@@ -1979,6 +2261,8 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: DXLUD2
 ! No device listed for: DYCA0
 ! No device listed for: DYCVM1
+! No device listed for: DYQDG001
+! No device listed for: DYQDG003
 ! No device listed for: DZA01
 ! No device listed for: DZA02
 ! No device listed for: DZAPM1
@@ -1990,14 +2274,18 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: ECD
 ! No device listed for: ECU
 ! No device listed for: END
+! No device listed for: ENDB
 ! No device listed for: ENDBC1B
 ! No device listed for: ENDBC2B
+! No device listed for: ENDBSYA_2
 ! No device listed for: ENDBSYH_1
 ! No device listed for: ENDBSYH_2
 ! No device listed for: ENDBSYS
 ! No device listed for: ENDBYP
 ! No device listed for: ENDCOL0
 ! No device listed for: ENDCOL1
+! No device listed for: ENDDASEL
+! No device listed for: ENDDIAG0
 ! No device listed for: ENDDMPH_1
 ! No device listed for: ENDDMPH_2
 ! No device listed for: ENDDMPS_1
@@ -2013,9 +2301,12 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: ENDL3B
 ! No device listed for: ENDLTUH
 ! No device listed for: ENDLTUS
+! No device listed for: ENDSLTD
 ! No device listed for: ENDSLTH
 ! No device listed for: ENDSLTS
 ! No device listed for: ENDSPD_1
+! No device listed for: ENDSPD_2
+! No device listed for: ENDSPD_3
 ! No device listed for: ENDSPH
 ! No device listed for: ENDSPS
 ! No device listed for: ENDUNDH
@@ -2027,8 +2318,11 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: FC4
 ! No device listed for: FC5
 ! No device listed for: FC6
+FCDG0DU[alias]=FARC:DIAG0:530
 FSPEPX1[alias]=VVFS:UNDS:4797
 ! No device listed for: FSPEPX3
+! No device listed for: FV10
+! No device listed for: FV28
 GJPEPX[alias]=GJET:UNDS:5049
 GSXS1[alias]=GRAT:UNDS:3515
 ! No device listed for: HOMCM
@@ -2039,6 +2333,11 @@ GSXS1[alias]=GRAT:UNDS:3515
 ! No device listed for: HXRSSEND
 ! No device listed for: HXRSTART
 ! No device listed for: HXRTERM
+! No device listed for: I10
+! No device listed for: I11
+! No device listed for: I24
+! No device listed for: I28
+! No device listed for: I29
 IM01B[alias]=TORO:GUNB:360
 IM11B[alias]=TORO:COL1:125
 IM21B[alias]=TORO:EMIT2:170
@@ -2046,18 +2345,28 @@ IM31[alias]=TORO:LTUH:195
 IM36[alias]=TORO:LTUH:605
 IMBCS1[alias]=TORO:LTUH:196
 IMBCS2[alias]=TORO:LTUH:510
+IMBCSD1[alias]=ACM:SPD:875
+IMBCSD2[alias]=ACM:SPD:876
 IMBCSH1[alias]=ACM:SPH:875
 IMBCSH2[alias]=ACM:SPH:876
 IMBCSI1[alias]=ACM:HTR:910
 IMBCSI2[alias]=ACM:HTR:922
 IMBCSS1[alias]=ACM:SPS:875
 IMBCSS2[alias]=ACM:SPS:876
+IMDAS1[alias]=ACM:DASEL:410
+IMDAS2[alias]=ACM:DASEL:411
+IMSP0D[alias]=TORO:SPD:695
 IMSP0H[alias]=TORO:SPH:365
 IMSP0S[alias]=TORO:SPS:605
 IMUNDI[alias]=TORO:LTUH:920
+! No device listed for: IV10
+! No device listed for: IV26
 ! No device listed for: LHBEGB
 ! No device listed for: LHENDB
 ! No device listed for: LTUSPLIT
+! No device listed for: M1DG0
+! No device listed for: M2DG0
+! No device listed for: MARC
 ! No device listed for: MBLMH13
 ! No device listed for: MBLMH14
 ! No device listed for: MBLMH15
@@ -2141,6 +2450,8 @@ MIRROR2[alias]=MIRR:UNDH:2145
 ! No device listed for: MQBP23
 ! No device listed for: MQDMP
 ! No device listed for: MQDMPB
+! No device listed for: MRFBSP1D
+! No device listed for: MRFBSP2D
 ! No device listed for: MRGALINE
 ! No device listed for: MRGCUSXR
 ! No device listed for: MSC0D
@@ -2157,6 +2468,8 @@ MSXS3[alias]=MIRR:UNDS:3565
 ! No device listed for: MTCX01
 ! No device listed for: MTCX01B
 ! No device listed for: MTCXB
+! No device listed for: MTCXDG0
+! No device listed for: MTCYDG0
 ! No device listed for: MUHWALL1
 ! No device listed for: MUHWALL1B
 ! No device listed for: MUHWALL2
@@ -2165,6 +2478,7 @@ MSXS3[alias]=MIRR:UNDS:3565
 ! No device listed for: MUQS
 ! No device listed for: MUWALL
 ! No device listed for: MUWALLB
+! No device listed for: MUWALLD
 ! No device listed for: MXL2A
 ! No device listed for: MXL2B
 OTR0H04[alias]=OTRS:HTR:330
@@ -2174,9 +2488,14 @@ OTR30[alias]=OTRS:LTU1:449
 OTR31[alias]=PROF:DOG:245
 OTR33[alias]=OTRS:LTUH:745
 OTRC006[alias]=PROF:COL0:535
+OTRDG01[alias]=OTRS:DIAG0:396
+OTRDG02[alias]=OTRS:DIAG0:420
+OTRDG03[alias]=OTRS:DIAG0:440
+OTRDG04[alias]=OTRS:DIAG0:525
 OTRDMP[alias]=OTRS:DMPH:695
 OTRDMPB[alias]=OTRS:DMPS:695
 OTRDOG[alias]=PROF:DOG:195
+OTRSPDMP[alias]=PROF:SLTD:897
 ! No device listed for: PC01
 ! No device listed for: PC01B
 ! No device listed for: PC02
@@ -2194,11 +2513,19 @@ OTRDOG[alias]=PROF:DOG:195
 ! No device listed for: PC09
 ! No device listed for: PC09B
 PC0H00[alias]=COLL:HTR:103
+! No device listed for: PC10
 ! No device listed for: PC10B
 PC119[alias]=COLL:BSYH:836
 ! No device listed for: PC11B
+! No device listed for: PC12
 ! No device listed for: PC12B
+! No device listed for: PC14
+! No device listed for: PC17
+! No device listed for: PC20
 ! No device listed for: PC22
+! No device listed for: PC24
+! No device listed for: PC26
+! No device listed for: PC29
 ! No device listed for: PC42
 ! No device listed for: PC43
 PC90[alias]=COLL:BSYH:762
@@ -2206,6 +2533,7 @@ PCAPM1[alias]=COLL:BSYH:479
 PCAPM2[alias]=COLL:BSYH:487
 PCAPM3[alias]=COLL:BSYH:495
 PCAPM4[alias]=COLL:BSYH:503
+PCBLRDAS[alias]=COLL:DASEL:210
 ! No device listed for: PCBP33
 PCBSY3[alias]=COLL:BSYH:471
 PCBSY4[alias]=COLL:BSYH:802
@@ -2245,6 +2573,15 @@ PH33[alias]=PCAV:DMPH:175
 PH33B[alias]=PCAV:DMPS:175
 PH34[alias]=PCAV:DMPH:180
 PH34B[alias]=PCAV:DMPS:180
+! No device listed for: PR10
+! No device listed for: PR18
+! No device listed for: PR20
+! No device listed for: PR28
+! No device listed for: PR33
+! No device listed for: PRBRAM1
+PRDAS12[alias]=PROF:DASEL:440
+PRDAS14[alias]=PROF:DASEL:655
+PRDAS17[alias]=PROF:DASEL:818
 ! No device listed for: PSC1D
 ! No device listed for: PSC1U
 ! No device listed for: PSC2D
@@ -2311,8 +2648,16 @@ Q0H05[alias]=QUAD:HTR:365
 Q0H06[alias]=QUAD:HTR:385
 Q0H07[alias]=QUAD:HTR:440
 Q0H08[alias]=QUAD:HTR:460
+! No device listed for: Q10
+! No device listed for: Q11
+! No device listed for: Q19
 Q1C01[alias]=QUAD:BC1B:125
+! No device listed for: Q20
+! No device listed for: Q27
+! No device listed for: Q28
 Q2C01[alias]=QUAD:BC2B:150
+! No device listed for: Q30
+! No device listed for: Q38
 Q4[alias]=QUAD:BSYH:465
 Q5[alias]=QUAD:BSYH:640
 Q50Q3[alias]=QUAD:BSYH:445
@@ -2403,8 +2748,33 @@ QCM32[alias]=QUAD:L3B:3285
 QCM33[alias]=QUAD:L3B:3385
 QCM34[alias]=QUAD:L3B:3485
 QCM35[alias]=QUAD:L3B:3585
+QDAS11[alias]=QUAD:DASEL:434
+QDAS12[alias]=QUAD:DASEL:489
+QDAS13[alias]=QUAD:DASEL:557
+QDAS14[alias]=QUAD:DASEL:625
+QDAS15[alias]=QUAD:DASEL:690
+QDAS16[alias]=QUAD:DASEL:758
+QDAS17[alias]=QUAD:DASEL:822
+QDAS18A[alias]=QUAD:DASEL:880
+QDAS18B[alias]=QUAD:DASEL:882
+QDAS19[alias]=QUAD:DASEL:910
+QDAS1A[alias]=QUAD:DASEL:304
+QDAS1B[alias]=QUAD:DASEL:300
+QDAS2A[alias]=QUAD:DASEL:312
+QDAS2B[alias]=QUAD:DASEL:314
 QDBL1[alias]=QUAD:LTUS:110
 QDBL2[alias]=QUAD:LTUS:120
+QDG001[alias]=QUAD:DIAG0:190
+QDG002[alias]=QUAD:DIAG0:210
+QDG003[alias]=QUAD:DIAG0:230
+QDG004[alias]=QUAD:DIAG0:270
+QDG005[alias]=QUAD:DIAG0:285
+QDG006[alias]=QUAD:DIAG0:300
+QDG007[alias]=QUAD:DIAG0:360
+QDG008[alias]=QUAD:DIAG0:370
+QDG009[alias]=QUAD:DIAG0:390
+QDG010[alias]=QUAD:DIAG0:455
+QDG011[alias]=QUAD:DIAG0:470
 QDL11[alias]=QUAD:LTUS:150
 QDL12[alias]=QUAD:LTUS:180
 QDL13[alias]=QUAD:LTUS:235
@@ -2510,9 +2880,11 @@ QSP10H[alias]=QUAD:SPH:920
 QSP11H[alias]=QUAD:SPH:940
 QSP12H[alias]=QUAD:SLTH:200
 QSP13H[alias]=QUAD:SLTH:220
+QSP1D[alias]=QUAD:SPD:690
 QSP1H[alias]=QUAD:SPH:320
 QSP1S[alias]=QUAD:SPS:570
 QSP2[alias]=QUAD:SPD:340
+QSP2D[alias]=QUAD:SPD:700
 QSP2H[alias]=QUAD:SPH:345
 QSP2S[alias]=QUAD:SPS:580
 QSP3H[alias]=QUAD:SPH:420
@@ -2593,6 +2965,8 @@ QVM4[alias]=QUAD:LTUH:190
 QVM4B[alias]=QUAD:LTUS:580
 QX01[alias]=QUAD:EXT:351
 QX02[alias]=QUAD:EXT:748
+RCDAS11[alias]=XCOR:DASEL:422
+RCDAS19[alias]=XCOR:DASEL:998
 RFB07[alias]=BPMS:LTUH:910
 RFB08[alias]=BPMS:LTUH:960
 ! No device listed for: RFB0H00
@@ -2615,6 +2989,9 @@ RFBC108[alias]=BPMS:COL1:675
 RFBC110[alias]=BPMS:COL1:835
 RFBDD[alias]=BPMS:DMPH:696
 RFBDDB[alias]=BPMS:DMPS:696
+RFBDG001[alias]=BPMS:DIAG0:160
+RFBDG002[alias]=BPMS:DIAG0:410
+RFBDG003[alias]=BPMS:DIAG0:480
 RFBDL1[alias]=BPMS:LTUH:251
 RFBE32[alias]=BPMS:LTUH:731
 RFBE32B[alias]=BPMS:LTUS:731
@@ -2698,16 +3075,28 @@ RFBWSBP4[alias]=BPMS:BPN16:848
 RFBX02[alias]=BPMS:EXT:738
 ! No device listed for: ROBRB1
 ! No device listed for: ROBRB2
+! No device listed for: RODAS1
+! No device listed for: RODAS11M
+! No device listed for: RODAS11P
+! No device listed for: RODAS19M
+! No device listed for: RODAS19P
+! No device listed for: RODAS2
+! No device listed for: RODAS3
+! No device listed for: RODG0K
+! No device listed for: RODG0L
 ! No device listed for: RODMP1H
 ! No device listed for: RODMP1S
 ! No device listed for: RODMP2H
 ! No device listed for: RODMP2S
+! No device listed for: ROLL2
+! No device listed for: ROLL3
 ! No device listed for: ROSP1H
 ! No device listed for: ROSP1S
 ! No device listed for: ROSP2H
 ! No device listed for: ROSP3H
 ! No device listed for: RWWAKE1
 ! No device listed for: RWWAKE2
+! No device listed for: RWWAKE3D
 ! No device listed for: RWWAKE3H
 ! No device listed for: RWWAKE3S
 ! No device listed for: RWWAKE4H
@@ -2735,10 +3124,13 @@ SDL1[alias]=SEXT:LTUS:230
 SDL2[alias]=SEXT:LTUS:297
 SDOG1[alias]=SEXT:DOG:132
 SDOG2[alias]=SEXT:DOG:213
+! No device listed for: SL10
+! No device listed for: SL19
 SLSXS1[alias]=SLIT:UNDS:3555
 SOL1B[alias]=SOLN:GUNB:212
 SOL1BKB[alias]=SOLN:GUNB:100
 SOL2B[alias]=SOLN:GUNB:823
+! No device listed for: SP18
 SPOILER[alias]=SPLR:LTUH:359
 SPOILERS[alias]=SPLR:LTUS:378
 SPTCX[alias]=SPLR:DMPH:373
@@ -2746,12 +3138,15 @@ SPTCXB[alias]=SPLR:DMPS:373
 SQ01B[alias]=QUAD:GUNB:212:2
 SQ02B[alias]=QUAD:GUNB:823:2
 SQ13B[alias]=QUAD:BC1B:625
+! No device listed for: SQ27P5
 ! No device listed for: SS1
 ! No device listed for: SS3
 SSP1H[alias]=SEXT:SPH:321
 SSP1S[alias]=SEXT:SPS:571
 SSP2H[alias]=SEXT:SPH:415
 SSP2S[alias]=SEXT:SPS:839
+! No device listed for: ST22
+! No device listed for: ST29
 ST60[alias]=STPR:BSYH:854
 ST61[alias]=STPR:BSYH:905
 STBP34A[alias]=STPR:BSYS:891
@@ -2762,14 +3157,18 @@ STBP34B[alias]=STPR:BSYS:897
 ! No device listed for: SXRTERM
 ! No device listed for: SXXSTART
 ! No device listed for: SXXTERM
+! No device listed for: SYNC
 TCX01[alias]=TCAV:DMPH:360
 TCX01B[alias]=TCAV:DMPS:360
 TCX02[alias]=TCAV:DMPH:361
 TCX02B[alias]=TCAV:DMPS:361
+TCXDG0[alias]=ACCL:DIAG0:340
+TCYDG0[alias]=ACCL:DIAG0:320
 TDKIK[alias]=DUMP:LTUH:360
 TDKIKS[alias]=DUMP:LTUS:385
 TDUND[alias]=DUMP:LTUH:970
 TDUNDB[alias]=DUMP:LTUS:972
+! No device listed for: TGTBRAM1
 TRUE1[alias]=THZR:DMPH:350
 TRUE1B[alias]=THZR:DMPS:350
 ! No device listed for: UEBEG
@@ -2900,12 +3299,14 @@ WSC104[alias]=WIRE:COL1:360
 WSC106[alias]=WIRE:COL1:520
 WSC108[alias]=WIRE:COL1:680
 WSC110[alias]=WIRE:COL1:840
+WSDG01[alias]=WIRE:DIAG0:424
 WSDL31[alias]=WIRE:LTUH:246
 WSDL4[alias]=WIRE:LTUH:538
 WSDOG[alias]=WIRE:DOG:202
 WSDUMP[alias]=WIRE:DMPH:697
 WSDUMPB[alias]=WIRE:DMPS:697
 WSEMIT2[alias]=WIRE:EMIT2:600
+WSSP1D[alias]=WIRE:SPD:872
 WSVM2[alias]=WIRE:LTUH:122
 XC01B[alias]=XCOR:GUNB:293
 XC02B[alias]=XCOR:GUNB:388
@@ -2959,9 +3360,19 @@ XCC110[alias]=XCOR:COL1:808
 XCC112[alias]=XCOR:COL1:968
 XCD3[alias]=XCOR:DMPH:392
 XCD3B[alias]=XCOR:DMPS:392
+XCDAS1[alias]=XCOR:DASEL:294
+XCDAS14[alias]=XCOR:DASEL:622
 XCDBL2[alias]=XCOR:LTUS:118
 XCDD[alias]=XCOR:DMPH:602
 XCDDB[alias]=XCOR:DMPS:602
+XCDG001[alias]=XCOR:DIAG0:178
+XCDG002[alias]=XCOR:DIAG0:218
+XCDG003[alias]=XCOR:DIAG0:280
+XCDG005[alias]=XCOR:DIAG0:290
+XCDG008[alias]=XCOR:DIAG0:380
+XCDG010[alias]=XCOR:DIAG0:460
+XCDGTCX[alias]=XCOR:DIAG0:340
+XCDGTCY[alias]=XCOR:DIAG0:320
 XCDL1[alias]=XCOR:LTUH:248
 XCDL11[alias]=XCOR:LTUS:148
 XCDL13[alias]=XCOR:LTUS:228
@@ -3108,10 +3519,13 @@ XCQT42[alias]=XCOR:LTUH:588
 XCSP1[alias]=XCOR:SPD:334
 XCSP11H[alias]=XCOR:SPH:938
 XCSP13H[alias]=XCOR:SLTH:218
+XCSP1D[alias]=XCOR:SPD:688
 XCSP1H[alias]=XCOR:SPH:324
 XCSP1S[alias]=XCOR:SPS:578
+XCSP3D[alias]=XCOR:SPD:964
 XCSP3H[alias]=XCOR:SPH:414
 XCSP3S[alias]=XCOR:SPS:634
+XCSP5D[alias]=XCOR:SLTD:616
 XCSP5H[alias]=XCOR:SPH:516
 XCSP5S[alias]=XCOR:SPS:706
 XCSP7H[alias]=XCOR:SPH:684
@@ -3243,9 +3657,19 @@ YCC109[alias]=YCOR:COL1:729
 YCC111[alias]=YCOR:COL1:889
 YCD3[alias]=YCOR:DMPH:391
 YCD3B[alias]=YCOR:DMPS:391
+YCDAS1[alias]=YCOR:DASEL:297
+YCDAS17[alias]=YCOR:DASEL:821
 YCDBL1[alias]=YCOR:LTUS:111
 YCDD[alias]=YCOR:DMPH:440
 YCDDB[alias]=YCOR:DMPS:440
+YCDG001[alias]=YCOR:DIAG0:199
+YCDG002[alias]=YCOR:DIAG0:247
+YCDG003[alias]=YCOR:DIAG0:280
+YCDG005[alias]=YCOR:DIAG0:290
+YCDG008[alias]=YCOR:DIAG0:380
+YCDG010[alias]=YCOR:DIAG0:460
+YCDGTCX[alias]=YCOR:DIAG0:340
+YCDGTCY[alias]=YCOR:DIAG0:320
 YCDL1[alias]=YCOR:LTUH:253
 YCDL12[alias]=YCOR:LTUS:183
 YCDL14[alias]=YCOR:LTUS:267
@@ -3388,10 +3812,13 @@ YCQT42[alias]=YCOR:LTUH:593
 YCSP10H[alias]=YCOR:SPH:917
 YCSP12H[alias]=YCOR:SLTH:201
 YCSP2[alias]=YCOR:SPD:343
+YCSP2D[alias]=YCOR:SPD:703
 YCSP2H[alias]=YCOR:SPH:346
 YCSP2S[alias]=YCOR:SPS:587
+YCSP4D[alias]=YCOR:SPD:965
 YCSP4H[alias]=YCOR:SPH:447
 YCSP4S[alias]=YCOR:SPS:643
+YCSP6D[alias]=YCOR:SLTD:619
 YCSP6H[alias]=YCOR:SPH:597
 YCSP6S[alias]=YCOR:SPS:767
 YCSP8H[alias]=YCOR:SPH:757

--- a/bmad/models/sc_bsyd/tao.init
+++ b/bmad/models/sc_bsyd/tao.init
@@ -11,11 +11,12 @@
 &tao_design_lattice
   !unique_name_suffix="*::_##?"
   design_lattice(1)%file='sc_bsyd.lat.bmad'
+  !design_lattice(1)%slice_lattice = "BEAM0:HXRSTART"
 /
 
 !------------------------------------------------------------------------
 &tao_params
-  !global%plot_on = T
+  global%plot_on = T
   global%track_type = 'single'
   global%beam_timer_on = T
   global%random_engine = 'pseudo' ! or: 'quasi'
@@ -35,6 +36,7 @@ ix_universe = 1
 beam_saved_at =  "MARKER::*"
 track_start = 'BEAM0'
 !track_end = 'DBMARK82'
+!track_end = 'HXRSTART'
 beam_init%position_file = '$LCLS_LATTICE/bmad/beams/FZ_100pC_10NOV17_scattered_5keV_resampled_100k.beam0'
 !beam_init%position_file = 'beam_1.hdf5'
 beam_init%center(1) = 0.0
@@ -56,19 +58,22 @@ beam_init%center(6) = 0.0
         ix_d1_data = 1
         default_weight = 1
         d1_data%name = 'energy'
-        datum( 1) =  'orbit.e_tot'     '' '' 'ENDL0B'   'target'  100e6  1e1
+        datum( 1) =  'orbit.e_tot'     '' '' 'BEAM0'   'target'  100e6  1e1
 /
 &tao_d1_data
     ix_d1_data = 2
     d1_data%name = 'endtwiss'
-    datum( 1) =  'beta.a'     '' '' 'ENDL0B'   'target'   2.124671319E+01   1e1
-    datum( 2) =  'alpha.a'    '' '' 'ENDL0B'   'target'  -1.623900964E+00   1e1
-    datum( 3) =  'beta.b'     '' '' 'ENDL0B'   'target'   4.416143920E+01   1e1
-    datum( 4) =  'alpha.b'    '' '' 'ENDL0B'   'target'  -5.562722043E+00   1e1
-    datum( 5) =  'eta.x'      '' '' 'ENDL0B'   'target'   0.000000000E+00   1e1
-    datum( 6) =  'etap.x'     '' '' 'ENDL0B'   'target'   0.000000000E+00   1e1
+    datum( 1) =  'beta.a'     '' '' 'BEAM0'   'target'   2.124671319E+01   1e1
+    datum( 2) =  'alpha.a'    '' '' 'BEAM0'   'target'  -1.623900964E+00   1e1
+    datum( 3) =  'beta.b'     '' '' 'BEAM0'   'target'   4.416143920E+01   1e1
+    datum( 4) =  'alpha.b'    '' '' 'BEAM0'   'target'  -5.562722043E+00   1e1
+    datum( 5) =  'eta.x'      '' '' 'BEAM0'   'target'   0.000000000E+00   1e1
+    datum( 6) =  'etap.x'     '' '' 'BEAM0'   'target'   0.000000000E+00   1e1
 /  
 
+
+!---------------------------------------------------------------------------------------
+! HTR
 
 &tao_d2_data
         d2_data%name = 'HTR'
@@ -88,10 +93,14 @@ beam_init%center(6) = 0.0
 /   
 
 
+
+!---------------------------------------------------------------------------------------
+! BC1
+
 &tao_d2_data
         d2_data%name = 'BC1'
         universe = 1
-        n_d1_data = 1
+        n_d1_data = 2
 /
 &tao_d1_data
         ix_d1_data = 1
@@ -103,16 +112,115 @@ beam_init%center(6) = 0.0
         datum( 4) =  'alpha.b'    '' '' 'BEGBC1B'   'target'  -7.975687433E-01  1e2
         datum( 5) =  'eta.x'      '' '' 'BEGBC1B'   'target'   0  1e1
         datum( 6) =  'etap.x'     '' '' 'BEGBC1B'   'target'   0   1e2
-/   
+/  
+
+&tao_d1_data
+        ix_d1_data = 2
+        default_weight = 1
+        d1_data%name = 'r56'
+        datum( 1) =  'r56_compaction'     'BEGBC1B' '' 'ENDBC1B'  'target' 45e-3  1e1
+/
+
+
+!---------------------------------------------------------------------------------------
+! COL1
+
+&tao_d2_data
+        d2_data%name = 'COL1'
+        universe = 1
+        n_d1_data = 1
+/
+&tao_d1_data
+        ix_d1_data = 1
+        default_weight = 1
+        d1_data%name = 'endtwiss'
+        datum( 1) =  'beta.a'     '' '' 'ENDCOL1'   'target'  25.77163820    1e1
+        datum( 2) =  'alpha.a'    '' '' 'ENDCOL1'   'target' 0.86995449 1e2
+        datum( 3) =  'beta.b'     '' '' 'ENDCOL1'   'target'   5.02337989     1e1
+        datum( 4) =  'alpha.b'    '' '' 'ENDCOL1'   'target' -0.18284591  1e2
+        datum( 5) =  'eta.x'      '' '' 'ENDCOL1'   'target'   0  1e1
+        datum( 6) =  'etap.x'     '' '' 'ENDCOL1'   'target'   0   1e2
+/  
+
+
+
+
+
+!---------------------------------------------------------------------------------------
+! BC2
+
+&tao_d2_data
+        d2_data%name = 'BC2'
+        universe = 1
+        n_d1_data = 2
+/
+&tao_d1_data
+        ix_d1_data = 1
+        default_weight = 1
+        d1_data%name = 'begtwiss'
+        datum( 1) =  'beta.a'     '' '' 'BEGBC2B'   'target'  3.870395077E+01   1e1
+        datum( 2) =  'alpha.a'    '' '' 'BEGBC2B'   'target'  4.476022866E-01    1e2
+        datum( 3) =  'beta.b'     '' '' 'BEGBC2B'   'target'  3.109163641E+01     1e1
+        datum( 4) =  'alpha.b'    '' '' 'BEGBC2B'   'target'  -7.975687433E-01   1e2
+        datum( 5) =  'eta.x'      '' '' 'BEGBC2B'   'target'   0  1e1
+        datum( 6) =  'etap.x'     '' '' 'BEGBC2B'   'target'   0   1e2
+/  
+
+&tao_d1_data
+        ix_d1_data = 2
+        default_weight = 1
+        d1_data%name = 'r56'
+        datum( 1) =  'r56_compaction'     'BEGBC2B' '' 'ENDBC2B'  'target' 45e-3  1e1
+/
+
+
+
+
+!---------------------------------------------------------------------------------------
+! EMIT2
+
+&tao_d2_data
+        d2_data%name = 'EMIT2'
+        universe = 1
+        n_d1_data = 1
+/
+&tao_d1_data
+        ix_d1_data = 1
+        default_weight = 1
+        d1_data%name = 'endtwiss'
+        datum( 1) =  'beta.a'     '' '' 'ENDEMIT2'   'target'  55.29630154    1e1
+        datum( 2) =  'alpha.a'    '' '' 'ENDEMIT2'   'target'  1.50461172  1e2
+        datum( 3) =  'beta.b'     '' '' 'ENDEMIT2'   'target'   7.84219456      1e1
+        datum( 4) =  'alpha.b'    '' '' 'ENDEMIT2'   'target'  -0.39966385   1e2
+        datum( 5) =  'eta.x'      '' '' 'ENDEMIT2'   'target'   0  1e1
+        datum( 6) =  'etap.x'     '' '' 'ENDEMIT2'   'target'   0   1e2
+/  
+
+
+
+
+
+ 
+
+!---------------------------------------------------------------------------------------
+! L1
 
 
 &tao_d2_data
         d2_data%name = 'L1'
         universe = 1
-        n_d1_data = 1
+        n_d1_data = 2
 /
+
 &tao_d1_data
-    ix_d1_data = 1
+        ix_d1_data = 1
+        default_weight = 1
+        d1_data%name = 'energy'
+        datum( 1) =  'orbit.e_tot'     '' '' 'ENDL1B'   'target'  230e6  1e1
+/
+
+&tao_d1_data
+    ix_d1_data = 2
     d1_data%name = 'endtwiss'
     datum( 1) =  'beta.a'     '' '' 'ENDL1B'   'target'   3.870395077E+01   1e1
     datum( 2) =  'alpha.a'    '' '' 'ENDL1B'   'target'   4.476022866E-01   1e1
@@ -123,13 +231,25 @@ beam_init%center(6) = 0.0
 /
 
 
+
+!---------------------------------------------------------------------------------------
+! L2
+
 &tao_d2_data
         d2_data%name = 'L2'
         universe = 1
-        n_d1_data = 1
+        n_d1_data = 2
 /
+
 &tao_d1_data
-    ix_d1_data = 1
+        ix_d1_data = 1
+        default_weight = 1
+        d1_data%name = 'energy'
+        datum( 1) =  'orbit.e_tot'     '' '' 'ENDL2B'   'target'  1600e6  1e1
+/
+
+&tao_d1_data
+    ix_d1_data = 2
     d1_data%name = 'endtwiss'
     datum( 1) =  'beta.a'     '' '' 'ENDL2B'   'target'   2.301739816E+02   1e1
     datum( 2) =  'alpha.a'    '' '' 'ENDL2B'   'target'  -3.315233808E+00   1e1
@@ -140,13 +260,25 @@ beam_init%center(6) = 0.0
 /  
 
 
+!---------------------------------------------------------------------------------------
+! L3
+
 &tao_d2_data
         d2_data%name = 'L3'
         universe = 1
-        n_d1_data = 1
+        n_d1_data = 2
 /
+
+
 &tao_d1_data
-    ix_d1_data = 1
+        ix_d1_data = 1
+        default_weight = 1
+        d1_data%name = 'energy'
+        datum( 1) =  'orbit.e_tot'     '' '' 'ENDL3B'   'target'  4000e6  1e1
+/
+
+&tao_d1_data
+    ix_d1_data = 2
     d1_data%name = 'endtwiss'
     datum( 1) =  'beta.a'     '' '' 'ENDL3B'   'target'   4.500235329E+01   1e1
     datum( 2) =  'alpha.a'    '' '' 'ENDL3B'   'target'  -1.062939587E+00   1e1
@@ -175,22 +307,39 @@ beam_init%center(6) = 0.0
 
 
 
-!----------------------------------------
-! Orbit 
-
+!-----------------------------------------
+! BPM Orbit
+! Auto-generated BPM datums using: $LCLS_LATTICE/bmad/conversion/tao/create_vars_and_datums.ipynb
+        
 &tao_d2_data
-    d2_data%name = "orbit"
+    d2_data%name = 'orbit'
     universe = 1
-    n_d1_data = 5
-/
-
+    n_d1_data = 3
+/    
+    
 &tao_d1_data
     ix_d1_data = 1
     default_weight = 1
     d1_data%name = 'x'
     default_data_type = 'bpm_orbit.x'
     default_data_source = 'lat'
-    search_for_lat_eles = "MONITOR::BPM*,MONITOR::RFB*"
+    !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
+    datum(1:)%ele_name =  'BPM1B', 'BPM2B', 'BPM0H01', 'BPM0H04', 'BPM0H05', 'BPM0H08',
+     'BPMH1', 'BPMH2', 'BPMHD01', 'BPMHD02', 'BPMHD03', 'BPMHD04',
+     'BPMDG000', 'BPMC001', 'BPMC002', 'BPMC003', 'BPMC004', 'BPMC005',
+     'BPMC006', 'BPMC007', 'BPMC008', 'BPMC009', 'BPMC010', 'BPMC011',
+     'BPMC012', 'BPM1C01', 'BPM11B', 'BPMC101', 'BPMC102', 'BPMC103',
+     'BPMC104', 'BPMC105', 'BPMC106', 'BPMC107', 'BPMC108', 'BPMC109',
+     'BPMC110', 'BPMC111', 'BPMC112', 'BPM2C01', 'BPM21B', 'BPME201',
+     'BPME202', 'BPME203', 'BPME204', 'BPMX01', 'BPMX02', 'BPMDOG1', 'BPMDOG2',
+     'BPMDOG3', 'BPMDOG4', 'BPMDOG5', 'BPMDOG6', 'BPMDOG7', 'BPMDOG8',
+     'BPML1P', 'BPML2P', 'BPML3P', 'BPML4P', 'BPML5P', 'BPMBP10', 'BPMBP11',
+     'BPMBP12', 'BPMBP13', 'BPMBP14', 'BPMBP15', 'BPMBP16', 'BPMBP17',
+     'BPMBP18', 'BPMBP19', 'BPMBP20', 'BPMBP21', 'BPMBP22', 'BPMBP23',
+     'BPMBP24', 'BPMBP25', 'BPMBP26', 'BPMBP27', 'BPMBP35', 'BPMBP28',
+     'BPMSPH', 'BPMSP1', 'BPMSP2', 'BPMSPS', 'BPMSP1D', 'BPMDAS', 'BPMSP2D',
+     'BPMSP3D', 'BPMSP4D', 'BPMSP5D'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -199,39 +348,26 @@ beam_init%center(6) = 0.0
     d1_data%name = 'y'
     default_data_type = 'bpm_orbit.y'
     default_data_source = 'lat'
-    search_for_lat_eles = "MONITOR::BPM*,MONITOR::RFB*"
+    !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
+    use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
     ix_d1_data = 3
     default_weight = 1
-    d1_data%name = 'profx'
-    default_data_type = 'orbit.x'
-    default_data_source = 'lat'
-    search_for_lat_eles = "MONITOR::YAG*,MONITOR::OTR*"
-/
-
-&tao_d1_data
-    ix_d1_data = 4
-    default_weight = 1
-    d1_data%name = 'profy'
-    default_data_type = 'orbit.y'
-    default_data_source = 'lat'
-    search_for_lat_eles = "MONITOR::YAG*,MONITOR::OTR*"
-/
-
-&tao_d1_data
-    ix_d1_data = 5
-    default_weight = 1
-    d1_data%name = 'e'
-    default_data_type = 'orbit.e_tot'
-    default_data_source = 'lat'
-    search_for_lat_eles = "MONITOR::BPM*,MONITOR::RFB*"
+    d1_data%name = 'charge'
+    default_data_type = 'bunch_charge.live'
+    default_data_source = 'beam'
+    !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
+    use_same_lat_eles_as = 'orbit.x'
 /
 
 
 
-!-----------------------------------------------------------------------------------------
+
+
+!-----------------------------------------
 !-----------------------------------------------------------------------------------------
 
 &tao_var
@@ -248,11 +384,26 @@ beam_init%center(6) = 0.0
 
 
 
-!&tao_var
-    v1_var%name = 'L0'
+&tao_var
+    v1_var%name = 'gradient.L0'
 	default_step = 1e-4
-	default_attribute = 'x'
-	var(1:)%ele_name = 'O_L0'
+	default_attribute = 'gradient'
+	search_for_lat_eles = 'lcavity::cavl01*'
+	!var(1:)%ele_name = 'O_L0'
+/
+&tao_var
+    v1_var%name = 'phi0.L0'
+	default_step = 1e-4
+	default_attribute = 'phi0'
+	search_for_lat_eles = 'lcavity::cavl01*'
+	!var(1:)%ele_name = 'O_L0'
+/
+
+&tao_var
+    v1_var%name = 'q.HTR'
+	default_step = 1e-4
+	default_attribute = 'K1'
+	search_for_lat_eles = 'quad::Q0H*'
 /
 
 &tao_var
@@ -274,8 +425,94 @@ beam_init%center(6) = 0.0
     v1_var%name = 'q.L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
-	var(1:)%ele_name = 'QCM16', 'QCM22', 'QCM29', 'QCM35'
+	var(1:)%ele_name = 'QCM17', 'QCM22', 'QCM29', 'QCM35'
 /
+
+
+
+&tao_var
+    v1_var%name = 'linac_phase'
+	default_step = 0.1
+	default_attribute = 'phase_deg'
+	var(1:)%ele_name = 'SC_L1', 'SC_L1H', 'SC_L2', 'SC_L3'
+/
+
+&tao_var
+    v1_var%name = 'q.COL1'
+	default_step = 1e-4
+	default_attribute = 'K1'
+	var(1:)%ele_name = 'QC101', 'QC102', 'QC103', 'QC104'
+/
+
+&tao_var
+    v1_var%name = 'q.EMIT2'
+	default_step = 1e-4
+	default_attribute = 'K1'
+	var(1:)%ele_name = 'QE201', 'QE202', 'QE203', 'QE204'
+/
+
+
+&tao_var
+    v1_var%name = 'bc1'
+    default_step = 0.01
+    default_attribute = 'angle_deg'
+    var(1:)%low_lim = -8.35
+    var(1:)%high_lim = 0
+    var(1:)%ele_name = 'SC_BC1'
+/
+
+&tao_var
+    v1_var%name = 'bc2'
+    default_step = 0.01
+    default_attribute = 'angle_deg'
+    var(1:)%low_lim =  0 
+    var(1:)%high_lim =  9.1
+    var(1:)%ele_name = 'SC_BC2'
+/
+
+
+!----------------------------------------
+! Correctors
+! Auto-generated corrector datums using: $LCLS_LATTICE/bmad/conversion/tao/create_vars_and_datums.ipynb
+        
+&tao_var
+    v1_var%name = 'xcor'
+    default_step = 1e-2
+    default_attribute = 'bl_kick'
+    var(1:)%ele_name =  'XC01B', 'XC02B', 'XC03B', 'XC04B', 'XC05B', 'XCM01', 'XC0H01',
+     'XC0H03', 'XC0H05', 'XC0H07', 'XCHD01', 'XCHD03', 'XCC000', 'XCC004',
+     'XCC006', 'XCC008', 'XCC010', 'XCC012', 'XCM02', 'XCM03', 'XC1C00', 'XCM12B',
+     'XCC101', 'XCC104', 'XCC106', 'XCC108', 'XCC110', 'XCC112', 'XCM04', 'XCM05',
+     'XCM06', 'XCM07', 'XCM08', 'XCM09', 'XCM10', 'XCM11', 'XCM12', 'XCM13', 'XCM14',
+     'XCM15', 'XC2C00', 'XCE202', 'XCE204', 'XCM16', 'XCM17', 'XCM18', 'XCM19',
+     'XCM20', 'XCM21', 'XCM22', 'XCM23', 'XCM24', 'XCM25', 'XCM26', 'XCM27', 'XCM28',
+     'XCM29', 'XCM30', 'XCM31', 'XCM32', 'XCM33', 'XCM34', 'XCM35', 'XCX01',
+     'XCDOG1', 'XCDOG3', 'XCDOG5', 'XCDOG7', 'XCL1P', 'XCL3P', 'XCL5P', 'XCBP11',
+     'XCBP13', 'XCBP14', 'XCBP15', 'XCBP16', 'XCBP17', 'XCBP18', 'XCBP19',
+     'XCBP20', 'XCBP21', 'XCBP22', 'XCBP23', 'XCBP24', 'XCBP25', 'XCBP26',
+     'XCBP27', 'XCBP35', 'XCBP28', 'XCSP1', 'XCSP1D', 'XCSP3D', 'BKXRASD'
+/
+
+
+&tao_var
+    v1_var%name = 'ycor'
+    default_step = 1e-2
+    default_attribute = 'bl_kick'
+    var(1:)%ele_name =  'YC01B', 'YC02B', 'YC03B', 'YC04B', 'YC05B', 'YCM01', 'YC0H01',
+     'YC0H03', 'YC0H05', 'YC0H07', 'YCHD01', 'YCHD03', 'YCC000', 'YCC003',
+     'YCC005', 'YCC007', 'YCC009', 'YCC011', 'YCM02', 'YCM03', 'YC1C00', 'YCM12B',
+     'YCC101', 'YCC105', 'YCC107', 'YCC109', 'YCC111', 'YCM04', 'YCM05', 'YCM06',
+     'YCM07', 'YCM08', 'YCM09', 'YCM10', 'YCM11', 'YCM12', 'YCM13', 'YCM14', 'YCM15',
+     'YC2C00', 'YCE201', 'YCE203', 'YCM16', 'YCM17', 'YCM18', 'YCM19', 'YCM20',
+     'YCM21', 'YCM22', 'YCM23', 'YCM24', 'YCM25', 'YCM26', 'YCM27', 'YCM28', 'YCM29',
+     'YCM30', 'YCM31', 'YCM32', 'YCM33', 'YCM34', 'YCM35', 'YCX02', 'YCDOG0',
+     'YCDOG2', 'YCDOG4', 'YCDOG6', 'YCDOG8', 'YCL2P', 'YCL4P', 'YCBP10', 'YCBP12',
+     'YCBP13', 'YCBP14', 'YCBP15', 'YCBP16', 'YCBP17', 'YCBP18', 'YCBP19',
+     'YCBP20', 'YCBP21', 'YCBP22', 'YCBP23', 'YCBP24', 'YCBP25', 'YCBP26',
+     'YCBP27', 'YCBP35', 'YCBP28', 'YCSP2', 'YCSP2D', 'YCSP4D', 'BKYRASD'
+/
+
+!----------------------------------------
 
 
 

--- a/bmad/models/sc_dasel/tao.init
+++ b/bmad/models/sc_dasel/tao.init
@@ -157,22 +157,40 @@
 
 
 
-!----------------------------------------
-! Orbit 
 
+!-----------------------------------------
+! BPM Orbit
+! Auto-generated BPM datums using: $LCLS_LATTICE/bmad/conversion/tao/create_vars_and_datums.ipynb
+        
 &tao_d2_data
-    d2_data%name = "orbit"
+    d2_data%name = 'orbit'
     universe = 1
-    n_d1_data = 5
-/
-
+    n_d1_data = 3
+/    
+    
 &tao_d1_data
     ix_d1_data = 1
     default_weight = 1
     d1_data%name = 'x'
     default_data_type = 'bpm_orbit.x'
     default_data_source = 'lat'
-    search_for_lat_eles = "Instrument::BPM*,Instrument::RFB*"
+    !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
+    datum(1:)%ele_name =  'BPM1B', 'BPM2B', 'BPM0H01', 'BPM0H04', 'BPM0H05', 'BPM0H08',
+     'BPMH1', 'BPMH2', 'BPMHD01', 'BPMHD02', 'BPMHD03', 'BPMHD04',
+     'BPMDG000', 'BPMC001', 'BPMC002', 'BPMC003', 'BPMC004', 'BPMC005',
+     'BPMC006', 'BPMC007', 'BPMC008', 'BPMC009', 'BPMC010', 'BPMC011',
+     'BPMC012', 'BPM1C01', 'BPM11B', 'BPMC101', 'BPMC102', 'BPMC103',
+     'BPMC104', 'BPMC105', 'BPMC106', 'BPMC107', 'BPMC108', 'BPMC109',
+     'BPMC110', 'BPMC111', 'BPMC112', 'BPM2C01', 'BPM21B', 'BPME201',
+     'BPME202', 'BPME203', 'BPME204', 'BPMX01', 'BPMX02', 'BPMDOG1', 'BPMDOG2',
+     'BPMDOG3', 'BPMDOG4', 'BPMDOG5', 'BPMDOG6', 'BPMDOG7', 'BPMDOG8',
+     'BPML1P', 'BPML2P', 'BPML3P', 'BPML4P', 'BPML5P', 'BPMBP10', 'BPMBP11',
+     'BPMBP12', 'BPMBP13', 'BPMBP14', 'BPMBP15', 'BPMBP16', 'BPMBP17',
+     'BPMBP18', 'BPMBP19', 'BPMBP20', 'BPMBP21', 'BPMBP22', 'BPMBP23',
+     'BPMBP24', 'BPMBP25', 'BPMBP26', 'BPMBP27', 'BPMBP35', 'BPMBP28',
+     'BPMSPH', 'BPMSP1', 'BPMSP2', 'BPMSPS', 'BPMSP1D', 'BPMDAS', 'BPMDAS1',
+     'BPMDAS19', 'BPM10A', 'BPM12A', 'BPM17', 'BPM24', 'BPM28', 'BPM31', 'BPM32'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
@@ -181,36 +199,26 @@
     d1_data%name = 'y'
     default_data_type = 'bpm_orbit.y'
     default_data_source = 'lat'
-    search_for_lat_eles = "Instrument::BPM*,Instrument::RFB*"
+    !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
+    use_same_lat_eles_as = 'orbit.x'
+    datum(1:)%meas = 0
 /
 
 &tao_d1_data
     ix_d1_data = 3
     default_weight = 1
-    d1_data%name = 'profx'
-    default_data_type = 'orbit.x'
-    default_data_source = 'lat'
-    search_for_lat_eles = "Instrument::YAG*,Instrument::OTR*"
+    d1_data%name = 'charge'
+    default_data_type = 'bunch_charge.live'
+    default_data_source = 'beam'
+    !search_for_lat_eles = "monitor::bpm*,monitor::rfb*" 
+    use_same_lat_eles_as = 'orbit.x'
 /
 
-&tao_d1_data
-    ix_d1_data = 4
-    default_weight = 1
-    d1_data%name = 'profy'
-    default_data_type = 'orbit.y'
-    default_data_source = 'lat'
-    search_for_lat_eles = "Instrument::YAG*,Instrument::OTR*"
-/
 
-&tao_d1_data
-    ix_d1_data = 5
-    default_weight = 1
-    d1_data%name = 'e'
-    default_data_type = 'orbit.e_tot'
-    default_data_source = 'lat'
-    search_for_lat_eles = "Instrument::BPM*,Instrument::RFB*"
-/
 
+
+
+!-----------------------------------------
 
 
 !-----------------------------------------------------------------------------------------
@@ -258,6 +266,51 @@
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM16', 'QCM22', 'QCM29', 'QCM35'
 /
+
+!----------------------------------------
+! Correctors
+! Auto-generated corrector datums using: $LCLS_LATTICE/bmad/conversion/tao/create_vars_and_datums.ipynb
+        
+&tao_var
+    v1_var%name = 'xcor'
+    default_step = 1e-2
+    default_attribute = 'bl_kick'
+    var(1:)%ele_name =  'XC01B', 'XC02B', 'XC03B', 'XC04B', 'XC05B', 'XCM01', 'XC0H01',
+     'XC0H03', 'XC0H05', 'XC0H07', 'XCHD01', 'XCHD03', 'XCC000', 'XCC004',
+     'XCC006', 'XCC008', 'XCC010', 'XCC012', 'XCM02', 'XCM03', 'XC1C00', 'XCM12B',
+     'XCC101', 'XCC104', 'XCC106', 'XCC108', 'XCC110', 'XCC112', 'XCM04', 'XCM05',
+     'XCM06', 'XCM07', 'XCM08', 'XCM09', 'XCM10', 'XCM11', 'XCM12', 'XCM13', 'XCM14',
+     'XCM15', 'XC2C00', 'XCE202', 'XCE204', 'XCM16', 'XCM17', 'XCM18', 'XCM19',
+     'XCM20', 'XCM21', 'XCM22', 'XCM23', 'XCM24', 'XCM25', 'XCM26', 'XCM27', 'XCM28',
+     'XCM29', 'XCM30', 'XCM31', 'XCM32', 'XCM33', 'XCM34', 'XCM35', 'XCX01',
+     'XCDOG1', 'XCDOG3', 'XCDOG5', 'XCDOG7', 'XCL1P', 'XCL3P', 'XCL5P', 'XCBP11',
+     'XCBP13', 'XCBP14', 'XCBP15', 'XCBP16', 'XCBP17', 'XCBP18', 'XCBP19',
+     'XCBP20', 'XCBP21', 'XCBP22', 'XCBP23', 'XCBP24', 'XCBP25', 'XCBP26',
+     'XCBP27', 'XCBP35', 'XCBP28', 'XCSP1', 'XCDAS1', 'RCDAS11', 'XCDAS14',
+     'RCDAS19', 'A28X', 'A32X'
+/
+
+
+&tao_var
+    v1_var%name = 'ycor'
+    default_step = 1e-2
+    default_attribute = 'bl_kick'
+    var(1:)%ele_name =  'YC01B', 'YC02B', 'YC03B', 'YC04B', 'YC05B', 'YCM01', 'YC0H01',
+     'YC0H03', 'YC0H05', 'YC0H07', 'YCHD01', 'YCHD03', 'YCC000', 'YCC003',
+     'YCC005', 'YCC007', 'YCC009', 'YCC011', 'YCM02', 'YCM03', 'YC1C00', 'YCM12B',
+     'YCC101', 'YCC105', 'YCC107', 'YCC109', 'YCC111', 'YCM04', 'YCM05', 'YCM06',
+     'YCM07', 'YCM08', 'YCM09', 'YCM10', 'YCM11', 'YCM12', 'YCM13', 'YCM14', 'YCM15',
+     'YC2C00', 'YCE201', 'YCE203', 'YCM16', 'YCM17', 'YCM18', 'YCM19', 'YCM20',
+     'YCM21', 'YCM22', 'YCM23', 'YCM24', 'YCM25', 'YCM26', 'YCM27', 'YCM28', 'YCM29',
+     'YCM30', 'YCM31', 'YCM32', 'YCM33', 'YCM34', 'YCM35', 'YCX02', 'YCDOG0',
+     'YCDOG2', 'YCDOG4', 'YCDOG6', 'YCDOG8', 'YCL2P', 'YCL4P', 'YCBP10', 'YCBP12',
+     'YCBP13', 'YCBP14', 'YCBP15', 'YCBP16', 'YCBP17', 'YCBP18', 'YCBP19',
+     'YCBP20', 'YCBP21', 'YCBP22', 'YCBP23', 'YCBP24', 'YCBP25', 'YCBP26',
+     'YCBP27', 'YCBP35', 'YCBP28', 'YCSP2', 'YCDAS1', 'YCDAS17', 'A10Y', 'A18Y',
+     'A29Y', 'A33Y'
+/
+
+!----------------------------------------
 
 
 


### PR DESCRIPTION
This adds the same automated treatment to add BPM datums and corrector variables as other models to `sc_bsyd` and `sc_dasel`.