### PR TITLE
Update tag-lcls-lattice-data.yaml

### DIFF
--- a/.github/workflows/tag-lcls-lattice-data.yaml
+++ b/.github/workflows/tag-lcls-lattice-data.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           git config --global user.email ${{ secrets.LCLS_LATTICE_DATA_USER_EMAIL }}
           git config --global user.name slaclab
-          git clone --single-branch --branch main "https://slaclab:${{ secrets.API_TOKEN_GITHUB }}@github.com/slaclab/lcls-lattice-data.git" 
+          git clone --single-branch --branch main "https://slaclab:${{ secrets.SSH_DEPLOY_KEY }}@github.com/slaclab/lcls-lattice-data.git"
           cd lcls-lattice-data 
           git tag  -a ${{ github.ref_name }} -m "Syncing with lcls-lattice tag ${{ github.ref_name }}"
           git push origin ${{ github.ref_name }}


### PR DESCRIPTION
API_TOKEN_GITHUB is deprecated and github tokens expire, necessitating regular maintenance.  SSH_DEPLOY_KEY are the now favored technique and do not expire.