### PR TITLE
New lcav model

### DIFF
--- a/bmad/models/cu_hxr/cu_hxr.lat.bmad
+++ b/bmad/models/cu_hxr/cu_hxr.lat.bmad
@@ -28,14 +28,25 @@ call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_defaults.bmad
 !Overall fudge
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_fudge_overlays.bmad
 
+l0a_fixer: fixer, superimpose, ref=l0bbeg, ref_origin=beginning, 
+  beta_a_stored=1.41638494, alpha_a_stored=-2.63706808, 
+  beta_b_stored=7.30559740, alpha_b_stored=0.44820610, 
+  phi_a_stored=2.80064764, phi_b_stored=2.02441779,
+  dbeta_dpz_a_stored=-20.37244771, dbeta_dpz_b_stored=22.09277041, 
+  dalpha_dpz_a_stored=24.55800482, dalpha_dpz_b_stored=-3.67860057,
+  is_on=T
+
+QA01[K1] = -1.23714160523957588E+001
+QA02[K1] =  1.37440905821587052E+001
+QE01[K1] = -6.56502402848857436E+000
+QE02[K1] =  5.35877772165317712E+000
 
 ! Apertures
 ! call, file = $LCLS_LATTICE/bmad/apertures/ltu/apertures_ltuh.bmad
 
-
 !expand_lattice
 !quad::*[field_master] = T
+lcavity::*[n_rf_steps]=100
+l0a[n_rf_steps] = 1000
+l0b[n_rf_steps] = 1000
 
-
-
-lcavity::*[n_rf_steps]=0

--- a/bmad/models/cu_spec/cu_spec.lat.bmad
+++ b/bmad/models/cu_spec/cu_spec.lat.bmad
@@ -15,5 +15,20 @@ sbend::*[fringe_type] = full
 
 use, cu_spec 
 
-lcavity::*[n_rf_steps]=0
+l0a_fixer: fixer, superimpose, ref=l0bbeg, ref_origin=beginning, 
+  beta_a_stored=1.41638494, alpha_a_stored=-2.63706808, 
+  beta_b_stored=7.30559740, alpha_b_stored=0.44820610, 
+  phi_a_stored=2.80064764, phi_b_stored=2.02441779,
+  dbeta_dpz_a_stored=-20.37244771, dbeta_dpz_b_stored=22.09277041, 
+  dalpha_dpz_a_stored=24.55800482, dalpha_dpz_b_stored=-3.67860057,
+  is_on=T
+
+QA01[K1] = -1.23714160523957588E+001
+QA02[K1] =  1.37440905821587052E+001
+QE01[K1] = -6.56502402848857436E+000
+QE02[K1] =  5.35877772165317712E+000
+
+lcavity::*[n_rf_steps]=100
+l0a[n_rf_steps] = 1000
+l0b[n_rf_steps] = 1000
 

--- a/bmad/models/cu_sxr/cu_sxr.lat.bmad
+++ b/bmad/models/cu_sxr/cu_sxr.lat.bmad
@@ -28,7 +28,21 @@ call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_phase_defaults.bmad
 !Overall fudge
 call, file =  $LCLS_LATTICE/bmad/overlays/cu/linac_fudge_overlays.bmad
 
+l0a_fixer: fixer, superimpose, ref=l0bbeg, ref_origin=beginning, 
+  beta_a_stored=1.41638494, alpha_a_stored=-2.63706808, 
+  beta_b_stored=7.30559740, alpha_b_stored=0.44820610, 
+  phi_a_stored=2.80064764, phi_b_stored=2.02441779,
+  dbeta_dpz_a_stored=-20.37244771, dbeta_dpz_b_stored=22.09277041, 
+  dalpha_dpz_a_stored=24.55800482, dalpha_dpz_b_stored=-3.67860057,
+  is_on=T
+
+QA01[K1] = -1.23714160523957588E+001
+QA02[K1] =  1.37440905821587052E+001
+QE01[K1] = -6.56502402848857436E+000
+QE02[K1] =  5.35877772165317712E+000
 
 !expand_lattice
 !quad::*[field_master] = T
