### PR TITLE
fix bug where if inline comment has "aperture" then names not expanded

### DIFF
--- a/bmad/conversion/python/slac2bmad/xsif.py
+++ b/bmad/conversion/python/slac2bmad/xsif.py
@@ -70,8 +70,8 @@ FULLNAMES = {
 def expand_names(line):
     for k, v in FULLNAMES.items():
         # Skip ones that are fine
-        if v in line.lower():
-            continue
+        # if v in line.lower():
+        #     continue
         line = re.sub(k,v,line)
     return line
 

--- a/bmad/conversion/python/slac2bmad/xsif.py
+++ b/bmad/conversion/python/slac2bmad/xsif.py
@@ -70,8 +70,6 @@ FULLNAMES = {
 def expand_names(line):
     for k, v in FULLNAMES.items():
         # Skip ones that are fine
-        # if v in line.lower():
-        #     continue
         line = re.sub(k,v,line)
     return line
 


### PR DESCRIPTION
There was a bug in xsif.py that prevented the APER names in the following two lines from being expanded.

`CQ03LEI : MULT, TYPE="solenoid trim", APER=0.076/2,  K1L=0     !aperture not defined`
`SQ03LEI : MULT, TYPE="solenoid trim", APER=0.076/2,  K1L=0, T1 !aperture not defined`