### PR TITLE
mad to bmad converter will replace tcxdg0 and tcydg0 with crab_cavities

### DIFF
--- a/bmad/conversion/slac_to_bmad.py
+++ b/bmad/conversion/slac_to_bmad.py
@@ -9,11 +9,11 @@ lcls_lat_check_1 = run(f'ls {LCLS_LATTICE_ENV}/bmad/conversion',shell=True,captu
 assert lcls_lat_check_1.returncode == 0
 print(f'{LCLS_LATTICE_ENV=}')
 
-BMAD_ENV = os.environ['ACC_ROOT_DIR']
-assert BMAD_ENV != ''
-bmad_env_check_1 = run(f'ls {BMAD_ENV}/util/dist_source_me',shell=True,capture_output=True)
+BMAD_CONVERT_SCRIPT = os.environ['MAD8_TO_BMAD']
+assert BMAD_CONVERT_SCRIPT != ''
+bmad_env_check_1 = run(f'ls {BMAD_CONVERT_SCRIPT}',shell=True,capture_output=True)
 assert bmad_env_check_1.returncode == 0
-print(f'{BMAD_ENV=}')
+print(f'{BMAD_CONVERT_SCRIPT=}')
 
 WORK_DIR = LCLS_LATTICE_ENV + '/bmad/conversion/work'
 TEMP_DIR = LCLS_LATTICE_ENV + '/bmad/conversion/temp'
@@ -208,6 +208,14 @@ SC_NEWELES['dyqdg003'] = """
 ! Replace k0l with quad offset and patch with y_pitch.
 dyqdg003: patch, y_pitch = 5.88487966838956720E-004
 """
+SC_NEWELES['tcxdg0'] = """
+! mad8 describes tcav as lcavity.  Replace it with a crab_cavity.
+tcxdg0: crab_cavity, type = "STCAV_X", rf_frequency = 2856 * 1e6, l = 20*in2m/2
+"""
+SC_NEWELES['tcydg0'] = """
+! mad8 describes tcav as lcavity.  Replace it with a crab_cavity.
+tcydg0: crab_cavity, type = "STCAV_Y", rf_frequency = 2856 * 1e6, l = 20*in2m/2
+"""
 # Not needed. Desplitting handles cavities now.
 # Add these repalcements
 #SC_LINAC_REPLACEMENTS = json.load(open('replacements/good_sc_linac_replacements.json'))
@@ -255,7 +263,8 @@ def process_master(master):
     print(f'Converting {master}')
     shutil.copytree(TEMP_DIR, WORK_DIR, dirs_exist_ok=True)
 
-    SCRIPT = f'python $ACC_ROOT_DIR/util_programs/mad_to_bmad/mad8_to_bmad.py --no_prepend_vars -f {master}'
+    #SCRIPT = f'python $ACC_ROOT_DIR/util_programs/mad_to_bmad/mad8_to_bmad.py --no_prepend_vars -f {master}'
+    SCRIPT = f'python {BMAD_CONVERT_SCRIPT} --no_prepend_vars -f {master}'
     res = run(SCRIPT, shell=True, cwd=WORK_DIR)
 
     assert res.returncode == 0

--- a/bmad/master/DIAG0.bmad
+++ b/bmad/master/DIAG0.bmad
@@ -131,8 +131,14 @@ kqbd0 = -7.825140556488    !-13.410702917581
 ! transverse deflecting cavities
 ! (NOTE: TCYDG0 might be installed as an uprgade at a later time)
 
-tcydg0: lcavity, type = "@4,STCAV_Y", rf_frequency = 2856 * 1e6, l = 20*in2m/2, cavity_type = traveling_wave !Y-deflector (split)
-tcxdg0: lcavity, type = "STCAV_X", rf_frequency = 2856 * 1e6, l = 20*in2m/2, cavity_type = traveling_wave !X-deflector (split)
+
+! mad8 describes tcav as lcavity.  Replace it with a crab_cavity.
+tcydg0: crab_cavity, type = "STCAV_Y", rf_frequency = 2856 * 1e6, l = 20*in2m/2 !Y-deflector (split)
+!old: tcydg0: lcavity, type = "@4,STCAV_Y", rf_frequency = 2856 * 1e6, l = 20*in2m/2, cavity_type = traveling_wave
+
+! mad8 describes tcav as lcavity.  Replace it with a crab_cavity.
+tcxdg0: crab_cavity, type = "STCAV_X", rf_frequency = 2856 * 1e6, l = 20*in2m/2 !X-deflector (split)
+!old: tcxdg0: lcavity, type = "STCAV_X", rf_frequency = 2856 * 1e6, l = 20*in2m/2, cavity_type = traveling_wave
 
 ! ==============================================================================
 ! SBEN


### PR DESCRIPTION
Following this PR, the Bmad DIAG0 will now translate the transverse deflecting cavities as crab_cavities.

```
! transverse deflecting cavities
! (NOTE: TCYDG0 might be installed as an uprgade at a later time)

! mad8 describes tcav as lcavity.  Replace it with a crab_cavity.
tcydg0: crab_cavity, type = "STCAV_Y", rf_frequency = 2856 * 1e6, l = 20*in2m/2 !Y-deflector (split)
!old: tcydg0: lcavity, type = "@4,STCAV_Y", rf_frequency = 2856 * 1e6, l = 20*in2m/2, cavity_type = traveling_wave

! mad8 describes tcav as lcavity.  Replace it with a crab_cavity. 
tcxdg0: crab_cavity, type = "STCAV_X", rf_frequency = 2856 * 1e6, l = 20*in2m/2 !X-deflector (split)
!old: tcxdg0: lcavity, type = "STCAV_X", rf_frequency = 2856 * 1e6, l = 20*in2m/2, cavity_type = traveling_wave
```

The cavities can be controlled as:
```
set ele TCXDG0 VOLTAGE=1e6
set ele TCXDG0 PHI0=0.25
```