-lcavity::*[n_rf_steps]=0
+lcavity::*[n_rf_steps]=100
+l0a[n_rf_steps] = 1000
+l0b[n_rf_steps] = 1000

--- a/bmad/models/sc_bsyd/sc_bsyd.lat.bmad
+++ b/bmad/models/sc_bsyd/sc_bsyd.lat.bmad
@@ -17,17 +17,30 @@ call, file =  $LCLS_LATTICE/bmad/master/sc/sc_linac_wakefields.bmad
 sbend::*[fringe_type] = full
 call, file = $LCLS_LATTICE/bmad/master/gunb/beginning_BEGGUNB.bmad
 
-! lcavity::*[cavity_type]=traveling_wave
-! BUN1B[cavity_type]=standing_wave
-! CAVL011[cavity_type]=standing_wave
-! CAVL012[cavity_type]=standing_wave
-! CAVL013[cavity_type]=standing_wave
-! CAVL014[cavity_type]=standing_wave
-! CAVL015[cavity_type]=standing_wave
-! CAVL016[cavity_type]=standing_wave
-! CAVL017[cavity_type]=standing_wave
-! CAVL018[cavity_type]=standing_wave
-
 use, SC_BSYD
 
-lcavity::*[n_rf_steps]=0
+bun1b_fixer: fixer, superimpose, ref=yag01b, ref_origin=beginning, 
+  beta_a_stored=6.81622856, alpha_a_stored=8.44804290, 
+  beta_b_stored=6.80741000, alpha_b_stored=8.43704745, 
+  phi_a_stored=0.07731317, phi_b_stored=0.07741332,
+  dbeta_dpz_a_stored=33.69751748, dbeta_dpz_b_stored=33.65372977, 
+  dalpha_dpz_a_stored=15.13066565, dalpha_dpz_b_stored=15.11140587,
+  is_on=T
+
+ !match cavl01
+Q0H01[K1] = -6.34014047578799378E+000
+Q0H02[K1] =  6.05385276279990237E+000
+Q0H03[K1] =  3.52789670818601186E-001
+Q0H04[K1] = -4.05044570481829247E+000
+
+!match cavl02 & cavl03
+QC011[K1] = -1.05410605153589820E+000
+QC012[K1] =  9.42126122808186528E-001
+QCM02[K1] = -2.17938345390083416E-001
+QCM03[K1] =  1.10938727219923053E-001
+
+lcavity::*[n_rf_steps]=100
+bun1b[n_rf_steps]=1000
+cavl01*[n_rf_steps]=1000
+cavl*[n_cell]=9
+cavc*[n_cell]=9

--- a/bmad/models/sc_dasel/sc_dasel.lat.bmad
+++ b/bmad/models/sc_dasel/sc_dasel.lat.bmad
@@ -19,4 +19,29 @@ sbend::*[fringe_type] = full
 call, file = $LCLS_LATTICE/bmad/master/gunb/beginning_BEGGUNB.bmad
 !  
 use, SC_DASEL
