### PR TITLE
Security urllib3

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8.12]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urllib3<2
+urllib3>=2.5.0
 pysocks
 pandas
 requests


### PR DESCRIPTION
Updating urllib3 spec from <2 to >=2.5.0 due to security vulnerability.

Also bumping python from 3.8 to 3.9 to accomodate urllib3 >/2.5.0.