### PR TITLE
Mpe update device names for XCBP10

### DIFF
--- a/bmad/master/LCLSsc_devicenames.bmad
+++ b/bmad/master/LCLSsc_devicenames.bmad
@@ -160,7 +160,7 @@ BKYSP5S[alias]=KICK:SPS:410
 ! No device listed for: BLF4
 ! No device listed for: BLF5
 ! No device listed for: BLF6
-! No device listed for: BLFD
+! No device listed for: BLF7
 ! No device listed for: BLFU
 BLRDAS[alias]=BEND:DASEL:210
 BLRDG0[alias]=BEND:DIAG0:155
@@ -1033,6 +1033,7 @@ CYDL16[alias]=COLL:LTUS:345
 ! No device listed for: D0CB2
 ! No device listed for: D0H00A
 ! No device listed for: D0H00B
+! No device listed for: D0H00C
 ! No device listed for: D0H01A
 ! No device listed for: D0H01B
 ! No device listed for: D0H02A
@@ -1123,7 +1124,8 @@ CYDL16[alias]=COLL:LTUS:345
 ! No device listed for: D124F
 ! No device listed for: D124G
 ! No device listed for: D125
-! No device listed for: D1C00
+! No device listed for: D1C00A
+! No device listed for: D1C00B
 ! No device listed for: D1C01A
 ! No device listed for: D1C01B
 ! No device listed for: D1CB1A
@@ -1150,8 +1152,11 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: D2C00A
 ! No device listed for: D2C00B
 ! No device listed for: D2C00C
+! No device listed for: D2C00D
 ! No device listed for: D2C01A
 ! No device listed for: D2C01B
+! No device listed for: D2C02A
+! No device listed for: D2C02B
 ! No device listed for: D2CB
 ! No device listed for: D2Q4A
 ! No device listed for: D2Q4A0
@@ -1259,6 +1264,7 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: DBD7C
 ! No device listed for: DBD8A
 ! No device listed for: DBD8B
+! No device listed for: DBDM0
 ! No device listed for: DBDM1
 ! No device listed for: DBKRAPM1A
 ! No device listed for: DBKRAPM1B
@@ -1334,7 +1340,8 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: DBPC
 ! No device listed for: DBPC1
 ! No device listed for: DBPD
-! No device listed for: DBPD1
+! No device listed for: DBPD1A
+! No device listed for: DBPD1B
 ! No device listed for: DBPD2
 ! No device listed for: DBPE
 ! No device listed for: DBPF
@@ -1395,6 +1402,7 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: DC011A
 ! No device listed for: DC011B
 ! No device listed for: DC011C
+! No device listed for: DC012
 ! No device listed for: DC100A
 ! No device listed for: DC100B
 ! No device listed for: DC100C
@@ -1435,6 +1443,7 @@ D2[alias]=STPR:BSYH:847
 ! No device listed for: DC111A
 ! No device listed for: DC111B
 ! No device listed for: DC112A
+! No device listed for: DC112B
 ! No device listed for: DC1IA
 ! No device listed for: DC1IB
 ! No device listed for: DC1IC
@@ -1575,9 +1584,9 @@ DCHIRPV[alias]=DCHP:LTUH:545
 ! No device listed for: DDAS13
 ! No device listed for: DDAS14AA
 ! No device listed for: DDAS14AB
+! No device listed for: DDAS14AC
 ! No device listed for: DDAS14B
-! No device listed for: DDAS15A
-! No device listed for: DDAS15B
+! No device listed for: DDAS15
 ! No device listed for: DDAS16
 ! No device listed for: DDAS17A
 ! No device listed for: DDAS17B
@@ -1685,8 +1694,6 @@ DCHIRPV[alias]=DCHP:LTUH:545
 ! No device listed for: DDLWALLB
 ! No device listed for: DDUMP
 ! No device listed for: DDUMPBSY
-! No device listed for: DE200A
-! No device listed for: DE200B
 ! No device listed for: DE201A
 ! No device listed for: DE201B
 ! No device listed for: DE201C
@@ -1815,7 +1822,6 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DMSC0DB
 ! No device listed for: DMSC0DC
 ! No device listed for: DMSC0DD
-! No device listed for: DMSC0DE
 ! No device listed for: DMSC1DA
 ! No device listed for: DMSC1DB
 ! No device listed for: DMSC1UA
@@ -1827,6 +1833,7 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DMSC2UB
 ! No device listed for: DMSC3DA
 ! No device listed for: DMSC3DB
+! No device listed for: DMSC3DC
 ! No device listed for: DMSC3UA
 ! No device listed for: DMSC3UB
 ! No device listed for: DMSC3UC
@@ -1847,12 +1854,6 @@ DM60[alias]=BTM:BSYH:858
 ! No device listed for: DPCMUON
 ! No device listed for: DPCVV
 ! No device listed for: DPR2
