### PR TITLE
replacing . in v1_var names with \

### DIFF
--- a/bmad/models/cu_hxr/scripts/match_BC1BEG.tao
+++ b/bmad/models/cu_hxr/scripts/match_BC1BEG.tao
@@ -3,5 +3,5 @@ vd
 x-s all 10 40
 sc
 use dat BC1.begtwiss[1:4]
-use var q.BC1
+use var q_BC1
 olmdif

--- a/bmad/models/cu_hxr/scripts/match_LI22BEG.tao
+++ b/bmad/models/cu_hxr/scripts/match_LI22BEG.tao
@@ -3,5 +3,5 @@ vd
 x-s all 80 100
 sc
 use dat LI22.begtwiss[1:4]
-use var q.LI22
+use var q_LI22
 olmdif

--- a/bmad/models/cu_hxr/scripts/match_OTR2.tao
+++ b/bmad/models/cu_hxr/scripts/match_OTR2.tao
@@ -3,9 +3,9 @@ vd
 x-s all 5 15
 sc
 use dat OTR2.begtwiss[1:4]
-use var q.OTR2.match
+use var q_OTR2_match
 
-set var q.OTR2.match|key_bound = T
-set var q.OTR2.match|key_delta = 1e-3
+set var q_OTR2_match|key_bound = T
+set var q_OTR2_match|key_delta = 1e-3
 
 olmdif

--- a/bmad/models/cu_hxr/tao.init
+++ b/bmad/models/cu_hxr/tao.init
@@ -391,35 +391,35 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\OTR2\match'
+    v1_var%name = 'q_OTR2_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q\LI21\match'
+    v1_var%name = 'q_LI21_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21201','QM11', 'QM12', 'QM13'
 /
 
 &tao_var
-    v1_var%name = 'q\LI26\match'
+    v1_var%name = 'q_LI26_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q26201','Q26301', 'Q26401', 'Q26501', 'Q26601', 'Q26701', 'Q26801', 'Q26901'
 /
 
 &tao_var
-    v1_var%name = 'q\LTU\match'
+    v1_var%name = 'q_LTU_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QEM1','QEM2','QEM3','QEM4'
 /
 
 &tao_var
-    v1_var%name = 'q\LI22'
+    v1_var%name = 'q_LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
@@ -427,7 +427,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q\BC1'
+    v1_var%name = 'q_BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'
@@ -458,7 +458,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'qm\LTUH'
+    v1_var%name = 'qm_LTUH'
         default_step = 1e-4
         default_attribute = 'K1'
         var(1:)%ele_name =  'Q50Q3','Q4','Q5', 'Q6', 'QA0', 'QEM1', 'QEM2', 'QEM3', 'QEM4'

--- a/bmad/models/cu_hxr/tao.init
+++ b/bmad/models/cu_hxr/tao.init
@@ -391,35 +391,35 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.OTR2.match'
+    v1_var%name = 'q\OTR2\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q.LI21.match'
+    v1_var%name = 'q\LI21\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21201','QM11', 'QM12', 'QM13'
 /
 
 &tao_var
-    v1_var%name = 'q.LI26.match'
+    v1_var%name = 'q\LI26\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q26201','Q26301', 'Q26401', 'Q26501', 'Q26601', 'Q26701', 'Q26801', 'Q26901'
 /
 
 &tao_var
-    v1_var%name = 'q.LTU.match'
+    v1_var%name = 'q\LTU\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QEM1','QEM2','QEM3','QEM4'
 /
 
 &tao_var
-    v1_var%name = 'q.LI22'
+    v1_var%name = 'q\LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
@@ -427,7 +427,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q.BC1'
+    v1_var%name = 'q\BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'
@@ -458,7 +458,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'qm.LTUH'
+    v1_var%name = 'qm\LTUH'
         default_step = 1e-4
         default_attribute = 'K1'
         var(1:)%ele_name =  'Q50Q3','Q4','Q5', 'Q6', 'QA0', 'QEM1', 'QEM2', 'QEM3', 'QEM4'

