### PR TITLE
overlay to turn qcm01 on and off per MW quad settings

### DIFF
--- a/bmad/models/sc_bsyd/sc_bsyd.lat.bmad
+++ b/bmad/models/sc_bsyd/sc_bsyd.lat.bmad
@@ -9,6 +9,7 @@ call, file = $LCLS_LATTICE/bmad/overlays/sc/bc1_overlays.bmad
 call, file = $LCLS_LATTICE/bmad/overlays/sc/bc2_overlays.bmad
 
 call, file = $LCLS_LATTICE/bmad/overlays/sc/qcm01_overlays.bmad
+call, file = $LCLS_LATTICE/bmad/overlays/sc/htr_overlays.bmad
 
 ! Extra match settings
 call, file =  $LCLS_LATTICE/bmad/master/sc/sc_linac_settings.bmad

--- a/bmad/models/sc_bsyd/sc_bsyd.lat.bmad
+++ b/bmad/models/sc_bsyd/sc_bsyd.lat.bmad
@@ -8,6 +8,8 @@ call, file = $LCLS_LATTICE/bmad/overlays/sc/linac_overlays.bmad
 call, file = $LCLS_LATTICE/bmad/overlays/sc/bc1_overlays.bmad
 call, file = $LCLS_LATTICE/bmad/overlays/sc/bc2_overlays.bmad
 
+call, file = $LCLS_LATTICE/bmad/overlays/sc/qcm01_overlays.bmad
+
 ! Extra match settings
 call, file =  $LCLS_LATTICE/bmad/master/sc/sc_linac_settings.bmad
 

--- a/bmad/models/sc_bsyd/tao.init
+++ b/bmad/models/sc_bsyd/tao.init
@@ -1,6 +1,6 @@
 &tao_start
   n_universes = 1
-  plot_file   ='$LCLS_LATTICE/bmad/tao/tao_plot.init '
+  plot_file   ='tao_plot.init '
   startup_file='$LCLS_LATTICE/bmad/tao/tao.startup'
 /
 

--- a/bmad/overlays/sc/qcm01_overlays.bmad
+++ b/bmad/overlays/sc/qcm01_overlays.bmad
@@ -1,0 +1,15 @@
+O_qcm01_overlay_qcm01: overlay = {qcm01[k1]: { 0.0, 0.378216 }}, interpolation = linear,
+ var={is_on}, x_knot = { 0, 1}, is_on = 1
+O_qcm01_overlay_q0h01: overlay = {q0h01[k1]: { -6.525508, -6.391218}}, interpolation = linear,
+ var={is_on}, x_knot = { 0, 1}, is_on = 1
+O_qcm01_overlay_q0h02: overlay = {q0h02[k1]: { 6.335021, 5.905989}}, interpolation = linear,
+ var={is_on}, x_knot = { 0, 1}, is_on = 1
+O_qcm01_overlay_q0h03: overlay = {q0h03[k1]: { -0.947731, 2.403934}}, interpolation = linear,
+ var={is_on}, x_knot = { 0, 1}, is_on = 1
+O_qcm01_overlay_q0h04: overlay = {q0h04[k1]: { -3.418410, -6.042775}}, interpolation = linear,
+ var={is_on}, x_knot = { 0, 1}, is_on = 1
+O_qcm01_overlay: overlay = {O_qcm01_overlay_qcm01[is_on], 
+                            O_qcm01_overlay_q0h01[is_on],
+                            O_qcm01_overlay_q0h02[is_on],
+                            O_qcm01_overlay_q0h03[is_on],
+                            O_qcm01_overlay_q0h04[is_on]}, var={is_on}, is_on = 1

--- a/bmad/overlays/sc/qcm01_overlays.bmad
+++ b/bmad/overlays/sc/qcm01_overlays.bmad
@@ -13,3 +13,4 @@ O_qcm01_overlay: overlay = {O_qcm01_overlay_qcm01[is_on],
                             O_qcm01_overlay_q0h02[is_on],
                             O_qcm01_overlay_q0h03[is_on],
                             O_qcm01_overlay_q0h04[is_on]}, var={is_on}, is_on = 1
+


### PR DESCRIPTION
Added o_qcm01_overlay which uses knots to turn qcm01 on and off per Mark Woodley's quadrupole settings for qcm01 and q0h0[1-4].  

Use:
```
set o_qcm01_overlay is_on = 1
set o_qcm01_overlay is_on = 0
```