### PR TITLE
Update from API_TOKEN_GITHUB to SSH_DEPLOY_KEY

### DIFF
--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Push lcls lattice
         uses: cpina/github-action-push-to-another-repository@v1.4.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
           source-directory: lattice-data
           target-directory: src
@@ -49,7 +49,7 @@ jobs:
       - name: Push test directory to lcls-lattice-data
         uses: cpina/github-action-push-to-another-repository@v1.4.1
         env:
-          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
         with:
           source-directory: python/tests
           target-directory: tests


### PR DESCRIPTION
Replace API_TOKEN_GITHUB (which expires every few months and so needs to be continuously renewed) with SSH_DEPLOY_KEY (which don't expire).