--- a/bmad/models/cu_inj/tao.init
+++ b/bmad/models/cu_inj/tao.init
@@ -250,14 +250,14 @@ beam_init%position_file = '$LCLS_LATTICE/bmad/beams/YAG03_100k.h5'
 /
 
 &tao_var
-    v1_var%name = 'q\OTR2'
+    v1_var%name = 'q_OTR2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q\LI22'
+    v1_var%name = 'q_LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
@@ -265,7 +265,7 @@ beam_init%position_file = '$LCLS_LATTICE/bmad/beams/YAG03_100k.h5'
 
 
 &tao_var
-    v1_var%name = 'q\BC1'
+    v1_var%name = 'q_BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'

--- a/bmad/models/cu_inj/tao.init
+++ b/bmad/models/cu_inj/tao.init
@@ -250,14 +250,14 @@ beam_init%position_file = '$LCLS_LATTICE/bmad/beams/YAG03_100k.h5'
 /
 
 &tao_var
-    v1_var%name = 'q.OTR2'
+    v1_var%name = 'q\OTR2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q.LI22'
+    v1_var%name = 'q\LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
@@ -265,7 +265,7 @@ beam_init%position_file = '$LCLS_LATTICE/bmad/beams/YAG03_100k.h5'
 
 
 &tao_var
-    v1_var%name = 'q.BC1'
+    v1_var%name = 'q\BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'

--- a/bmad/models/cu_linac/tao.init
+++ b/bmad/models/cu_linac/tao.init
@@ -308,14 +308,14 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.OTR2'
+    v1_var%name = 'q\OTR2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q.LI22'
+    v1_var%name = 'q\LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
@@ -323,7 +323,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q.BC1'
+    v1_var%name = 'q\BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'

--- a/bmad/models/cu_linac/tao.init
+++ b/bmad/models/cu_linac/tao.init
@@ -308,14 +308,14 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\OTR2'
+    v1_var%name = 'q_OTR2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q\LI22'
+    v1_var%name = 'q_LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
@@ -323,7 +323,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q\BC1'
+    v1_var%name = 'q_BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'

--- a/bmad/models/cu_spec/tao.init
+++ b/bmad/models/cu_spec/tao.init
@@ -199,7 +199,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q.OTR2'
+    v1_var%name = 'q\OTR2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'

--- a/bmad/models/cu_spec/tao.init
+++ b/bmad/models/cu_spec/tao.init
@@ -199,7 +199,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q\OTR2'
+    v1_var%name = 'q_OTR2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'

--- a/bmad/models/cu_sxr/scripts/match_BC1BEG.tao
+++ b/bmad/models/cu_sxr/scripts/match_BC1BEG.tao
@@ -3,5 +3,5 @@ vd
 x-s all 10 40
 sc
 use dat BC1.begtwiss[1:4]
-use var q.BC1
+use var q_BC1
 olmdif

--- a/bmad/models/cu_sxr/scripts/match_LI22BEG.tao
+++ b/bmad/models/cu_sxr/scripts/match_LI22BEG.tao
@@ -3,5 +3,5 @@ vd
 x-s all 80 100
 sc
 use dat LI22.begtwiss[1:4]
-use var q.LI22
+use var q_LI22
 olmdif

--- a/bmad/models/cu_sxr/scripts/match_OTR2.tao
+++ b/bmad/models/cu_sxr/scripts/match_OTR2.tao
@@ -3,5 +3,5 @@ vd
 x-s all 10 20
 sc
 use dat OTR2.begtwiss[1:4]
-use var q.OTR2
+use var q_OTR2
 olmdif

--- a/bmad/models/cu_sxr/tao.init
+++ b/bmad/models/cu_sxr/tao.init
@@ -394,42 +394,42 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.OTR2.match'
+    v1_var%name = 'q\OTR2\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q.LI21.match'
+    v1_var%name = 'q\LI21\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21201','QM11', 'QM12', 'QM13'
 /
 
 &tao_var
-    v1_var%name = 'q.LI26.match'
+    v1_var%name = 'q\LI26\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q26201','Q26301', 'Q26401', 'Q26501', 'Q26601', 'Q26701', 'Q26801', 'Q26901'
 /
 
 &tao_var
