### PR TITLE
Adding production unit tests

### DIFF
--- a/.github/workflows/tests-prod.yml
+++ b/.github/workflows/tests-prod.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run prod tests
 
 on:
   pull_request:

--- a/.github/workflows/tests-prod.yml
+++ b/.github/workflows/tests-prod.yml
@@ -1,0 +1,51 @@
+name: Run tests
+
+on:
+  pull_request:
+  push:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+
+    name: Test Suite
+
+    env:
+      LCLS_LATTICE: ${{ github.workspace }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/conda-setup
+        with:
+          filename: "environment-prod.yml"
+          env_name: "lcls-lattice-prod"
+          extras: ""
+      - name: Test environment conda package list
+        shell: bash -l {0}
+        run: |
+          conda list
+
+      - name: Fetch special SLAC executables
+        uses: slaclab/accel_unit_test_execs@v1.2
+
+      - name: Check mad8s version
+        shell: bash -l {0}
+        run: |
+          echo -e '# testing if mad8s is functional' >> "$GITHUB_STEP_SUMMARY"
+          set -o pipefail
+          cd mad
+          ../mad8s <<< "STOP" | grep -qvz Error
+
+      - name: Run unit tests
+        shell: bash -l {0}
+        run: |
+          echo -e '## Test results\n\n```' >> "$GITHUB_STEP_SUMMARY"
+          pytest -v 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/environment-prod.yml
+++ b/environment-prod.yml
@@ -1,0 +1,19 @@
+# conda env create -f environment-prod.yml
+name: lcls-lattice-prod
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - bmad=20260223.1
+  - pytao=0.5.7
+  - distgen
+  - impact-t =*=mpi_openmpi*
+  - genesis4 >=4.6.6=mpi_openmpi*
+  - lume-genesis
+  - lume-impact
+  - openPMD-beamphysics=0.14.0
+  - pytest
+  - ipykernel
+  - ipywidgets
+  - jupyterlab
+  - openpyxl


### PR DESCRIPTION
These are the same as the existing lcls-lattice-dev unit tests, except that the software versions are pinned.

Also, `lcls-lattice/environment-prod.yml` is added, and can be harvested to find the minimum package versions needed to parse the master branch lcls-lattice release.

When merged and released to s3df, the environment file can be found here:
`/sdf/group/ad/sw/scm/repos/optics/lcls-lattice/environment-prod.yml`