### PR TITLE
Update distgen

### DIFF
--- a/distgen/models/cu_inj/2gauss/distgen.yaml
+++ b/distgen/models/cu_inj/2gauss/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 100000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/cu_inj/v0/distgen.yaml
+++ b/distgen/models/cu_inj/v0/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 100000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/cu_inj/vcc_image/distgen.yaml
+++ b/distgen/models/cu_inj/vcc_image/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 1000000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/gunb_gaussian/distgen.yaml
+++ b/distgen/models/gunb_gaussian/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 100000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/sc_inj/stanford/distgen.yaml
+++ b/distgen/models/sc_inj/stanford/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 100000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/sc_inj/v0/distgen.yaml
+++ b/distgen/models/sc_inj/v0/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 100000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/sc_inj/vcc_image/distgen.yaml
+++ b/distgen/models/sc_inj/vcc_image/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 100000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode

--- a/distgen/models/sc_inj_truncated/distgen.yaml
+++ b/distgen/models/sc_inj_truncated/distgen.yaml
@@ -1,5 +1,6 @@
 n_particle: 250000
 random_type: hammersley
+species: electron
 
 start:
   type: cathode


### PR DESCRIPTION
The python module distgen now requires that yaml files contain `species: ...`.  `...` is probably `electron`.