### PR TITLE
Update publish-data.yaml

### DIFF
--- a/.github/workflows/publish-data.yaml
+++ b/.github/workflows/publish-data.yaml
@@ -1,6 +1,7 @@
 name: publish-data
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Add workflow_dispatch to publish-data.yaml action so that publish can be run on demand.  One use for this is to trigger the action when conda tao is updated.