-! No device listed for: DPSC1D
-! No device listed for: DPSC1U
-! No device listed for: DPSC2D
-! No device listed for: DPSC2U
-! No device listed for: DPSC3D
-! No device listed for: DPSC3U
 ! No device listed for: DPSHX13
 ! No device listed for: DPSHX21
 ! No device listed for: DPSHX28
@@ -2259,12 +2260,16 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: DWSDUMPC
 ! No device listed for: DWSVM2A
 ! No device listed for: DWSVM2B
-! No device listed for: DX00
+! No device listed for: DX00A
+! No device listed for: DX00B
+! No device listed for: DX00C
+! No device listed for: DX00D
 ! No device listed for: DX01A
 ! No device listed for: DX01B
 ! No device listed for: DX01C
 ! No device listed for: DX02A
 ! No device listed for: DX02B
+! No device listed for: DX02C
 ! No device listed for: DX33A
 ! No device listed for: DX33B
 ! No device listed for: DX34A
@@ -2290,8 +2295,8 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: DZAPM2B
 ! No device listed for: DZAPM3
 ! No device listed for: DZAPM4
-! No device listed for: ECD
-! No device listed for: ECU
+! No device listed for: EC1
+! No device listed for: EC2
 ! No device listed for: END
 ! No device listed for: ENDB
 ! No device listed for: ENDBC1B
@@ -2338,6 +2343,7 @@ DUMPFACEB[alias]=DUMP:DMPS:699
 ! No device listed for: FC5
 ! No device listed for: FC6
 FCDG0DU[alias]=FARC:DIAG0:530
+! No device listed for: FSEXT
 ! No device listed for: FV10
 ! No device listed for: FV28
 GJPEPX[alias]=GJET:UNDS:5049
@@ -2606,12 +2612,6 @@ PH34B[alias]=PCAV:DMPS:180
 PRDAS12[alias]=PROF:DASEL:440
 PRDAS14[alias]=PROF:DASEL:655
 PRDAS17[alias]=PROF:DASEL:818
-! No device listed for: PSC1D
-! No device listed for: PSC1U
-! No device listed for: PSC2D
-! No device listed for: PSC2U
-! No device listed for: PSC3D
-! No device listed for: PSC3U
 PSHXH14[alias]=PHAS:UNDH:1495
 PSHXH15[alias]=PHAS:UNDH:1595
 PSHXH16[alias]=PHAS:UNDH:1695
@@ -3259,24 +3259,28 @@ UMXL4H[alias]=WIGG:LTUS:774
 ! No device listed for: VBINB
 ! No device listed for: VBOUT
 ! No device listed for: VBOUTB
-! No device listed for: VG0H00
 ! No device listed for: VGCCPEPX1
+! No device listed for: VGEXTD
+! No device listed for: VGL0BD
+! No device listed for: VGL3BD
 ! No device listed for: VGPEPX1
 ! No device listed for: VGPRPEPX1
-! No device listed for: VP0H00
+! No device listed for: VPEXT1
+! No device listed for: VPEXT2
+! No device listed for: VPL0BD
 ! No device listed for: VPPEPX1
 ! No device listed for: VPPEPX2
 ! No device listed for: VTL1
 ! No device listed for: VTL2
 ! No device listed for: VV01B
 ! No device listed for: VV02B
-! No device listed for: VV0H00
 ! No device listed for: VV36
 ! No device listed for: VV36B
 ! No device listed for: VV37
 ! No device listed for: VV37B
 ! No device listed for: VV999
 ! No device listed for: VV999B
+! No device listed for: VVEXTD
 ! No device listed for: VVHXU14
 ! No device listed for: VVHXU17
 ! No device listed for: VVHXU20
@@ -3290,6 +3294,13 @@ UMXL4H[alias]=WIGG:LTUS:774
 ! No device listed for: VVHXU40
 ! No device listed for: VVHXU43
 ! No device listed for: VVHXU45
+! No device listed for: VVL0BD
+! No device listed for: VVL1BD
+! No device listed for: VVL1BU
+! No device listed for: VVL2BD
+! No device listed for: VVL2BU
+! No device listed for: VVL3BD
+! No device listed for: VVL3BU
 ! No device listed for: VVSXU26
 ! No device listed for: VVSXU32
 ! No device listed for: VVSXU38
@@ -3344,6 +3355,7 @@ XC1C00[alias]=XCOR:BC1B:100
 XC2C00[alias]=XCOR:BC2B:126
 XCA0[alias]=XCOR:BSYH:900
 XCAPM2[alias]=XCOR:BSYH:485
+XCBP10[alias]=XCOR:DOG:584
 XCBP11[alias]=XCOR:DOG:744
 XCBP13[alias]=XCOR:BPN13:406
 XCBP14[alias]=XCOR:BPN14:406


### PR DESCRIPTION
Adds the following alias

`XCBP10[alias]=XCOR:DOG:584`