-    v1_var%name = 'q.LTU.match'
+    v1_var%name = 'q\LTU\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QEM1B','QEM2B','QEM3B','QEM4B'
 /
 
 &tao_var
-    v1_var%name = 'q.LI22'
+    v1_var%name = 'q\LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
 /
 
 &tao_var
-    v1_var%name = 'q.BC1'
+    v1_var%name = 'q\BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'
@@ -451,7 +451,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.LTUS'
+    v1_var%name = 'q\LTUS'
         default_step = 1e-4
         default_attribute = 'K1'
         var(1:)%ele_name = 'QBP33', 'QBP34', 'QDBL1', 'QDBL2', 'QDL11'

--- a/bmad/models/cu_sxr/tao.init
+++ b/bmad/models/cu_sxr/tao.init
@@ -394,42 +394,42 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\OTR2\match'
+    v1_var%name = 'q_OTR2_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QA01','QA02', 'QE01', 'QE02', 'QE03', 'QE04'
 /
 
 &tao_var
-    v1_var%name = 'q\LI21\match'
+    v1_var%name = 'q_LI21_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21201','QM11', 'QM12', 'QM13'
 /
 
 &tao_var
-    v1_var%name = 'q\LI26\match'
+    v1_var%name = 'q_LI26_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q26201','Q26301', 'Q26401', 'Q26501', 'Q26601', 'Q26701', 'Q26801', 'Q26901'
 /
 
 &tao_var
-    v1_var%name = 'q\LTU\match'
+    v1_var%name = 'q_LTU_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QEM1B','QEM2B','QEM3B','QEM4B'
 /
 
 &tao_var
-    v1_var%name = 'q\LI22'
+    v1_var%name = 'q_LI22'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'Q21601','Q21701', 'Q21801', 'Q21901'
 /
 
 &tao_var
-    v1_var%name = 'q\BC1'
+    v1_var%name = 'q_BC1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name =  'QA11', 'QA12', 'Q21201', 'QM11'
@@ -451,7 +451,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\LTUS'
+    v1_var%name = 'q_LTUS'
         default_step = 1e-4
         default_attribute = 'K1'
         var(1:)%ele_name = 'QBP33', 'QBP34', 'QDBL1', 'QDBL2', 'QDL11'

--- a/bmad/models/sc_bsyd/tao.init
+++ b/bmad/models/sc_bsyd/tao.init
@@ -459,14 +459,14 @@ beam_init%sig_z = 0.8e-3
 
 
 &tao_var
-    v1_var%name = 'gradient.L0'
+    v1_var%name = 'gradient\L0'
 	default_step = 1e-4
 	default_attribute = 'gradient'
 	search_for_lat_eles = 'lcavity::cavl01*'
 	!var(1:)%ele_name = 'O_L0'
 /
 &tao_var
-    v1_var%name = 'phi0.L0'
+    v1_var%name = 'phi0\L0'
 	default_step = 1e-4
 	default_attribute = 'phi0'
 	search_for_lat_eles = 'lcavity::cavl01*'
@@ -474,14 +474,14 @@ beam_init%sig_z = 0.8e-3
 /
 
 &tao_var
-    v1_var%name = 'q.HTR'
+    v1_var%name = 'q\HTR'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	search_for_lat_eles = 'quad::Q0H*'
 /
 
 &tao_var
-    v1_var%name = 'q.L1'
+    v1_var%name = 'q\L1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC010', 'QC011','QC012', 'QCM02', 'QCM03'
@@ -489,14 +489,14 @@ beam_init%sig_z = 0.8e-3
 
 
 &tao_var
-    v1_var%name = 'q.L2'
+    v1_var%name = 'q\L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q.L3'
+    v1_var%name = 'q\L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM17', 'QCM22', 'QCM29', 'QCM35'
@@ -512,14 +512,14 @@ beam_init%sig_z = 0.8e-3
 /
 
 &tao_var
-    v1_var%name = 'q.COL1'
+    v1_var%name = 'q\COL1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC101', 'QC102', 'QC103', 'QC104'
 /
 
 &tao_var
