### PR TITLE
Add mad8s binary for use in testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Install dependencies
         run: |
           mamba install pytest pytao bmad
+
+      - name: Fetch executables for testing
+        uses: slaclab/accel-test-exec-fetcher@v1.0
+
+      # This step can be removed, just ensuring it is working properly
+      - name: Check mad8s version
+        run: mad8s --version
+        shell: bash
           
       - name: Run tests
         shell: bash -l {0}


### PR DESCRIPTION
Adds a step for fetching external binaries to use in the testing workflow (just mad8s for now). Also includes an example showing it is available on the PATH for use in any step after. (Can be removed as part of this PR if preferred).

I added this as a custom action just in case it would be useful in other places as well, will keep any future additions or changes confined to just a single place to make maintaining it easier in the future.

https://github.com/slaclab/accel-test-exec-fetcher

If we do want matlab support or to be as close to our controls network environment as possible we should probably still look into using self-hosted github runners.