-lcavity::*[n_rf_steps]=0
+
+bun1b_fixer: fixer, superimpose, ref=yag01b, ref_origin=beginning, 
+  beta_a_stored=6.81622856, alpha_a_stored=8.44804290, 
+  beta_b_stored=6.80741000, alpha_b_stored=8.43704745, 
+  phi_a_stored=0.07731317, phi_b_stored=0.07741332,
+  dbeta_dpz_a_stored=33.69751748, dbeta_dpz_b_stored=33.65372977, 
+  dalpha_dpz_a_stored=15.13066565, dalpha_dpz_b_stored=15.11140587,
+  is_on=T
+
+ !match cavl01
+Q0H01[K1] = -6.34014047578799378E+000
+Q0H02[K1] =  6.05385276279990237E+000
+Q0H03[K1] =  3.52789670818601186E-001
+Q0H04[K1] = -4.05044570481829247E+000
+
+!match cavl02 & cavl03
+QC011[K1] = -1.05410605153589820E+000
+QC012[K1] =  9.42126122808186528E-001
+QCM02[K1] = -2.17938345390083416E-001
+QCM03[K1] =  1.10938727219923053E-001
+
+lcavity::*[n_rf_steps]=100
+bun1b[n_rf_steps]=1000
+cavl01*[n_rf_steps]=1000
+cavl*[n_cell]=9
+cavc*[n_cell]=9

--- a/bmad/models/sc_diag0/sc_diag0.lat.bmad
+++ b/bmad/models/sc_diag0/sc_diag0.lat.bmad
@@ -20,4 +20,29 @@ sbend::*[fringe_type] = full
 call, file = $LCLS_LATTICE/bmad/master/gunb/beginning_BEGGUNB.bmad
 
 use, sc_diag0
-lcavity::*[n_rf_steps]=0
+
+bun1b_fixer: fixer, superimpose, ref=yag01b, ref_origin=beginning, 
+  beta_a_stored=6.81622856, alpha_a_stored=8.44804290, 
+  beta_b_stored=6.80741000, alpha_b_stored=8.43704745, 
+  phi_a_stored=0.07731317, phi_b_stored=0.07741332,
+  dbeta_dpz_a_stored=33.69751748, dbeta_dpz_b_stored=33.65372977, 
+  dalpha_dpz_a_stored=15.13066565, dalpha_dpz_b_stored=15.11140587,
+  is_on=T
+
+ !match cavl01
+Q0H01[K1] = -6.34014047578799378E+000
+Q0H02[K1] =  6.05385276279990237E+000
+Q0H03[K1] =  3.52789670818601186E-001
+Q0H04[K1] = -4.05044570481829247E+000
+
+!match cavl02 & cavl03
+QC011[K1] = -1.05410605153589820E+000
+QC012[K1] =  9.42126122808186528E-001
+QCM02[K1] = -2.17938345390083416E-001
+QCM03[K1] =  1.10938727219923053E-001
+
+lcavity::*[n_rf_steps]=100
+bun1b[n_rf_steps]=1000
+cavl01*[n_rf_steps]=1000
+cavl*[n_cell]=9
+cavc*[n_cell]=9

--- a/bmad/models/sc_hxr/sc_hxr.lat.bmad
+++ b/bmad/models/sc_hxr/sc_hxr.lat.bmad
@@ -37,7 +37,33 @@ call, file = $LCLS_LATTICE/bmad/master/gunb/beginning_BEGGUNB.bmad
 use, SC_HXR
 
 
+otr_fixer: fixer, superimpose, ref=OTR0H04
 
+!lcavity::*[n_rf_steps]=0
+!cavl*[n_cell]=9
 
+bun1b_fixer: fixer, superimpose, ref=yag01b, ref_origin=beginning, 
+  beta_a_stored=6.81622856, alpha_a_stored=8.44804290, 
+  beta_b_stored=6.80741000, alpha_b_stored=8.43704745, 
+  phi_a_stored=0.07731317, phi_b_stored=0.07741332,
+  dbeta_dpz_a_stored=33.69751748, dbeta_dpz_b_stored=33.65372977, 
+  dalpha_dpz_a_stored=15.13066565, dalpha_dpz_b_stored=15.11140587,
+  is_on=T
 