-    v1_var%name = 'q.EMIT2'
+    v1_var%name = 'q\EMIT2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QE201', 'QE202', 'QE203', 'QE204'

--- a/bmad/models/sc_bsyd/tao.init
+++ b/bmad/models/sc_bsyd/tao.init
@@ -459,14 +459,14 @@ beam_init%sig_z = 0.8e-3
 
 
 &tao_var
-    v1_var%name = 'gradient\L0'
+    v1_var%name = 'gradient_L0'
 	default_step = 1e-4
 	default_attribute = 'gradient'
 	search_for_lat_eles = 'lcavity::cavl01*'
 	!var(1:)%ele_name = 'O_L0'
 /
 &tao_var
-    v1_var%name = 'phi0\L0'
+    v1_var%name = 'phi0_L0'
 	default_step = 1e-4
 	default_attribute = 'phi0'
 	search_for_lat_eles = 'lcavity::cavl01*'
@@ -474,14 +474,14 @@ beam_init%sig_z = 0.8e-3
 /
 
 &tao_var
-    v1_var%name = 'q\HTR'
+    v1_var%name = 'q_HTR'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	search_for_lat_eles = 'quad::Q0H*'
 /
 
 &tao_var
-    v1_var%name = 'q\L1'
+    v1_var%name = 'q_L1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC010', 'QC011','QC012', 'QCM02', 'QCM03'
@@ -489,14 +489,14 @@ beam_init%sig_z = 0.8e-3
 
 
 &tao_var
-    v1_var%name = 'q\L2'
+    v1_var%name = 'q_L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q\L3'
+    v1_var%name = 'q_L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM17', 'QCM22', 'QCM29', 'QCM35'
@@ -512,14 +512,14 @@ beam_init%sig_z = 0.8e-3
 /
 
 &tao_var
-    v1_var%name = 'q\COL1'
+    v1_var%name = 'q_COL1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC101', 'QC102', 'QC103', 'QC104'
 /
 
 &tao_var
-    v1_var%name = 'q\EMIT2'
+    v1_var%name = 'q_EMIT2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QE201', 'QE202', 'QE203', 'QE204'

--- a/bmad/models/sc_dasel/tao.init
+++ b/bmad/models/sc_dasel/tao.init
@@ -250,7 +250,7 @@
 /
 
 &tao_var
-    v1_var%name = 'q.L1'
+    v1_var%name = 'q\L1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC010', 'QC011','QC012', 'QCM02', 'QCM03'
@@ -258,14 +258,14 @@
 
 
 &tao_var
-    v1_var%name = 'q.L2'
+    v1_var%name = 'q\L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q.L3'
+    v1_var%name = 'q\L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM16', 'QCM22', 'QCM29', 'QCM35'

--- a/bmad/models/sc_dasel/tao.init
+++ b/bmad/models/sc_dasel/tao.init
@@ -250,7 +250,7 @@
 /
 
 &tao_var
-    v1_var%name = 'q\L1'
+    v1_var%name = 'q_L1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC010', 'QC011','QC012', 'QCM02', 'QCM03'
@@ -258,14 +258,14 @@
 
 
 &tao_var
-    v1_var%name = 'q\L2'
+    v1_var%name = 'q_L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q\L3'
+    v1_var%name = 'q_L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM16', 'QCM22', 'QCM29', 'QCM35'

--- a/bmad/models/sc_diag0/tao.init
+++ b/bmad/models/sc_diag0/tao.init
@@ -255,7 +255,7 @@ beam_init%sig_z = 0.8e-3
 
 
 &tao_var
-    v1_var%name = 'q\HTR\match'
+    v1_var%name = 'q_HTR_match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM01', 'Q0H01', 'Q0H02', 'Q0H03', 'Q0H04'

--- a/bmad/models/sc_diag0/tao.init
+++ b/bmad/models/sc_diag0/tao.init
@@ -255,7 +255,7 @@ beam_init%sig_z = 0.8e-3
 
 
 &tao_var
-    v1_var%name = 'q.HTR.match'
+    v1_var%name = 'q\HTR\match'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM01', 'Q0H01', 'Q0H02', 'Q0H03', 'Q0H04'

