### PR TITLE
correct OTR0H04.midtwiss element from D0H00B to OTR0H04

### DIFF
--- a/bmad/models/sc_bsyd/tao.init
+++ b/bmad/models/sc_bsyd/tao.init
@@ -108,12 +108,12 @@ beam_init%sig_z = 0.8e-3
         ix_d1_data = 1
         default_weight = 1
         d1_data%name = 'midtwiss'
-        datum( 1) =  'beta.a'     '' '' 'D0H00B'   'target'   5.01187794  1e1
-        datum( 2) =  'alpha.a'    '' '' 'D0H00B'   'target'   0.04874000  1e2
-        datum( 3) =  'beta.b'     '' '' 'D0H00B'   'target'   4.96994136  1e1
-        datum( 4) =  'alpha.b'    '' '' 'D0H00B'   'target'   0.00576731  1e2
-        datum( 5) =  'eta.x'      '' '' 'D0H00B'   'target'   0  1e1
-        datum( 6) =  'etap.x'     '' '' 'D0H00B'   'target'   0  1e2
+        datum( 1) =  'beta.a'     '' '' 'OTR0H04'   'target'   5.01187794  1e1
+        datum( 2) =  'alpha.a'    '' '' 'OTR0H04'   'target'   0.04874000  1e2
+        datum( 3) =  'beta.b'     '' '' 'OTR0H04'   'target'   4.96994136  1e1
+        datum( 4) =  'alpha.b'    '' '' 'OTR0H04'   'target'   0.00576731  1e2
+        datum( 5) =  'eta.x'      '' '' 'OTR0H04'   'target'   0  1e1
+        datum( 6) =  'etap.x'     '' '' 'OTR0H04'   'target'   0  1e2
 /  
 
 !---------------------------------------------------------------------------------------

--- a/bmad/models/sc_diag0/tao.init
+++ b/bmad/models/sc_diag0/tao.init
@@ -111,12 +111,12 @@ beam_init%sig_z = 0.8e-3
         ix_d1_data = 1
         default_weight = 1
         d1_data%name = 'midtwiss'
-        datum( 1) =  'beta.a'     '' '' 'D0H00B'   'target'   5.01187794  1e1
-        datum( 2) =  'alpha.a'    '' '' 'D0H00B'   'target'   0.04874000  1e2
-        datum( 3) =  'beta.b'     '' '' 'D0H00B'   'target'   4.96994136  1e1
-        datum( 4) =  'alpha.b'    '' '' 'D0H00B'   'target'   0.00576731  1e2
-        datum( 5) =  'eta.x'      '' '' 'D0H00B'   'target'   0  1e1
-        datum( 6) =  'etap.x'     '' '' 'D0H00B'   'target'   0  1e2
+        datum( 1) =  'beta.a'     '' '' 'OTR0H04'   'target'   5.01187794  1e1
+        datum( 2) =  'alpha.a'    '' '' 'OTR0H04'   'target'   0.04874000  1e2
+        datum( 3) =  'beta.b'     '' '' 'OTR0H04'   'target'   4.96994136  1e1
+        datum( 4) =  'alpha.b'    '' '' 'OTR0H04'   'target'   0.00576731  1e2
+        datum( 5) =  'eta.x'      '' '' 'OTR0H04'   'target'   0  1e1
+        datum( 6) =  'etap.x'     '' '' 'OTR0H04'   'target'   0  1e2
 /  
 
 !---------------------------------------------------------------------------------------

--- a/bmad/models/sc_hxr/tao.init
+++ b/bmad/models/sc_hxr/tao.init
@@ -107,12 +107,12 @@ beam_init%center(6) = 0.0
         ix_d1_data = 1
         default_weight = 1
         d1_data%name = 'midtwiss'
-        datum( 1) =  'beta.a'     '' '' 'D0H00B'   'target'   5.01187794  1e1
-        datum( 2) =  'alpha.a'    '' '' 'D0H00B'   'target'   0.04874000  1e2
-        datum( 3) =  'beta.b'     '' '' 'D0H00B'   'target'   4.96994136  1e1
-        datum( 4) =  'alpha.b'    '' '' 'D0H00B'   'target'   0.00576731  1e2
-        datum( 5) =  'eta.x'      '' '' 'D0H00B'   'target'   0  1e1
-        datum( 6) =  'etap.x'     '' '' 'D0H00B'   'target'   0  1e2
+        datum( 1) =  'beta.a'     '' '' 'OTR0H04'   'target'   5.01187794  1e1
+        datum( 2) =  'alpha.a'    '' '' 'OTR0H04'   'target'   0.04874000  1e2
+        datum( 3) =  'beta.b'     '' '' 'OTR0H04'   'target'   4.96994136  1e1
+        datum( 4) =  'alpha.b'    '' '' 'OTR0H04'   'target'   0.00576731  1e2
+        datum( 5) =  'eta.x'      '' '' 'OTR0H04'   'target'   0  1e1
+        datum( 6) =  'etap.x'     '' '' 'OTR0H04'   'target'   0  1e2
 /  
 
 !---------------------------------------------------------------------------------------


### PR DESCRIPTION
William Colocho noticed that the element for the OTR0H04 data was D0H00B, which is nowhere near OTR0H04.  OTR0H04 is a zero length element, so its "midtwiss" can simply be taken at the element itself.