-lcavity::*[n_rf_steps]=0
+ !match cavl01
+Q0H01[K1] = -6.34014047578799378E+000
+Q0H02[K1] =  6.05385276279990237E+000
+Q0H03[K1] =  3.52789670818601186E-001
+Q0H04[K1] = -4.05044570481829247E+000
+
+!match cavl01 & cavl03
+QC011[K1] = -1.05410605153589820E+000
+QC012[K1] =  9.42126122808186528E-001
+QCM02[K1] = -2.17938345390083416E-001
+QCM03[K1] =  1.10938727219923053E-001
+
+lcavity::*[n_rf_steps]=100
+bun1b[n_rf_steps]=1000
+cavl01*[n_rf_steps]=1000
+cavl*[n_cell]=9
+cavc*[n_cell]=9

--- a/bmad/models/sc_sxr/sc_sxr.lat.bmad
+++ b/bmad/models/sc_sxr/sc_sxr.lat.bmad
@@ -35,6 +35,28 @@ call, file = $LCLS_LATTICE/bmad/master/gunb/beginning_BEGGUNB.bmad
 
 use, SC_SXR
 
+bun1b_fixer: fixer, superimpose, ref=yag01b, ref_origin=beginning, 
+  beta_a_stored=6.81622856, alpha_a_stored=8.44804290, 
+  beta_b_stored=6.80741000, alpha_b_stored=8.43704745, 
+  phi_a_stored=0.07731317, phi_b_stored=0.07741332,
+  dbeta_dpz_a_stored=33.69751748, dbeta_dpz_b_stored=33.65372977, 
+  dalpha_dpz_a_stored=15.13066565, dalpha_dpz_b_stored=15.11140587,
+  is_on=T
 
+ !match cavl01
+Q0H01[K1] = -6.34014047578799378E+000
+Q0H02[K1] =  6.05385276279990237E+000
+Q0H03[K1] =  3.52789670818601186E-001
+Q0H04[K1] = -4.05044570481829247E+000
 
-lcavity::*[n_rf_steps]=0
+!match cavl02 & cavl03
+QC011[K1] = -1.05410605153589820E+000
+QC012[K1] =  9.42126122808186528E-001
+QCM02[K1] = -2.17938345390083416E-001
+QCM03[K1] =  1.10938727219923053E-001
+
+lcavity::*[n_rf_steps]=100
+bun1b[n_rf_steps]=1000
+cavl01*[n_rf_steps]=1000
+cavl*[n_cell]=9
+cavc*[n_cell]=9

--- a/python/tests/test_twiss_comparison.py
+++ b/python/tests/test_twiss_comparison.py
@@ -21,7 +21,7 @@ MODELS = [
 'cu_hxr',
 'cu_spec',
 'sc_dasel',
-# 'sc_diag0',
+'sc_diag0',
 # 'cu_inj',
  #'cu_linac',
 # 'sc_inj',
@@ -32,6 +32,7 @@ TOLS['sc_bsyd']  = (1e-5,   1e-5,   1e-9)
 TOLS['sc_sxr']   = (5e-5,   5e-5,   1e-9)
 TOLS['sc_hxr']   = (1e-5,   5e-5,   1e-9)
 TOLS['sc_dasel'] = (1e-5,   5e-5,   1e-9)
+TOLS['sc_diag0'] = (1e-5,   5e-5,   1e-9)
 TOLS['cu_sxr']   = (2e-2,   2e-2,   1e-9)
 TOLS['cu_hxr']   = (2e-2,   2e-2,   1e-9)
 TOLS['cu_spec']  = (2e-2,   2e-2,   1e-9)


### PR DESCRIPTION
For the Cu and SC cavities, setting n_rf_steps > 0 tells Bmad to use the new kick-drift model.  This new model supports reverse tracking, is more accurate for beta<1, and is better at slicing.

This PR sets n_rf_steps to 100 for all lcavities, except for those at low energy, which are set to 1000.

Re-matching of the optics at low energy is necessary. to maintain agreement with mad8s.

For the SC lcavities (standing wave), it is necessary to set n_cell properly to get the effective length correct.  Each of the two SC buncher cavities gets one cell.  All other lcavities are set to 9 cells.