--- a/bmad/models/sc_hxr/scripts/match_COL1.tao
+++ b/bmad/models/sc_hxr/scripts/match_COL1.tao
@@ -1,7 +1,7 @@
 vv
 vd
 use dat COL1.endtwiss[1:4]
-use var q.match.COL1
+use var q_match_COL1
 osvd
 do i=1, 10
   run

--- a/bmad/models/sc_hxr/scripts/match_EMIT2.tao
+++ b/bmad/models/sc_hxr/scripts/match_EMIT2.tao
@@ -1,6 +1,6 @@
 vv
 vd
 use dat EMIT2.endtwiss[1:4]
-use var q.EMIT2
+use var q_EMIT2
 olmdif
 run

--- a/bmad/models/sc_hxr/scripts/match_HTR.tao
+++ b/bmad/models/sc_hxr/scripts/match_HTR.tao
@@ -1,6 +1,6 @@
 vv
 vd
 use dat HTR.midtwiss[1:4]
-use var q.HTR[1:6]
+use var q_HTR[1:6]
 olmdif
 run

--- a/bmad/models/sc_hxr/scripts/match_L1.tao
+++ b/bmad/models/sc_hxr/scripts/match_L1.tao
@@ -1,6 +1,6 @@
 vv
 vd
 use dat L1.endtwiss[1:4]
-use var q.L1
+use var q_L1
 olmdif
 run

--- a/bmad/models/sc_hxr/scripts/match_L2.tao
+++ b/bmad/models/sc_hxr/scripts/match_L2.tao
@@ -1,6 +1,6 @@
 vv
 vd
 use dat L2.endtwiss[1:4]
-use var q.L2
+use var q_L2
 olmdif
 run

--- a/bmad/models/sc_hxr/scripts/match_L3.tao
+++ b/bmad/models/sc_hxr/scripts/match_L3.tao
@@ -1,6 +1,6 @@
 vv
 vd
 use dat L3.endtwiss[1:4]
-use var q.L3
+use var q_L3
 olmdif
 run

--- a/bmad/models/sc_hxr/tao.init
+++ b/bmad/models/sc_hxr/tao.init
@@ -470,14 +470,14 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'gradient\L0'
+    v1_var%name = 'gradient_L0'
 	default_step = 1e-4
 	default_attribute = 'gradient'
 	search_for_lat_eles = 'lcavity::cavl01*'
 	!var(1:)%ele_name = 'O_L0'
 /
 &tao_var
-    v1_var%name = 'phi0\L0'
+    v1_var%name = 'phi0_L0'
     default_step = 1e-4
     default_attribute = 'phi0'
     search_for_lat_eles = 'lcavity::cavl01*'
@@ -485,7 +485,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\HTR'
+    v1_var%name = 'q_HTR'
     default_step = 1e-4
     default_attribute = 'K1'
    ! search_for_lat_eles = 'quad::Q0H*'
@@ -507,7 +507,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q\match\COL1'
+    v1_var%name = 'q_match_COL1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC001', 
@@ -522,14 +522,14 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q\L2'
+    v1_var%name = 'q_L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q\L3'
+    v1_var%name = 'q_L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM17', 'QCM22', 'QCM29', 'QCM35'
@@ -545,7 +545,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\COL0'
+    v1_var%name = 'q_COL0'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC001',
@@ -563,14 +563,14 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\COL1'
+    v1_var%name = 'q_COL1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC101', 'QC102', 'QC103', 'QC104'
 /
 
 &tao_var
-    v1_var%name = 'q\EMIT2'
+    v1_var%name = 'q_EMIT2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QE201', 'QE202', 'QE203', 'QE204'

--- a/bmad/models/sc_hxr/tao.init
+++ b/bmad/models/sc_hxr/tao.init
@@ -470,14 +470,14 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'gradient.L0'
+    v1_var%name = 'gradient\L0'
 	default_step = 1e-4
 	default_attribute = 'gradient'
 	search_for_lat_eles = 'lcavity::cavl01*'
 	!var(1:)%ele_name = 'O_L0'
 /
 &tao_var
-    v1_var%name = 'phi0.L0'
+    v1_var%name = 'phi0\L0'
     default_step = 1e-4
     default_attribute = 'phi0'
     search_for_lat_eles = 'lcavity::cavl01*'
@@ -485,7 +485,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.HTR'
+    v1_var%name = 'q\HTR'
     default_step = 1e-4
     default_attribute = 'K1'
    ! search_for_lat_eles = 'quad::Q0H*'
@@ -507,7 +507,7 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q.match.COL1'
+    v1_var%name = 'q\match\COL1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC001', 
@@ -522,14 +522,14 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q.L2'
+    v1_var%name = 'q\L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q.L3'
+    v1_var%name = 'q\L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM17', 'QCM22', 'QCM29', 'QCM35'
@@ -545,7 +545,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.COL0'
+    v1_var%name = 'q\COL0'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC001',
@@ -563,14 +563,14 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.COL1'
+    v1_var%name = 'q\COL1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC101', 'QC102', 'QC103', 'QC104'
 /
 
 &tao_var
-    v1_var%name = 'q.EMIT2'
+    v1_var%name = 'q\EMIT2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QE201', 'QE202', 'QE203', 'QE204'

--- a/bmad/models/sc_inj/scripts/match_HTR.tao
+++ b/bmad/models/sc_inj/scripts/match_HTR.tao
@@ -1,6 +1,6 @@
 vv
 vd
 use dat HTR.begtwiss[1:4]
-use var q.HTR[1:6]
+use var q_HTR[1:6]
 olmdif
 run

--- a/bmad/models/sc_inj/tao.init
+++ b/bmad/models/sc_inj/tao.init
@@ -168,7 +168,7 @@ beam_init%position_file = 'cathode_probe_particles.h5'
 
 
 &tao_var
-    v1_var%name = 'q.HTR'
+    v1_var%name = 'q\HTR'
     default_step = 1e-4
     default_attribute = 'K1'
     search_for_lat_eles = 'quad::Q0H*'

--- a/bmad/models/sc_inj/tao.init
+++ b/bmad/models/sc_inj/tao.init
@@ -168,7 +168,7 @@ beam_init%position_file = 'cathode_probe_particles.h5'
 
 
 &tao_var
-    v1_var%name = 'q\HTR'
+    v1_var%name = 'q_HTR'
     default_step = 1e-4
     default_attribute = 'K1'
     search_for_lat_eles = 'quad::Q0H*'

--- a/bmad/models/sc_sxr/tao.init
+++ b/bmad/models/sc_sxr/tao.init
@@ -275,7 +275,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q.L1'
+    v1_var%name = 'q\L1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC010', 'QC011','QC012', 'QCM02', 'QCM03'
@@ -283,14 +283,14 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q.L2'
+    v1_var%name = 'q\L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q.L3'
+    v1_var%name = 'q\L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM16', 'QCM22', 'QCM29', 'QCM35'

--- a/bmad/models/sc_sxr/tao.init
+++ b/bmad/models/sc_sxr/tao.init
@@ -275,7 +275,7 @@ beam_init%center(6) = 0.0
 /
 
 &tao_var
-    v1_var%name = 'q\L1'
+    v1_var%name = 'q_L1'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QC010', 'QC011','QC012', 'QCM02', 'QCM03'
@@ -283,14 +283,14 @@ beam_init%center(6) = 0.0
 
 
 &tao_var
-    v1_var%name = 'q\L2'
+    v1_var%name = 'q_L2'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM04', 'QCM08', 'QCM11', 'QCM15'
 /
 
 &tao_var
-    v1_var%name = 'q\L3'
+    v1_var%name = 'q_L3'
 	default_step = 1e-4
 	default_attribute = 'K1'
 	var(1:)%ele_name = 'QCM16', 'QCM22', 'QCM29', 'QCM35'


### PR DESCRIPTION
replace "." with "\" in tao.init v1_var names to satisfy stricter standard enforcement in tao.init parser.

e.g.   "q.OTR2.match" is now "q\OTR2\match"