### PR TITLE
add alias property and utility function to do so

### DIFF
--- a/cheetah/conversion/add_alias.py
+++ b/cheetah/conversion/add_alias.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+"""Add metadata.alias to Cheetah JSON element definitions.
+
+The alias mapping is derived from
+`bmad/conversion/from_oracle/lcls_elements.csv`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+from urllib.parse import unquote
+
+
+def parse_args() -> argparse.Namespace:
+	repo_root = Path(__file__).resolve().parents[2]
+	default_csv = repo_root / "bmad" / "conversion" / "from_oracle" / "lcls_elements.csv"
+	default_json_dir = repo_root / "cheetah"
+
+	parser = argparse.ArgumentParser(
+		description="Inject metadata.alias into Cheetah JSON files using the LCLS element table."
+	)
+	parser.add_argument(
+		"--csv",
+		dest="csv_path",
+		type=Path,
+		default=default_csv,
+		help=f"Path to lcls_elements.csv (default: {default_csv})",
+	)
+	parser.add_argument(
+		"--json-dir",
+		dest="json_dir",
+		type=Path,
+		default=default_json_dir,
+		help=f"Directory containing JSON files to update (default: {default_json_dir})",
+	)
+	parser.add_argument(
+		"--dry-run",
+		action="store_true",
+		help="Report changes without writing files.",
+	)
+	return parser.parse_args()
+
+
+def base_alias_from_row(row: Dict[str, str]) -> str | None:
+	# Prefer Control System Name for a stable base PV per element.
+	control_name = (row.get("Control System Name") or "").strip()
+	if control_name:
+		parts = control_name.split(":")
+		if len(parts) >= 3:
+			return ":".join(parts[:3])
+		return control_name
+
+	# Fallback to IOC search when Control System Name is missing.
+	ioc_search = (row.get("Ioc Captar Search") or "").strip()
+	if ioc_search and ioc_search != "%25":
+		decoded = unquote(ioc_search)
+		alias = decoded.rstrip("%")
+		if alias:
+			return alias
+
+	return None
+
+
+def build_alias_map(csv_path: Path) -> Dict[str, str]:
+	alias_map: Dict[str, str] = {}
+	with csv_path.open("r", encoding="utf-8", newline="") as handle:
+		reader = csv.DictReader(handle)
+		for row in reader:
+			element = (row.get("Element") or "").strip()
+			if not element:
+				continue
+
+			alias = base_alias_from_row(row)
+			if not alias:
+				continue
+
+			alias_map[element.upper()] = alias
+
+	return alias_map
+
+
+def iter_json_files(json_dir: Path) -> Iterable[Path]:
+	yield from sorted(json_dir.glob("*.json"))
+
+
+def update_json_file(file_path: Path, alias_map: Dict[str, str], dry_run: bool = False) -> tuple[int, int]:
+	with file_path.open("r", encoding="utf-8") as handle:
+		data = json.load(handle)
+
+	elements = data.get("elements")
+	if not isinstance(elements, dict):
+		return 0, 0
+
+	matched = 0
+	updated = 0
+
+	for element_name, element_def in elements.items():
+		if not isinstance(element_name, str):
+			continue
+		if not (isinstance(element_def, list) and len(element_def) >= 2 and isinstance(element_def[1], dict)):
+			continue
+
+		alias = alias_map.get(element_name.upper())
+		if not alias:
+			continue
+
+		matched += 1
+		attributes = element_def[1]
+		metadata = attributes.get("metadata")
+		if not isinstance(metadata, dict):
+			metadata = {}
+
+		if metadata.get("alias") == alias:
+			continue
+
+		metadata["alias"] = alias
+		attributes["metadata"] = metadata
+		updated += 1
+
+	if updated and not dry_run:
+		with file_path.open("w", encoding="utf-8") as handle:
+			json.dump(data, handle, indent=4, allow_nan=True)
+			handle.write("\n")
+
+	return matched, updated
+
+
+def main() -> None:
+	args = parse_args()
+
+	csv_path = args.csv_path.expanduser().resolve()
+	json_dir = args.json_dir.expanduser().resolve()
+
+	if not csv_path.exists():
+		raise FileNotFoundError(f"CSV file not found: {csv_path}")
+	if not json_dir.exists() or not json_dir.is_dir():
+		raise NotADirectoryError(f"JSON directory not found: {json_dir}")
+
+	alias_map = build_alias_map(csv_path)
+	if not alias_map:
+		raise RuntimeError("No element aliases were loaded from CSV.")
+
+	json_files = list(iter_json_files(json_dir))
+	if not json_files:
+		raise RuntimeError(f"No JSON files found in {json_dir}")
+
+	total_matched = 0
+	total_updated = 0
+
+	for json_file in json_files:
+		matched, updated = update_json_file(json_file, alias_map, dry_run=args.dry_run)
+		total_matched += matched
+		total_updated += updated
+		print(f"{json_file.name}: matched={matched}, updated={updated}")
+
+	mode = "dry-run" if args.dry_run else "write"
+	print(
+		f"Done ({mode}). files={len(json_files)}, matched={total_matched}, updated={total_updated}"
+	)
+
+
+if __name__ == "__main__":
+	main()

--- a/cheetah/nc_hxr.json
+++ b/cheetah/nc_hxr.json
@@ -4,1722 +4,18121 @@
     "info": "This is a placeholder lattice description",
     "root": "cu_hxr",
     "elements": {
-        "dl00": ["Drift", {"length": -0.869047999382019, "tracking_method": "linear"}],
-        "loadlock": ["Drift", {"length": 0.869047999382019, "tracking_method": "linear"}],
-        "beggun": ["Marker", {}],
-        "sol1bk": ["Solenoid", {"length": 0.0, "k": 0.0, "misalignment": [0.0, 0.0]}],
-        "dbmark80": ["Marker", {}],
-        "cathode": ["Marker", {}],
-        "dl01a": ["Drift", {"length": 0.0960099995136261, "tracking_method": "linear"}],
-        "sol1": ["Solenoid", {"length": 0.20000000298023224, "k": 0.0, "misalignment": [0.0, 0.0]}],
-        "dl01a1": ["Drift", {"length": 0.07851000130176544, "tracking_method": "linear"}],
-        "vv01": ["Marker", {}],
-        "dl01a2": ["Drift", {"length": 0.11608999967575073, "tracking_method": "linear"}],
-        "am00": ["Marker", {}],
-        "dl01a3": ["Drift", {"length": 0.10461000353097916, "tracking_method": "linear"}],
-        "am01": ["Marker", {}],
-        "dl01a4": ["Drift", {"length": 0.018400000408291817, "tracking_method": "linear"}],
-        "yag01": ["Marker", {}],
-        "dl01a5": ["Drift", {"length": 0.010970000177621841, "tracking_method": "linear"}],
-        "fc01": ["Marker", {}],
-        "dl01b": ["Drift", {"length": 0.08250000327825546, "tracking_method": "linear"}],
-        "im01": ["Marker", {}],
-        "dl01c": ["Drift", {"length": 0.12729500234127045, "tracking_method": "linear"}],
-        "xc01": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc01": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dl01h": ["Drift", {"length": 0.05818859860301018, "tracking_method": "linear"}],
-        "bpm2": ["BPM", {"is_active": true}],
-        "dl01d": ["Drift", {"length": 0.0852707028388977, "tracking_method": "linear"}],
-        "dbmark81": ["Marker", {}],
-        "endgun": ["Marker", {}],
-        "begl0": ["Marker", {}],
-        "dbxg": ["Drift", {"length": 0.13261835277080536, "tracking_method": "linear"}],
-        "dl01e": ["Drift", {"length": 0.10619734227657318, "tracking_method": "linear"}],
-        "bpm3": ["BPM", {"is_active": true}],
-        "dl01f": ["Drift", {"length": 0.1423799991607666, "tracking_method": "linear"}],
-        "cr01": ["Marker", {}],
-        "dl01f2": ["Drift", {"length": 0.029370000585913658, "tracking_method": "linear"}],
-        "yag02": ["Marker", {}],
-        "dl01g": ["Drift", {"length": 0.07058999687433243, "tracking_method": "linear"}],
-        "zlin00": ["Marker", {}],
-        "l0a": ["Cavity", {"length": 3.0952439308166504, "voltage": 58010692.0, "phase": 1.0999999999999999, "frequency": 2856000000.0}],
-        "l0awake": ["Marker", {}],
-        "l0bbeg": ["Marker", {}],
-        "dl02a1": ["Drift", {"length": 0.060294605791568756, "tracking_method": "linear"}],
-        "yag03": ["Marker", {}],
-        "dl02a2": ["Drift", {"length": 0.11278499662876129, "tracking_method": "linear"}],
-        "dl02a3": ["Drift", {"length": 0.07361000031232834, "tracking_method": "linear"}],
-        "qa01": ["Quadrupole", {"length": 0.1080000028014183, "k1": -9.879051208496094, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dl02b1": ["Drift", {"length": 0.09448400139808655, "tracking_method": "linear"}],
-        "ph01": ["Marker", {}],
-        "dl02b2": ["Drift", {"length": 0.12589199841022491, "tracking_method": "linear"}],
-        "qa02": ["Quadrupole", {"length": 0.1080000028014183, "k1": 10.775527000427246, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dl02c": ["Drift", {"length": 0.06588800251483917, "tracking_method": "linear"}],
-        "l0b": ["Cavity", {"length": 3.0952439308166504, "voltage": 71013088.0, "phase": 1.0999999999999999, "frequency": 2856000000.0}],
-        "endl0": ["Marker", {}],
-        "begdl1_1": ["Marker", {}],
-        "emat": ["Marker", {}],
-        "de00": ["Drift", {"length": 0.024994000792503357, "tracking_method": "linear"}],
-        "de00a": ["Drift", {"length": 0.016612999141216278, "tracking_method": "linear"}],
-        "qe01": ["Quadrupole", {"length": 0.1080000028014183, "k1": -0.2743176221847534, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "de01a": ["Drift", {"length": 0.07637300342321396, "tracking_method": "linear"}],
-        "im02": ["Marker", {}],
-        "de01b": ["Drift", {"length": 0.12235900014638901, "tracking_method": "linear"}],
-        "vv02": ["Marker", {}],
-        "de01c": ["Drift", {"length": 0.09478099644184113, "tracking_method": "linear"}],
-        "qe02": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.7829366326332092, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dh00": ["Drift", {"length": 0.1273304522037506, "tracking_method": "linear"}],
-        "lhbeg": ["Marker", {}],
-        "bxh1": ["Dipole", {"length": 0.12476039677858353, "angle": -0.13170939683914185, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.13170939683914185, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.4000000059604645, "fringe_integral_exit": 0.4000000059604645, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dh01": ["Drift", {"length": 0.14182840287685394, "tracking_method": "linear"}],
-        "bxh2": ["Dipole", {"length": 0.12476039677858353, "angle": 0.13170939683914185, "k1": 0.0, "dipole_e1": 0.13170939683914185, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.4000000059604645, "fringe_integral_exit": 0.4000000059604645, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dh02a": ["Drift", {"length": 0.059970200061798096, "tracking_method": "linear"}],
-        "otrh1": ["Screen", {"resolution": [1040,1392],"pixel_size": [18.59e-6,18.59e-6],"is_active": true}],
-        "dh03a": ["Drift", {"length": 0.07603974640369415, "tracking_method": "linear"}],
-        "lh_und": ["Undulator", {"length": 0.5400000214576721}],
-        "dh03b": ["Drift", {"length": 0.0671498030424118, "tracking_method": "linear"}],
-        "otrh2": ["Screen", {"resolution": [1392,1040],"pixel_size": [19.16e-6,19.16e-6],"is_active": true}],
-        "dh02b": ["Drift", {"length": 0.08783020079135895, "tracking_method": "linear"}],
-        "bxh3": ["Dipole", {"length": 0.12476039677858353, "angle": 0.13170939683914185, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.13170939683914185, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.4000000059604645, "fringe_integral_exit": 0.4000000059604645, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bxh4": ["Dipole", {"length": 0.12476039677858353, "angle": -0.13170939683914185, "k1": 0.0, "dipole_e1": -0.13170939683914185, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.4000000059604645, "fringe_integral_exit": 0.4000000059604645, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "lhend": ["Marker", {}],
-        "dh06": ["Drift", {"length": 0.12290070205926895, "tracking_method": "linear"}],
-        "tcav0": ["Cavity", {"length": 0.6680235862731934, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "de02": ["Drift", {"length": 0.03573950007557869, "tracking_method": "linear"}],
-        "qe03": ["Quadrupole", {"length": 0.1080000028014183, "k1": 11.568048477172852, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "de03a": ["Drift", {"length": 0.11432000249624252, "tracking_method": "linear"}],
-        "de03b": ["Drift", {"length": 0.04758099839091301, "tracking_method": "linear"}],
-        "xc07": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc07": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "de03c": ["Drift", {"length": 0.13649900257587433, "tracking_method": "linear"}],
-        "qe04": ["Quadrupole", {"length": 0.1080000028014183, "k1": -6.789909839630127, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "de04": ["Drift", {"length": 0.14368799328804016, "tracking_method": "linear"}],
-        "ws01": ["Marker", {}],
-        "de05": ["Drift", {"length": 0.15196800231933594, "tracking_method": "linear"}],
-        "otr1": ["Screen", {"resolution": [1392,1040],"pixel_size": [12.66e-6,12.66e-6],"is_active": true}],
-        "de05c": ["Drift", {"length": 0.10446999967098236, "tracking_method": "linear"}],
-        "vv03": ["Marker", {}],
-        "de06a": ["Drift", {"length": 1.409488558769226, "tracking_method": "linear"}],
-        "rst1": ["Marker", {}],
-        "de06b": ["Drift", {"length": 0.24780240654945374, "tracking_method": "linear"}],
-        "ws02": ["Marker", {}],
-        "de05a": ["Drift", {"length": 0.07598400115966797, "tracking_method": "linear"}],
-        "mrk0": ["Marker", {}],
-        "otr2": ["Screen", {"resolution": [1392,1040],"pixel_size": [12.66e-6,12.66e-6],"is_active": true}],
-        "de06d": ["Drift", {"length": 0.1638306975364685, "tracking_method": "linear"}],
-        "bpm10": ["BPM", {"is_active": true}],
-        "de06e": ["Drift", {"length": 1.5979303121566772, "tracking_method": "linear"}],
-        "ws03": ["Marker", {}],
-        "otr3": ["Screen", {"resolution": [1392,1040],"pixel_size": [12.12e-6,12.12e-6],"is_active": true}],
-        "de07": ["Drift", {"length": 0.15080569684505463, "tracking_method": "linear"}],
-        "qm01": ["Quadrupole", {"length": 0.1080000028014183, "k1": 15.08299732208252, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "de08": ["Drift", {"length": 0.14787210524082184, "tracking_method": "linear"}],
-        "xc08": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc08": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "de08a": ["Drift", {"length": 0.1833299994468689, "tracking_method": "linear"}],
-        "vv04": ["Marker", {}],
-        "de08b": ["Drift", {"length": 0.11661999672651291, "tracking_method": "linear"}],
-        "qm02": ["Quadrupole", {"length": 0.1080000028014183, "k1": -11.969358444213867, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "de09": ["Drift", {"length": 0.22345000505447388, "tracking_method": "linear"}],
-        "dbmark82": ["Marker", {}],
-        "enddl1_1": ["Marker", {}],
-        "begdl1_2": ["Marker", {}],
-        "bx01": ["Dipole", {"length": 0.20399200916290283, "angle": -0.30543261766433716, "k1": 0.0, "dipole_e1": -0.15271630883216858, "dipole_e2": -0.15271630883216858, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.44999998807907104, "fringe_integral_exit": 0.44999998807907104, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "db00a": ["Drift", {"length": 0.39969944953918457, "tracking_method": "linear"}],
-        "otr4": ["Screen", {"resolution": [1392,1040],"pixel_size": [17.06e-6,17.06e-6],"is_active": true}],
-        "db00b": ["Drift", {"length": 0.16099999845027924, "tracking_method": "linear"}],
-        "xc09": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc09": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "db00c": ["Drift", {"length": 0.1657000035047531, "tracking_method": "linear"}],
-        "qb": ["Quadrupole", {"length": 0.10679999738931656, "k1": 22.169715881347656, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "db00d": ["Drift", {"length": 0.28859999775886536, "tracking_method": "linear"}],
-        "ws04": ["Marker", {}],
-        "db00e": ["Drift", {"length": 0.43779945373535156, "tracking_method": "linear"}],
-        "bx02": ["Dipole", {"length": 0.20399200916290283, "angle": -0.30543261766433716, "k1": 0.0, "dipole_e1": -0.15271630883216858, "dipole_e2": -0.15271630883216858, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.44999998807907104, "fringe_integral_exit": 0.44999998807907104, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cnt0": ["Marker", {}],
-        "dbmark83": ["Marker", {}],
-        "dm00": ["Drift", {"length": 0.22130104899406433, "tracking_method": "linear"}],
-        "xc10": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc10": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dm00a": ["Drift", {"length": 0.14068299531936646, "tracking_method": "linear"}],
-        "qm03": ["Quadrupole", {"length": 0.1080000028014183, "k1": -8.29494571685791, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm01": ["Drift", {"length": 0.08836700022220612, "tracking_method": "linear"}],
-        "dm01a": ["Drift", {"length": 0.20880000293254852, "tracking_method": "linear"}],
-        "qm04": ["Quadrupole", {"length": 0.1080000028014183, "k1": 13.337873458862305, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm02": ["Drift", {"length": 0.14020000398159027, "tracking_method": "linear"}],
-        "im03": ["Marker", {}],
-        "dm02a": ["Drift", {"length": 0.15744799375534058, "tracking_method": "linear"}],
-        "enddl1_2": ["Marker", {}],
-        "begl1": ["Marker", {}],
-        "zlin01": ["Marker", {}],
-        "k21_1b": ["Cavity", {"length": 2.8691999912261963, "voltage": 45397560.0, "phase": 21.5, "frequency": 2856000000.0}],
-        "daqa1": ["Drift", {"length": 0.03686999902129173, "tracking_method": "linear"}],
-        "qa11": ["Quadrupole", {"length": 0.1080000028014183, "k1": -3.7779366970062256, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daqa2": ["Drift", {"length": 0.03002999909222126, "tracking_method": "linear"}],
-        "k21_1c": ["Cavity", {"length": 2.8691999912261963, "voltage": 32100922.0, "phase": 21.5, "frequency": 2856000000.0}],
-        "daqa3": ["Drift", {"length": 0.03344999998807907, "tracking_method": "linear"}],
-        "qa12": ["Quadrupole", {"length": 0.1080000028014183, "k1": 1.8813942670822144, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daqa4": ["Drift", {"length": 0.03344999998807907, "tracking_method": "linear"}],
-        "k21_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 34057724.0, "phase": 21.5, "frequency": 2856000000.0}],
-        "endl1": ["Marker", {}],
-        "begbc1": ["Marker", {}],
-        "dl1xa": ["Drift", {"length": 0.0933689996600151, "tracking_method": "linear"}],
-        "vvx1": ["Marker", {}],
-        "dl1xb": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "l1x": ["Cavity", {"length": 0.5947999954223633, "voltage": 20000000.0, "phase": 160.0, "frequency": 11424000000.0}],
-        "dm10a": ["Drift", {"length": 0.20507800579071045, "tracking_method": "linear"}],
-        "vvx2": ["Marker", {}],
-        "dm10c": ["Drift", {"length": 0.11993200331926346, "tracking_method": "linear"}],
-        "q21201": ["Quadrupole", {"length": 0.10679999738931656, "k1": -9.33825397491455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm10x": ["Drift", {"length": 0.0860069990158081, "tracking_method": "linear"}],
-        "imbc1i": ["Marker", {}],
-        "dm11": ["Drift", {"length": 0.2788830101490021, "tracking_method": "linear"}],
-        "qm11": ["Quadrupole", {"length": 0.1080000028014183, "k1": 7.949062347412109, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm12": ["Drift", {"length": 0.12780100107192993, "tracking_method": "linear"}],
-        "bc1cbeg": ["Marker", {}],
-        "bx11": ["Dipole", {"length": 0.20349685847759247, "angle": -0.09357535094022751, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.09357535094022751, "tilt": 0.0, "gap": 0.04328000172972679, "gap_exit": 0.04328000172972679, "fringe_integral": 0.3869999945163727, "fringe_integral_exit": 0.3869999945163727, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dbq1": ["Drift", {"length": 0.2458566129207611, "tracking_method": "linear"}],
-        "cq11": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d11o": ["Drift", {"length": 2.091742515563965, "tracking_method": "linear"}],
-        "bx12": ["Dipole", {"length": 0.20349685847759247, "angle": 0.09357535094022751, "k1": 0.0, "dipole_e1": 0.09357535094022751, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.04328000172972679, "gap_exit": 0.04328000172972679, "fringe_integral": 0.3869999945163727, "fringe_integral_exit": 0.3869999945163727, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ddg1": ["Drift", {"length": 0.2486400008201599, "tracking_method": "linear"}],
-        "bpms11": ["BPM", {"is_active": true}],
-        "ddg2": ["Drift", {"length": 0.16446000337600708, "tracking_method": "linear"}],
-        "ce11_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "ce11_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "ddg3": ["Drift", {"length": 0.18260599672794342, "tracking_method": "linear"}],
-        "otr11": ["Marker", {}],
-        "ddg4": ["Drift", {"length": 0.23449400067329407, "tracking_method": "linear"}],
-        "bx13": ["Dipole", {"length": 0.20349685847759247, "angle": 0.09357535094022751, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.09357535094022751, "tilt": 0.0, "gap": 0.04328000172972679, "gap_exit": 0.04328000172972679, "fringe_integral": 0.3869999945163727, "fringe_integral_exit": 0.3869999945163727, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d11oa": ["Drift", {"length": 0.2624492049217224, "tracking_method": "linear"}],
-        "sq13": ["Quadrupole", {"length": 0.1599999964237213, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.7853981852531433}],
-        "d11ob": ["Drift", {"length": 1.6692934036254883, "tracking_method": "linear"}],
-        "cq12": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "bx14": ["Dipole", {"length": 0.20349685847759247, "angle": -0.09357535094022751, "k1": 0.0, "dipole_e1": -0.09357535094022751, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.04328000172972679, "gap_exit": 0.04328000172972679, "fringe_integral": 0.3869999945163727, "fringe_integral_exit": 0.3869999945163727, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cnt1": ["Marker", {}],
-        "bc1cend": ["Marker", {}],
-        "dm13a": ["Drift", {"length": 0.1617249995470047, "tracking_method": "linear"}],
-        "bl11": ["Marker", {}],
-        "dm13b": ["Drift", {"length": 0.1617249995470047, "tracking_method": "linear"}],
-        "qm12": ["Quadrupole", {"length": 0.1080000028014183, "k1": -8.326568603515625, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm14a": ["Drift", {"length": 0.17384999990463257, "tracking_method": "linear"}],
-        "dm14b": ["Drift", {"length": 0.20713874697685242, "tracking_method": "linear"}],
-        "imbc1o": ["Marker", {}],
-        "dm14c": ["Drift", {"length": 0.18178875744342804, "tracking_method": "linear"}],
-        "qm13": ["Quadrupole", {"length": 0.1080000028014183, "k1": 9.937676429748535, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm15a": ["Drift", {"length": 0.10047200322151184, "tracking_method": "linear"}],
-        "bl12": ["Marker", {}],
-        "dm15b": ["Drift", {"length": 0.2010740041732788, "tracking_method": "linear"}],
-        "xc21275": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc21276": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dm15c": ["Drift", {"length": 0.23499999940395355, "tracking_method": "linear"}],
-        "ws11": ["Marker", {}],
-        "dww1a": ["Drift", {"length": 1.6561959981918335, "tracking_method": "linear"}],
-        "ws12": ["Marker", {}],
-        "dww1b": ["Drift", {"length": 0.29499998688697815, "tracking_method": "linear"}],
-        "otr12": ["Marker", {}],
-        "dww1c1": ["Drift", {"length": 0.4153299927711487, "tracking_method": "linear"}],
-        "ph02": ["Marker", {}],
-        "dww1c2": ["Drift", {"length": 0.30240100622177124, "tracking_method": "linear"}],
-        "xc21302": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dww1d": ["Drift", {"length": 0.34609898924827576, "tracking_method": "linear"}],
-        "yc21303": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dww1e": ["Drift", {"length": 0.2973659932613373, "tracking_method": "linear"}],
-        "ws13": ["Marker", {}],
-        "dm16": ["Drift", {"length": 0.255730003118515, "tracking_method": "linear"}],
-        "q21301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.1347000002861023, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm17a": ["Drift", {"length": 0.26010408997535706, "tracking_method": "linear"}],
-        "dm17b": ["Drift", {"length": 0.40088289976119995, "tracking_method": "linear"}],
-        "td11": ["Marker", {}],
-        "dm17c": ["Drift", {"length": 0.3875870108604431, "tracking_method": "linear"}],
-        "qm14": ["Quadrupole", {"length": 0.1080000028014183, "k1": 7.054168701171875, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm18a": ["Drift", {"length": 0.22612999379634857, "tracking_method": "linear"}],
-        "xc21325": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "yc21325": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dm18b": ["Drift", {"length": 0.23068000376224518, "tracking_method": "linear"}],
-        "qm15": ["Quadrupole", {"length": 0.1080000028014183, "k1": -6.723000526428223, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbmark28": ["Marker", {}],
-        "dm19": ["Drift", {"length": 0.09692099690437317, "tracking_method": "linear"}],
-        "endbc1": ["Marker", {}],
-        "begl2": ["Marker", {}],
-        "li21beg": ["Marker", {}],
-        "zlin04": ["Marker", {}],
-        "k21_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 72760504.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "daq1": ["Drift", {"length": 0.03420000150799751, "tracking_method": "linear"}],
-        "q21401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 1.0301234722137451, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq2": ["Drift", {"length": 0.027000000700354576, "tracking_method": "linear"}],
-        "k21_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q21501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.8207575678825378, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k21_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q21601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7139142751693726, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k21_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q21701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7058273553848267, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k21_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_7d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q21801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7356926202774048, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k21_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k21_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "daq3": ["Drift", {"length": 0.353300005197525, "tracking_method": "linear"}],
-        "q21901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7182051539421082, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d219a": ["Drift", {"length": 0.3109000027179718, "tracking_method": "linear"}],
-        "bky21929": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "d219b": ["Drift", {"length": 0.24390000104904175, "tracking_method": "linear"}],
-        "bkx21957": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "d219c": ["Drift", {"length": 1.3978999853134155, "tracking_method": "linear"}],
-        "li21end": ["Marker", {}],
-        "li22beg": ["Marker", {}],
-        "zlin05": ["Marker", {}],
-        "k22_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7146031856536865, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7621889114379883, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_7d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.747560441493988, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k22_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k22_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q22901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7099809050559998, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d229a": ["Drift", {"length": 0.3109000027179718, "tracking_method": "linear"}],
-        "bky22929": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "d229b": ["Drift", {"length": 0.24390000104904175, "tracking_method": "linear"}],
-        "bkx22957": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "d229c": ["Drift", {"length": 1.3978999853134155, "tracking_method": "linear"}],
-        "li22end": ["Marker", {}],
-        "li23beg": ["Marker", {}],
-        "zlin06": ["Marker", {}],
-        "k23_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7207915186882019, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7418510317802429, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7083885073661804, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_7d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7706663608551025, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k23_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k23_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q23901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.7268516421318054, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq4": ["Drift", {"length": 2.5527000427246094, "tracking_method": "linear"}],
-        "li23end": ["Marker", {}],
-        "li24beg": ["Marker", {}],
-        "zlin07": ["Marker", {}],
-        "k24_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q24201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.7792933583259583, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k24_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q24301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.8564971685409546, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k24_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q24401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 1.0248178243637085, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k24_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q24501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.9540035724639893, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k24_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "q24601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.6081355214118958, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k24_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "k24_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 51449448.0, "phase": 33.5, "frequency": 2856000000.0}],
-        "li24term": ["Marker", {}],
-        "endl2": ["Marker", {}],
-        "begbc2": ["Marker", {}],
-        "dm20": ["Drift", {"length": 0.03420000150799751, "tracking_method": "linear"}],
-        "q24701a": ["Quadrupole", {"length": 0.10679999738931656, "k1": -1.307122826576233, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d10cma": ["Drift", {"length": 0.12700000405311584, "tracking_method": "linear"}],
-        "q24701b": ["Quadrupole", {"length": 0.10679999738931656, "k1": -1.307122826576233, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm21z": ["Drift", {"length": 0.055800601840019226, "tracking_method": "linear"}],
-        "dm21a": ["Drift", {"length": 0.3199993968009949, "tracking_method": "linear"}],
-        "ws24": ["Marker", {}],
-        "dm21h": ["Drift", {"length": 0.19300000369548798, "tracking_method": "linear"}],
-        "imbc2i": ["Marker", {}],
-        "dm21b": ["Drift", {"length": 0.6340001821517944, "tracking_method": "linear"}],
-        "vv21": ["Marker", {}],
-        "dm21c": ["Drift", {"length": 0.32024040818214417, "tracking_method": "linear"}],
-        "qm21": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.5118958950042725, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm21d": ["Drift", {"length": 0.13953599333763123, "tracking_method": "linear"}],
-        "dm21e": ["Drift", {"length": 0.19510340690612793, "tracking_method": "linear"}],
-        "bc2cbeg": ["Marker", {}],
-        "bx21": ["Dipole", {"length": 0.549125075340271, "angle": -0.0369713231921196, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.0369713231921196, "tilt": 0.0, "gap": 0.03334999829530716, "gap_exit": 0.03334999829530716, "fringe_integral": 0.6330000162124634, "fringe_integral_exit": 0.6330000162124634, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dbq2a": ["Drift", {"length": 1.9568371772766113, "tracking_method": "linear"}],
-        "cq21": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d21oa": ["Drift", {"length": 7.80210542678833, "tracking_method": "linear"}],
-        "bx22": ["Dipole", {"length": 0.549125075340271, "angle": 0.0369713231921196, "k1": 0.0, "dipole_e1": 0.0369713231921196, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03334999829530716, "gap_exit": 0.03334999829530716, "fringe_integral": 0.6330000162124634, "fringe_integral_exit": 0.6330000162124634, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ddg0": ["Drift", {"length": 0.13118499517440796, "tracking_method": "linear"}],
-        "bpms21": ["BPM", {"is_active": true}],
-        "ce21_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "ce21_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "otr21": ["Marker", {}],
-        "ddga": ["Drift", {"length": 0.13121500611305237, "tracking_method": "linear"}],
-        "bx23": ["Dipole", {"length": 0.549125075340271, "angle": 0.0369713231921196, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0369713231921196, "tilt": 0.0, "gap": 0.03334999829530716, "gap_exit": 0.03334999829530716, "fringe_integral": 0.6330000162124634, "fringe_integral_exit": 0.6330000162124634, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d21ob": ["Drift", {"length": 7.80210542678833, "tracking_method": "linear"}],
-        "cq22": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbq2b": ["Drift", {"length": 1.9568371772766113, "tracking_method": "linear"}],
-        "bx24": ["Dipole", {"length": 0.549125075340271, "angle": -0.0369713231921196, "k1": 0.0, "dipole_e1": -0.0369713231921196, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03334999829530716, "gap_exit": 0.03334999829530716, "fringe_integral": 0.6330000162124634, "fringe_integral_exit": 0.6330000162124634, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cnt2": ["Marker", {}],
-        "bc2cend": ["Marker", {}],
-        "d21w": ["Drift", {"length": 0.30649998784065247, "tracking_method": "linear"}],
-        "d21x": ["Drift", {"length": 0.2087000012397766, "tracking_method": "linear"}],
-        "bl21": ["Marker", {}],
-        "d21y": ["Drift", {"length": 0.11423499882221222, "tracking_method": "linear"}],
-        "dm23b": ["Drift", {"length": 0.050404999405145645, "tracking_method": "linear"}],
-        "qm22": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.5894557237625122, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm24a": ["Drift", {"length": 0.12943999469280243, "tracking_method": "linear"}],
-        "vv22": ["Marker", {}],
-        "dm24b": ["Drift", {"length": 0.17800000309944153, "tracking_method": "linear"}],
-        "dm24d": ["Drift", {"length": 0.07069999724626541, "tracking_method": "linear"}],
-        "q24901a": ["Quadrupole", {"length": 0.10679999738931656, "k1": 1.08145272731781, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm24c": ["Drift", {"length": 0.1062999963760376, "tracking_method": "linear"}],
-        "q24901b": ["Quadrupole", {"length": 0.10679999738931656, "k1": 1.08145272731781, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm25": ["Drift", {"length": 0.16040000319480896, "tracking_method": "linear"}],
-        "endbc2": ["Marker", {}],
-        "begl3": ["Marker", {}],
-        "li25beg": ["Marker", {}],
-        "zlin09": ["Marker", {}],
-        "k25_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d25_1c": ["Drift", {"length": 3.044100046157837, "tracking_method": "linear"}],
-        "k25_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 68162928.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q25201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.6983538866043091, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 68162928.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d255a": ["Drift", {"length": 0.06469999998807907, "tracking_method": "linear"}],
-        "imbc2o": ["Marker", {}],
-        "d255b": ["Drift", {"length": 0.11334999650716782, "tracking_method": "linear"}],
-        "d255c": ["Drift", {"length": 0.15254999697208405, "tracking_method": "linear"}],
-        "tcav3": ["Cavity", {"length": 2.437999963760376, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d255d": ["Drift", {"length": 0.30970001220703125, "tracking_method": "linear"}],
-        "q25301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.4798545241355896, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 68162928.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d256a": ["Drift", {"length": 0.5989999771118164, "tracking_method": "linear"}],
-        "ph03": ["Marker", {}],
-        "d256b": ["Drift", {"length": 0.5590999722480774, "tracking_method": "linear"}],
-        "bl22": ["Marker", {}],
-        "d256c": ["Drift", {"length": 0.6147500276565552, "tracking_method": "linear"}],
-        "bxkik": ["Drift", {"length": 1.0600999593734741, "tracking_method": "linear"}],
-        "d256d": ["Drift", {"length": 0.21115000545978546, "tracking_method": "linear"}],
-        "q25401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.4298321604728699, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q25501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.400216281414032, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q25601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q25701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_7d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q25801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.4075244665145874, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k25_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k25_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq7": ["Drift", {"length": 0.27480000257492065, "tracking_method": "linear"}],
-        "q25901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3886786997318268, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq8a": ["Drift", {"length": 0.5031999945640564, "tracking_method": "linear"}],
-        "otr_tcav": ["Marker", {}],
-        "daq8b": ["Drift", {"length": 2.128000020980835, "tracking_method": "linear"}],
-        "li25end": ["Marker", {}],
-        "li26beg": ["Marker", {}],
-        "zlin10": ["Marker", {}],
-        "k26_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.3888441324234009, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.4053811728954315, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_7d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.4060079753398895, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k26_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k26_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 48198468.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q26901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3887695372104645, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq8": ["Drift", {"length": 2.631200075149536, "tracking_method": "linear"}],
-        "li26end": ["Marker", {}],
-        "li27beg": ["Marker", {}],
-        "zlin11": ["Marker", {}],
-        "k27_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_1d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.3910715579986572, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.4071718752384186, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_4d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_5d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq5a": ["Drift", {"length": 2.3434998989105225, "tracking_method": "linear"}],
-        "ws27644": ["Marker", {}],
-        "daq6a": ["Drift", {"length": 0.7347999811172485, "tracking_method": "linear"}],
-        "q27701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_7d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.4068216383457184, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k27_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k27_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q27901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.38950514793395996, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "li27end": ["Marker", {}],
-        "li28beg": ["Marker", {}],
-        "zlin12": ["Marker", {}],
-        "k28_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq5b1": ["Drift", {"length": 2.0906999111175537, "tracking_method": "linear"}],
-        "xc29092": ["Marker", {}],
-        "daq5b2": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "yc29092": ["Marker", {}],
-        "daq5b3": ["Drift", {"length": 0.4542999863624573, "tracking_method": "linear"}],
-        "ws28144": ["Marker", {}],
-        "daq6b": ["Drift", {"length": 0.23729999363422394, "tracking_method": "linear"}],
-        "q28201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.3908107280731201, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q28301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.40650999546051025, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q28401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq5c1": ["Drift", {"length": 2.080699920654297, "tracking_method": "linear"}],
-        "xc29095": ["Marker", {}],
-        "daq5c2": ["Drift", {"length": 0.28600001335144043, "tracking_method": "linear"}],
-        "yc29095": ["Marker", {}],
-        "daq5c3": ["Drift", {"length": 0.47429999709129333, "tracking_method": "linear"}],
-        "ws28444": ["Marker", {}],
-        "daq6c": ["Drift", {"length": 0.23729999363422394, "tracking_method": "linear"}],
-        "q28501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d28_5d": ["Drift", {"length": 3.044100046157837, "tracking_method": "linear"}],
-        "q28601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q28701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq5d": ["Drift", {"length": 2.3440001010894775, "tracking_method": "linear"}],
-        "ws28744": ["Marker", {}],
-        "daq6d": ["Drift", {"length": 0.7343000173568726, "tracking_method": "linear"}],
-        "q28801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.40682169795036316, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k28_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k28_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q28901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.38950520753860474, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq8c": ["Drift", {"length": 0.3352000117301941, "tracking_method": "linear"}],
-        "c29096_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c29096_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "daq8d1": ["Drift", {"length": 0.743399977684021, "tracking_method": "linear"}],
-        "st28950": ["Drift", {"length": 0.20319999754428864, "tracking_method": "linear"}],
-        "daq8d2": ["Drift", {"length": 0.21580000221729279, "tracking_method": "linear"}],
-        "st28960": ["Drift", {"length": 0.20319999754428864, "tracking_method": "linear"}],
-        "daq8d3": ["Drift", {"length": 0.930400013923645, "tracking_method": "linear"}],
-        "li28end": ["Marker", {}],
-        "li29beg": ["Marker", {}],
-        "zlin13": ["Marker", {}],
-        "k29_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d10ca": ["Drift", {"length": 2.815700054168701, "tracking_method": "linear"}],
-        "c29146_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c29146_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "d10cb": ["Drift", {"length": 0.22840000689029694, "tracking_method": "linear"}],
-        "q29201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.39081063866615295, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q29301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.4065098166465759, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_3d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q29401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d10cc": ["Drift", {"length": 2.8159000873565674, "tracking_method": "linear"}],
-        "c29446_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c29446_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "d10cd": ["Drift", {"length": 0.2282000035047531, "tracking_method": "linear"}],
-        "q29501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "d10ce": ["Drift", {"length": 2.8160998821258545, "tracking_method": "linear"}],
-        "c29546_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c29546_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "d10cf": ["Drift", {"length": 0.2280000001192093, "tracking_method": "linear"}],
-        "q29601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_6d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q29701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_7d": ["Cavity", {"length": 2.8691999912261963, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq9a": ["Drift", {"length": 0.08110000193119049, "tracking_method": "linear"}],
-        "pk297": ["Marker", {}],
-        "daq9b": ["Drift", {"length": 0.12800000607967377, "tracking_method": "linear"}],
-        "q29801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.4067477583885193, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k29_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k29_8d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q29901": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3893742561340332, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq4a": ["Drift", {"length": 0.25270000100135803, "tracking_method": "linear"}],
-        "p30013": ["Marker", {}],
-        "daq4b": ["Drift", {"length": 0.2029999941587448, "tracking_method": "linear"}],
-        "p30014": ["Marker", {}],
-        "daq4c": ["Drift", {"length": 0.9150000214576721, "tracking_method": "linear"}],
-        "c29956_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c29956_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "daq4d": ["Drift", {"length": 0.2720000147819519, "tracking_method": "linear"}],
-        "pk299": ["Marker", {}],
-        "daq4e": ["Drift", {"length": 0.9100000262260437, "tracking_method": "linear"}],
-        "li29end": ["Marker", {}],
-        "li30beg": ["Marker", {}],
-        "zlin14": ["Marker", {}],
-        "k30_1a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_1b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_1c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_1d": ["Cavity", {"length": 2.1693999767303467, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq10a": ["Drift", {"length": 0.13330000638961792, "tracking_method": "linear"}],
-        "p30143": ["Marker", {}],
-        "daq10b": ["Drift", {"length": 0.2029999941587448, "tracking_method": "linear"}],
-        "p30144": ["Marker", {}],
-        "daq10c": ["Drift", {"length": 0.2150000035762787, "tracking_method": "linear"}],
-        "c30146_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c30146_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "daq10d": ["Drift", {"length": 0.35760000348091125, "tracking_method": "linear"}],
-        "q30201": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.3905400335788727, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k30_2a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_2b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_2c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_2d": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "q30301": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.4062204658985138, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k30_3a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_3b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_3c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_3d": ["Cavity", {"length": 2.1693999767303467, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq10e": ["Drift", {"length": 0.7764999866485596, "tracking_method": "linear"}],
-        "pk303": ["Marker", {}],
-        "daq10f": ["Drift", {"length": 0.1324000060558319, "tracking_method": "linear"}],
-        "q30401": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k30_4a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_4b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_4c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_4d": ["Cavity", {"length": 2.1693999767303467, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq10g": ["Drift", {"length": 0.13009999692440033, "tracking_method": "linear"}],
-        "p30443": ["Marker", {}],
-        "daq10h": ["Drift", {"length": 0.2029999941587448, "tracking_method": "linear"}],
-        "p30444": ["Marker", {}],
-        "daq10i": ["Drift", {"length": 0.20600000023841858, "tracking_method": "linear"}],
-        "c30446_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c30446_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "daq10j": ["Drift", {"length": 0.2370000034570694, "tracking_method": "linear"}],
-        "pk304": ["Marker", {}],
-        "daq10k": ["Drift", {"length": 0.13279999792575836, "tracking_method": "linear"}],
-        "q30501": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3956492841243744, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "k30_5a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_5b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_5c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_5d": ["Cavity", {"length": 2.1693999767303467, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq11a": ["Drift", {"length": 0.13169999420642853, "tracking_method": "linear"}],
-        "p30543": ["Marker", {}],
-        "daq11b": ["Drift", {"length": 0.210999995470047, "tracking_method": "linear"}],
-        "p30544": ["Marker", {}],
-        "daq11c": ["Drift", {"length": 0.210999995470047, "tracking_method": "linear"}],
-        "c30546_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "c30546_aperture": ["Aperture", {"x_max": Infinity, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "daq11d": ["Drift", {"length": 0.15360000729560852, "tracking_method": "linear"}],
-        "q30601": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.395798921585083, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq12": ["Drift", {"length": 0.22859999537467957, "tracking_method": "linear"}],
-        "k30_6a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_6b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_6c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_6d": ["Cavity", {"length": 2.8691999912261963, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq13": ["Drift", {"length": 0.023099999874830246, "tracking_method": "linear"}],
-        "q30701": ["Quadrupole", {"length": 0.10679999738931656, "k1": -0.3962310254573822, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq14": ["Drift", {"length": 0.21299999952316284, "tracking_method": "linear"}],
-        "k30_7a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_7b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_7c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_7d": ["Cavity", {"length": 2.8691999912261963, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq15": ["Drift", {"length": 0.008700000122189522, "tracking_method": "linear"}],
-        "q30801": ["Quadrupole", {"length": 0.10679999738931656, "k1": 0.48059216141700745, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "daq16": ["Drift", {"length": 0.227400004863739, "tracking_method": "linear"}],
-        "k30_8a": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_8b": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "k30_8c": ["Cavity", {"length": 3.044100046157837, "voltage": 0.0, "phase": -0.0, "frequency": 2856000000.0}],
-        "daq17": ["Drift", {"length": 0.061900001019239426, "tracking_method": "linear"}],
-        "li30term": ["Marker", {}],
-        "dbmark29": ["Marker", {}],
-        "endl3": ["Marker", {}],
-        "begclth_0": ["Marker", {}],
-        "bsybeg": ["Marker", {}],
-        "bsy1beg": ["Marker", {}],
-        "dbsy01a": ["Drift", {"length": 0.728600025177002, "tracking_method": "linear"}],
-        "imbsy1": ["Marker", {}],
-        "dbsy01b": ["Drift", {"length": 0.25005000829696655, "tracking_method": "linear"}],
-        "imbsy2": ["Marker", {}],
-        "dbsy01c": ["Drift", {"length": 0.25005000829696655, "tracking_method": "linear"}],
-        "imbsy3": ["Marker", {}],
-        "dbsy01d": ["Drift", {"length": 0.41429999470710754, "tracking_method": "linear"}],
-        "imbsy34": ["Marker", {}],
-        "dbsy01e": ["Drift", {"length": 2.904599905014038, "tracking_method": "linear"}],
-        "imbsy1b": ["Marker", {}],
-        "dbsy01f": ["Drift", {"length": 0.31575000286102295, "tracking_method": "linear"}],
-        "imbsy2b": ["Marker", {}],
-        "dbsy01g": ["Drift", {"length": 0.31575000286102295, "tracking_method": "linear"}],
-        "imbsy3b": ["Marker", {}],
-        "dbsy01h": ["Drift", {"length": 0.7975000143051147, "tracking_method": "linear"}],
-        "fftborgn": ["Marker", {}],
-        "dbsy01i": ["Drift", {"length": 0.018400000408291817, "tracking_method": "linear"}],
-        "s100": ["Marker", {}],
-        "zlin15": ["Marker", {}],
-        "dbsy50a": ["Drift", {"length": 0.5781999826431274, "tracking_method": "linear"}],
-        "ycbsyq1": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dbsy50b": ["Drift", {"length": 1.4345760345458984, "tracking_method": "linear"}],
-        "q50q1": ["Quadrupole", {"length": 0.2630000114440918, "k1": -0.23152229189872742, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbsy02a": ["Drift", {"length": 0.2362239956855774, "tracking_method": "linear"}],
-        "wooddoor": ["Marker", {}],
-        "endclth_0": ["Marker", {}],
-        "begclth_1": ["Marker", {}],
-        "dbsy02b": ["Drift", {"length": 0.2198999971151352, "tracking_method": "linear"}],
-        "bpmbsyq1": ["Marker", {}],
-        "dbsy51a": ["Drift", {"length": 5.021975994110107, "tracking_method": "linear"}],
-        "xcbsyq2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dbsy51b": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "q50q2": ["Quadrupole", {"length": 0.32430198788642883, "k1": 0.10207433253526688, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbsy52a": ["Drift", {"length": 0.07914900034666061, "tracking_method": "linear"}],
-        "bpmbsyq2": ["Marker", {}],
-        "dbsy52b": ["Drift", {"length": 1.7995890378952026, "tracking_method": "linear"}],
-        "endclth_1": ["Marker", {}],
-        "begclth_2": ["Marker", {}],
-        "dbrcusdc1a": ["Drift", {"length": 0.13455000519752502, "tracking_method": "linear"}],
-        "dbrcusdc1b": ["Drift", {"length": 0.13455000519752502, "tracking_method": "linear"}],
-        "dckdc1": ["Drift", {"length": 0.3521620035171509, "tracking_method": "linear"}],
-        "dbkrcusa": ["Drift", {"length": 0.5300499796867371, "tracking_method": "linear"}],
-        "dbkrcusb": ["Drift", {"length": 0.5300499796867371, "tracking_method": "linear"}],
-        "dckdc2": ["Drift", {"length": 0.3521620035171509, "tracking_method": "linear"}],
-        "dbrcusdc2a": ["Drift", {"length": 0.13455000519752502, "tracking_method": "linear"}],
-        "dbrcusdc2b": ["Drift", {"length": 0.13455000519752502, "tracking_method": "linear"}],
-        "dcusblra": ["Drift", {"length": 4.574337959289551, "tracking_method": "linear"}],
-        "bpmcus": ["BPM", {"is_active": true}],
-        "dcusblrb": ["Drift", {"length": 10.951299667358398, "tracking_method": "linear"}],
-        "dblrcusa": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "dblrcusb": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "dbsy52c": ["Drift", {"length": 32.67631530761719, "tracking_method": "linear"}],
-        "dbxsp1ha": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "dbxsp1hb": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "bsy1end": ["Marker", {}],
-        "endclth_2": ["Marker", {}],
-        "begbsyh_1": ["Marker", {}],
-        "dbsy52d": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "q50q3": ["Quadrupole", {"length": 0.2865079939365387, "k1": 0.38484084606170654, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbsy53a": ["Drift", {"length": 0.09169600158929825, "tracking_method": "linear"}],
-        "bpmbsyq3": ["BPM", {"is_active": true}],
-        "rfbbsyq3": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dbsy53b": ["Drift", {"length": 0.6107050180435181, "tracking_method": "linear"}],
-        "dbsy53c": ["Drift", {"length": 0.7799450159072876, "tracking_method": "linear"}],
-        "xcbsyq3": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dbsy53d": ["Drift", {"length": 2.0176539421081543, "tracking_method": "linear"}],
-        "ycbsyq4": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dbsy53f": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "q4": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.219396710395813, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbsy53ga": ["Drift", {"length": 0.9129300117492676, "tracking_method": "linear"}],
-        "pcbsy3": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "dbsy53gb": ["Drift", {"length": 0.22357000410556793, "tracking_method": "linear"}],
-        "mrgaline": ["Marker", {}],
-        "endbsyh_1": ["Marker", {}],
-        "begbsyh_2": ["Marker", {}],
-        "dbkrapm1a": ["Drift", {"length": 0.5274994969367981, "tracking_method": "linear"}],
-        "dbkrapm1b": ["Drift", {"length": 0.5274994969367981, "tracking_method": "linear"}],
-        "dzapm1": ["Drift", {"length": 0.20634886622428894, "tracking_method": "linear"}],
-        "pcapm1_drift": ["Drift", {"length": 0.18240000307559967, "tracking_method": "linear"}],
-        "pcapm1_aperture": ["Aperture", {"x_max": 0.044449999928474426, "y_max": 0.00634999992325902, "shape": "elliptical", "is_active": true}],
-        "dbkrapm2a": ["Drift", {"length": 0.5274954438209534, "tracking_method": "linear"}],
-        "dbkrapm2b": ["Drift", {"length": 0.5274954438209534, "tracking_method": "linear"}],
-        "dzapm2a": ["Drift", {"length": 0.10317272692918777, "tracking_method": "linear"}],
-        "xcapm2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ycapm2": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dzapm2b": ["Drift", {"length": 0.10317272692918777, "tracking_method": "linear"}],
-        "pcapm2_drift": ["Drift", {"length": 0.18240000307559967, "tracking_method": "linear"}],
-        "pcapm2_aperture": ["Aperture", {"x_max": 0.044449999928474426, "y_max": 0.00634999992325902, "shape": "elliptical", "is_active": true}],
-        "dzapm2": ["Drift", {"length": 0.20634545385837555, "tracking_method": "linear"}],
-        "dbkrapm3a": ["Drift", {"length": 0.5274873971939087, "tracking_method": "linear"}],
-        "dbkrapm3b": ["Drift", {"length": 0.5274873971939087, "tracking_method": "linear"}],
-        "dzapm3": ["Drift", {"length": 0.2063397616147995, "tracking_method": "linear"}],
-        "pcapm3_drift": ["Drift", {"length": 0.18240000307559967, "tracking_method": "linear"}],
-        "pcapm3_aperture": ["Aperture", {"x_max": 0.044449999928474426, "y_max": 0.00634999992325902, "shape": "elliptical", "is_active": true}],
-        "dbkrapm4a": ["Drift", {"length": 0.5274752974510193, "tracking_method": "linear"}],
-        "dbkrapm4b": ["Drift", {"length": 0.5274752974510193, "tracking_method": "linear"}],
-        "dzapm4": ["Drift", {"length": 0.2063317894935608, "tracking_method": "linear"}],
-        "pcapm4_drift": ["Drift", {"length": 0.18240000307559967, "tracking_method": "linear"}],
-        "pcapm4_aperture": ["Aperture", {"x_max": 0.044449999928474426, "y_max": 0.00634999992325902, "shape": "elliptical", "is_active": true}],
-        "dza01": ["Drift", {"length": 0.19716443121433258, "tracking_method": "linear"}],
-        "dza02": ["Drift", {"length": 2.824061870574951, "tracking_method": "linear"}],
-        "pcbsyh": ["Drift", {"length": 0.44999998807907104, "tracking_method": "linear"}],
-        "dbsy53h": ["Drift", {"length": 23.390478134155273, "tracking_method": "linear"}],
-        "q5": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.16570885479450226, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dbsy54a": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "xcbsyq5": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dbsy54b": ["Drift", {"length": 3.2245399951934814, "tracking_method": "linear"}],
-        "dbsy54c": ["Drift", {"length": 15.535515785217285, "tracking_method": "linear"}],
-        "q6": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.11356910318136215, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "drfb": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "rfbbsyq6": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dbsy55a": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "ycbsyq6": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dbsy55b": ["Drift", {"length": 4.226741790771484, "tracking_method": "linear"}],
-        "pc90_drift": ["Drift", {"length": 0.4536440074443817, "tracking_method": "linear"}],
-        "pc90_aperture": ["Aperture", {"x_max": 0.010200000368058681, "y_max": 0.010200000368058681, "shape": "elliptical", "is_active": true}],
-        "dbsy55c": ["Drift", {"length": 8.01602840423584, "tracking_method": "linear"}],
-        "pcbsy4": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "dbsy55d": ["Drift", {"length": 6.466827869415283, "tracking_method": "linear"}],
-        "pc119_drift": ["Drift", {"length": 0.4536440074443817, "tracking_method": "linear"}],
-        "pc119_aperture": ["Aperture", {"x_max": 0.010200000368058681, "y_max": 0.010200000368058681, "shape": "elliptical", "is_active": true}],
-        "dbsy55e": ["Drift", {"length": 1.4463779926300049, "tracking_method": "linear"}],
-        "d2": ["Drift", {"length": 0.4300000071525574, "tracking_method": "linear"}],
-        "dm3": ["Drift", {"length": 0.8438000082969666, "tracking_method": "linear"}],
-        "st60": ["Drift", {"length": 0.7599999904632568, "tracking_method": "linear"}],
-        "dm4a": ["Drift", {"length": 0.4410000145435333, "tracking_method": "linear"}],
-        "dm60": ["Marker", {}],
-        "dm4b": ["Drift", {"length": 5.192866802215576, "tracking_method": "linear"}],
-        "cc31beg": ["Marker", {}],
-        "bcx311": ["Drift", {"length": 0.3499999940395355, "tracking_method": "linear"}],
-        "dcc31o": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "bcx312": ["Drift", {"length": 0.3499999940395355, "tracking_method": "linear"}],
-        "dcc31i": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "bcx313": ["Drift", {"length": 0.3499999940395355, "tracking_method": "linear"}],
-        "bcx314": ["Drift", {"length": 0.3499999940395355, "tracking_method": "linear"}],
-        "cc31end": ["Marker", {}],
-        "dm4c": ["Drift", {"length": 0.30113300681114197, "tracking_method": "linear"}],
-        "cxq6_drift": ["Drift", {"length": 0.05999999865889549, "tracking_method": "linear"}],
-        "cxq6_aperture": ["Aperture", {"x_max": 0.0017000000225380063, "y_max": 0.019999999552965164, "shape": "rectangular", "is_active": true}],
-        "dm4da": ["Drift", {"length": 0.27684998512268066, "tracking_method": "linear"}],
-        "pcbsy5": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "dm4db": ["Drift", {"length": 0.7985169887542725, "tracking_method": "linear"}],
-        "xca0": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dxca0": ["Drift", {"length": 0.3100000023841858, "tracking_method": "linear"}],
-        "yca0": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dyca0": ["Drift", {"length": 0.509020984172821, "tracking_method": "linear"}],
-        "st61": ["Drift", {"length": 0.7599999904632568, "tracking_method": "linear"}],
-        "dm5": ["Drift", {"length": 0.7909790277481079, "tracking_method": "linear"}],
-        "qa0": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.10921010375022888, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dm6": ["Drift", {"length": 0.5675879716873169, "tracking_method": "linear"}],
-        "dmoni": ["Drift", {"length": 0.009525000117719173, "tracking_method": "linear"}],
-        "muwall": ["Marker", {}],
-        "dwalla": ["Drift", {"length": 1.840975046157837, "tracking_method": "linear"}],
-        "dumpbsyh": ["Marker", {}],
-        "dwallb": ["Drift", {"length": 14.923025131225586, "tracking_method": "linear"}],
-        "bsyend": ["Marker", {}],
-        "rwwake3h": ["Marker", {}],
-        "endbsyh_2": ["Marker", {}],
-        "begltuh": ["Marker", {}],
-        "dycvm1": ["Drift", {"length": 0.4000000059604645, "tracking_method": "linear"}],
-        "ycvm1": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqvm1": ["Drift", {"length": 0.3400000035762787, "tracking_method": "linear"}],
-        "qvm1": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.3374372720718384, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dqvm2a": ["Drift", {"length": 0.2504599988460541, "tracking_method": "linear"}],
-        "xcvm2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqvm2b": ["Drift", {"length": 0.24954000115394592, "tracking_method": "linear"}],
-        "qvm2": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.23657725751399994, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dwsvm2a": ["Drift", {"length": 0.2541399896144867, "tracking_method": "linear"}],
-        "wsvm2": ["Marker", {}],
-        "dwsvm2b": ["Drift", {"length": 0.2458599954843521, "tracking_method": "linear"}],
-        "vbin": ["Marker", {}],
-        "by1": ["Dipole", {"length": 1.024999976158142, "angle": -0.002334257122129202, "k1": 0.0, "dipole_e1": -0.001167128561064601, "dipole_e2": -0.001167128561064601, "tilt": 1.5707963705062866, "gap": 0.03492499887943268, "gap_exit": 0.03492499887943268, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dvb1": ["Drift", {"length": 7.375, "tracking_method": "linear"}],
-        "qvb1": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.4222303628921509, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d40cmc": ["Drift", {"length": 0.4000000059604645, "tracking_method": "linear"}],
-        "ycvb1": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dvb2m80cm": ["Drift", {"length": 3.200000047683716, "tracking_method": "linear"}],
-        "xcvb2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qvb2": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.4222303628921509, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dvb2ha": ["Drift", {"length": 0.8704320192337036, "tracking_method": "linear"}],
-        "pc01": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm01": ["Marker", {}],
-        "dvb2hb": ["Drift", {"length": 3.066067934036255, "tracking_method": "linear"}],
-        "qvb3": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.4222303628921509, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ycvb3": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dvb1m40cm": ["Drift", {"length": 6.974999904632568, "tracking_method": "linear"}],
-        "by2": ["Dipole", {"length": 1.024999976158142, "angle": -0.002334257122129202, "k1": 0.0, "dipole_e1": -0.001167128561064601, "dipole_e2": -0.001167128561064601, "tilt": 1.5707963705062866, "gap": 0.03492499887943268, "gap_exit": 0.03492499887943268, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cntlt1h": ["Marker", {}],
-        "vbout": ["Marker", {}],
-        "dvb25cmc": ["Drift", {"length": 0.25, "tracking_method": "linear"}],
-        "xcvm3": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d25cm": ["Drift", {"length": 0.25, "tracking_method": "linear"}],
-        "qvm3": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.7151508331298828, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dvbem25cm": ["Drift", {"length": 0.25, "tracking_method": "linear"}],
-        "ycvm4": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qvm4": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.6816501617431641, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dvbem15cm": ["Drift", {"length": 0.1726129949092865, "tracking_method": "linear"}],
-        "im31": ["Marker", {}],
-        "d10cmb": ["Drift", {"length": 0.10648690164089203, "tracking_method": "linear"}],
-        "imbcs1": ["Marker", {}],
-        "d25cma": ["Drift", {"length": 0.22090010344982147, "tracking_method": "linear"}],
-        "mm1": ["Marker", {}],
-        "dbmark34": ["Marker", {}],
-        "bx31": ["Dipole", {"length": 2.6230082511901855, "angle": 0.008726643398404121, "k1": 0.0, "dipole_e1": 0.004363321699202061, "dipole_e2": 0.004363321699202061, "tilt": 0.0, "gap": 0.01724660024046898, "gap_exit": 0.01724660024046898, "fringe_integral": 0.5236999988555908, "fringe_integral_exit": 0.5236999988555908, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ddl10wa": ["Drift", {"length": 0.986719012260437, "tracking_method": "linear"}],
-        "pc02": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm02": ["Marker", {}],
-        "ddl10wb": ["Drift", {"length": 10.944183349609375, "tracking_method": "linear"}],
-        "dwsdl31a": ["Drift", {"length": 0.09623699635267258, "tracking_method": "linear"}],
-        "wsdl31": ["Marker", {}],
-        "dwsdl31b": ["Drift", {"length": 0.15376299619674683, "tracking_method": "linear"}],
-        "ddl10x": ["Drift", {"length": 0.12631399929523468, "tracking_method": "linear"}],
-        "xcdl1": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d31a": ["Drift", {"length": 0.5604649782180786, "tracking_method": "linear"}],
-        "qdl31": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.4371839761734009, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbdl1": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "d31b": ["Drift", {"length": 0.36043810844421387, "tracking_method": "linear"}],
-        "ycdl1": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d32cmb": ["Drift", {"length": 0.6638033986091614, "tracking_method": "linear"}],
-        "cedl1_drift": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "cedl1_aperture": ["Aperture", {"x_max": 0.002300000051036477, "y_max": 0.019999999552965164, "shape": "rectangular", "is_active": true}],
-        "d31c": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "wig1h": ["Drift", {"length": 0.24400000274181366, "tracking_method": "linear"}],
-        "dwgh": ["Drift", {"length": 0.12652499973773956, "tracking_method": "linear"}],
-        "wig2h": ["Drift", {"length": 0.4880000054836273, "tracking_method": "linear"}],
-        "wig3h": ["Drift", {"length": 0.24400000274181366, "tracking_method": "linear"}],
-        "cntwigh": ["Marker", {}],
-        "ddl10em80cma": ["Drift", {"length": 3.703274965286255, "tracking_method": "linear"}],
-        "pc22": ["Drift", {"length": 0.20319999754428864, "tracking_method": "linear"}],
-        "ddl10em80cmb": ["Drift", {"length": 5.1214118003845215, "tracking_method": "linear"}],
-        "cybx32_drift": ["Drift", {"length": 0.05999999865889549, "tracking_method": "linear"}],
-        "cybx32_aperture": ["Aperture", {"x_max": 0.019999999552965164, "y_max": 0.001500000013038516, "shape": "rectangular", "is_active": true}],
-        "dcb32": ["Drift", {"length": 0.8100000023841858, "tracking_method": "linear"}],
-        "bx32": ["Dipole", {"length": 2.6230082511901855, "angle": 0.008726643398404121, "k1": 0.0, "dipole_e1": 0.004363321699202061, "dipole_e2": 0.004363321699202061, "tilt": 0.0, "gap": 0.01724660024046898, "gap_exit": 0.01724660024046898, "fringe_integral": 0.5236999988555908, "fringe_integral_exit": 0.5236999988555908, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cntlt2h": ["Marker", {}],
-        "ddl20e": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "qt11": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ddl30em40cm": ["Drift", {"length": 0.5099869966506958, "tracking_method": "linear"}],
-        "xcqt12": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d40cmb": ["Drift", {"length": 0.4900130033493042, "tracking_method": "linear"}],
-        "qt12": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.839614748954773, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ycqt12": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qt13": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ss1": ["Marker", {}],
-        "dx33a": ["Drift", {"length": 1.4154000282287598, "tracking_method": "linear"}],
-        "cc32beg": ["Marker", {}],
-        "bcx321": ["Dipole", {"length": 0.3500059247016907, "angle": 0.01008035708218813, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.01008035708218813, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcc32o": ["Drift", {"length": 0.20001016557216644, "tracking_method": "linear"}],
-        "bcx322": ["Dipole", {"length": 0.3500059247016907, "angle": -0.01008035708218813, "k1": 0.0, "dipole_e1": -0.01008035708218813, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcc32i": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "bcx323": ["Dipole", {"length": 0.3500059247016907, "angle": -0.01008035708218813, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.01008035708218813, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bcx324": ["Dipole", {"length": 0.3500059247016907, "angle": 0.01008035708218813, "k1": 0.0, "dipole_e1": 0.01008035708218813, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cc32end": ["Marker", {}],
-        "dx33b": ["Drift", {"length": 0.38563698530197144, "tracking_method": "linear"}],
-        "pc03": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm03": ["Marker", {}],
-        "ddl1ab": ["Drift", {"length": 4.049038887023926, "tracking_method": "linear"}],
-        "bykik1": ["Dipole", {"length": 1.0600999593734741, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 1.5707963705062866, "gap": 0.05079999938607216, "gap_exit": 0.05079999938607216, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ddl1d": ["Drift", {"length": 0.07917600125074387, "tracking_method": "linear"}],
-        "bykik2": ["Dipole", {"length": 1.0600999593734741, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 1.5707963705062866, "gap": 0.05079999938607216, "gap_exit": 0.05079999938607216, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ddl1e": ["Drift", {"length": 4.891592025756836, "tracking_method": "linear"}],
-        "xcdl2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d32a": ["Drift", {"length": 0.4704599976539612, "tracking_method": "linear"}],
-        "qdl32": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.4371839761734009, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d32b": ["Drift", {"length": 0.4704599976539612, "tracking_method": "linear"}],
-        "ycdl2": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dsplr": ["Drift", {"length": 0.43035998940467834, "tracking_method": "linear"}],
-        "spoiler": ["Marker", {}],
-        "ddl1cm40cm": ["Drift", {"length": 5.295199871063232, "tracking_method": "linear"}],
-        "tdkik": ["Drift", {"length": 0.6096000075340271, "tracking_method": "linear"}],
-        "d30cma": ["Drift", {"length": 0.257425993680954, "tracking_method": "linear"}],
-        "pctdkik1_drift": ["Drift", {"length": 0.8127999901771545, "tracking_method": "linear"}],
-        "pctdkik1_aperture": ["Aperture", {"x_max": 0.011112499982118607, "y_max": 0.011112499982118607, "shape": "elliptical", "is_active": true}],
-        "dpc1": ["Drift", {"length": 0.2666969895362854, "tracking_method": "linear"}],
-        "pctdkik2_drift": ["Drift", {"length": 0.8127999901771545, "tracking_method": "linear"}],
-        "pctdkik2_aperture": ["Aperture", {"x_max": 0.011112499982118607, "y_max": 0.011112499982118607, "shape": "elliptical", "is_active": true}],
-        "dpc2": ["Drift", {"length": 0.2666969895362854, "tracking_method": "linear"}],
-        "pctdkik3_drift": ["Drift", {"length": 0.8127999901771545, "tracking_method": "linear"}],
-        "pctdkik3_aperture": ["Aperture", {"x_max": 0.011112499982118607, "y_max": 0.011112499982118607, "shape": "elliptical", "is_active": true}],
-        "dpc3": ["Drift", {"length": 0.2666969895362854, "tracking_method": "linear"}],
-        "pctdkik4_drift": ["Drift", {"length": 0.8127999901771545, "tracking_method": "linear"}],
-        "pctdkik4_aperture": ["Aperture", {"x_max": 0.011112499982118607, "y_max": 0.011112499982118607, "shape": "elliptical", "is_active": true}],
-        "dpc4": ["Drift", {"length": 0.1999099999666214, "tracking_method": "linear"}],
-        "dspontua": ["Drift", {"length": 0.75, "tracking_method": "linear"}],
-        "dspontub": ["Drift", {"length": 0.75, "tracking_method": "linear"}],
-        "ddl1dm30cm": ["Drift", {"length": 0.11693199723958969, "tracking_method": "linear"}],
-        "dx34a": ["Drift", {"length": 0.12300000339746475, "tracking_method": "linear"}],
-        "cc35beg": ["Marker", {}],
-        "bcx351": ["Dipole", {"length": 0.3500029742717743, "angle": 0.0071278284303843975, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0071278284303843975, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcc35o": ["Drift", {"length": 0.20000508427619934, "tracking_method": "linear"}],
-        "bcx352": ["Dipole", {"length": 0.3500029742717743, "angle": -0.0071278284303843975, "k1": 0.0, "dipole_e1": -0.0071278284303843975, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcc35i": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "bcx353": ["Dipole", {"length": 0.3500029742717743, "angle": -0.0071278284303843975, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.0071278284303843975, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bcx354": ["Dipole", {"length": 0.3500029742717743, "angle": 0.0071278284303843975, "k1": 0.0, "dipole_e1": 0.0071278284303843975, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cc35end": ["Marker", {}],
-        "dx34b": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "ycqt21": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddl20": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "qt21": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "xcqt22": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qt22": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.839614748954773, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d46cm": ["Drift", {"length": 0.4699999988079071, "tracking_method": "linear"}],
-        "cxqt22_drift": ["Drift", {"length": 0.05999999865889549, "tracking_method": "linear"}],
-        "cxqt22_aperture": ["Aperture", {"x_max": 0.0015999999595806003, "y_max": 0.019999999552965164, "shape": "rectangular", "is_active": true}],
-        "qt23": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dl23beg": ["Marker", {}],
-        "bx35": ["Dipole", {"length": 2.6230082511901855, "angle": -0.008726643398404121, "k1": 0.0, "dipole_e1": -0.004363321699202061, "dipole_e2": -0.004363321699202061, "tilt": 0.0, "gap": 0.01724660024046898, "gap_exit": 0.01724660024046898, "fringe_integral": 0.5236999988555908, "fringe_integral_exit": 0.5236999988555908, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcq31aa": ["Drift", {"length": 1.3509670495986938, "tracking_method": "linear"}],
-        "pc04": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm04": ["Marker", {}],
-        "dcq31ab": ["Drift", {"length": 4.622714996337891, "tracking_method": "linear"}],
-        "cq31": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dcq31ba": ["Drift", {"length": 0.8270940184593201, "tracking_method": "linear"}],
-        "pc42": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm42": ["Marker", {}],
-        "dcq31bb": ["Drift", {"length": 4.9210638999938965, "tracking_method": "linear"}],
-        "otr30": ["Marker", {}],
-        "d29cma": ["Drift", {"length": 0.5843420028686523, "tracking_method": "linear"}],
-        "xcdl3": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d33a": ["Drift", {"length": 0.38999998569488525, "tracking_method": "linear"}],
-        "qdl33": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.4371839761734009, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d33b": ["Drift", {"length": 0.3199999928474426, "tracking_method": "linear"}],
-        "ycdl3": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d32cmd": ["Drift", {"length": 0.9042415022850037, "tracking_method": "linear"}],
-        "cedl3_drift": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "cedl3_aperture": ["Aperture", {"x_max": 0.002300000051036477, "y_max": 0.019999999552965164, "shape": "rectangular", "is_active": true}],
-        "dcq32a": ["Drift", {"length": 5.4817585945129395, "tracking_method": "linear"}],
-        "cq32": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dcq32b": ["Drift", {"length": 5.167178630828857, "tracking_method": "linear"}],
-        "cybx36_drift": ["Drift", {"length": 0.05999999865889549, "tracking_method": "linear"}],
-        "cybx36_aperture": ["Aperture", {"x_max": 0.019999999552965164, "y_max": 0.001500000013038516, "shape": "rectangular", "is_active": true}],
-        "dcb36": ["Drift", {"length": 0.8100000023841858, "tracking_method": "linear"}],
-        "bx36": ["Dipole", {"length": 2.6230082511901855, "angle": -0.008726643398404121, "k1": 0.0, "dipole_e1": -0.004363321699202061, "dipole_e2": -0.004363321699202061, "tilt": 0.0, "gap": 0.01724660024046898, "gap_exit": 0.01724660024046898, "fringe_integral": 0.5236999988555908, "fringe_integral_exit": 0.5236999988555908, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cntlt3h": ["Marker", {}],
-        "qt31": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ddl30em40cma": ["Drift", {"length": 0.5104600191116333, "tracking_method": "linear"}],
-        "xcqt32": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d40cmd": ["Drift", {"length": 0.4895400106906891, "tracking_method": "linear"}],
-        "qt32": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.839614748954773, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d40cme": ["Drift", {"length": 0.5004600286483765, "tracking_method": "linear"}],
-        "ycqt32": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddl30em40cmb": ["Drift", {"length": 0.4995400011539459, "tracking_method": "linear"}],
-        "qt33": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ss3": ["Marker", {}],
-        "d37a": ["Drift", {"length": 0.27031999826431274, "tracking_method": "linear"}],
-        "cc36beg": ["Marker", {}],
-        "bcx361": ["Dipole", {"length": 0.3500029742717743, "angle": 0.0071278284303843975, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0071278284303843975, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcc36o": ["Drift", {"length": 0.20000508427619934, "tracking_method": "linear"}],
-        "bcx362": ["Dipole", {"length": 0.3500029742717743, "angle": -0.0071278284303843975, "k1": 0.0, "dipole_e1": -0.0071278284303843975, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dcc36i": ["Drift", {"length": 0.20000000298023224, "tracking_method": "linear"}],
-        "bcx363": ["Dipole", {"length": 0.3500029742717743, "angle": -0.0071278284303843975, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.0071278284303843975, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bcx364": ["Dipole", {"length": 0.3500029742717743, "angle": 0.0071278284303843975, "k1": 0.0, "dipole_e1": 0.0071278284303843975, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.8435999751091003, "fringe_integral_exit": 0.8435999751091003, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cc36end": ["Marker", {}],
-        "d37ba": ["Drift", {"length": 0.12488999962806702, "tracking_method": "linear"}],
-        "pc43": ["Drift", {"length": 0.20319999754428864, "tracking_method": "linear"}],
-        "btm43": ["Marker", {}],
-        "d37bb": ["Drift", {"length": 0.3245899975299835, "tracking_method": "linear"}],
-        "imbcs2": ["Marker", {}],
-        "d37c": ["Drift", {"length": 1.2619099617004395, "tracking_method": "linear"}],
-        "pc05": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm05": ["Marker", {}],
-        "d37d": ["Drift", {"length": 7.697981357574463, "tracking_method": "linear"}],
-        "wsdl4": ["Marker", {}],
-        "d37e": ["Drift", {"length": 1.0975228548049927, "tracking_method": "linear"}],
-        "dchirpv": ["Drift", {"length": 2.0, "tracking_method": "linear"}],
-        "d37f": ["Drift", {"length": 0.5102658271789551, "tracking_method": "linear"}],
-        "qdl34": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.4371839761734009, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "d38a": ["Drift", {"length": 0.5098704695701599, "tracking_method": "linear"}],
-        "dchirph": ["Drift", {"length": 2.0, "tracking_method": "linear"}],
-        "d38b": ["Drift", {"length": 0.6091175079345703, "tracking_method": "linear"}],
-        "xcdl4": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d38c": ["Drift", {"length": 0.5407059192657471, "tracking_method": "linear"}],
-        "ycdl4": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d38da": ["Drift", {"length": 7.151035785675049, "tracking_method": "linear"}],
-        "pc06": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm06": ["Marker", {}],
-        "d38db": ["Drift", {"length": 4.67995023727417, "tracking_method": "linear"}],
-        "qt41": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ddl30em40cmc": ["Drift", {"length": 0.574999988079071, "tracking_method": "linear"}],
-        "xcqt42": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d40cmf": ["Drift", {"length": 0.42500001192092896, "tracking_method": "linear"}],
-        "qt42": ["Quadrupole", {"length": 0.4609200060367584, "k1": 0.839614748954773, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "ycqt42": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qt43": ["Quadrupole", {"length": 0.4609200060367584, "k1": -0.42093783617019653, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "mm2": ["Marker", {}],
-        "d25cmb": ["Drift", {"length": 0.26269999146461487, "tracking_method": "linear"}],
-        "im36": ["Marker", {}],
-        "d25cmc": ["Drift", {"length": 0.23729999363422394, "tracking_method": "linear"}],
-        "dmm1m90cm": ["Drift", {"length": 1.2004599571228027, "tracking_method": "linear"}],
-        "ycem1": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dem1a": ["Drift", {"length": 0.3700000047683716, "tracking_method": "linear"}],
-        "qem1": ["Quadrupole", {"length": 0.3199999928474426, "k1": -0.3908277451992035, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dem1c": ["Drift", {"length": 4.140920162200928, "tracking_method": "linear"}],
-        "qem2": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.43221572041511536, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dem2b": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "xcem2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dmm3ma": ["Drift", {"length": 4.362410068511963, "tracking_method": "linear"}],
-        "pc07": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm07": ["Marker", {}],
-        "dmm3mb": ["Drift", {"length": 6.845009803771973, "tracking_method": "linear"}],
-        "ycem3": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dem3a": ["Drift", {"length": 0.3700000047683716, "tracking_method": "linear"}],
-        "qem3": ["Quadrupole", {"length": 0.3199999928474426, "k1": -0.5934339761734009, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dem3b": ["Drift", {"length": 0.773298978805542, "tracking_method": "linear"}],
-        "qem3v": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dmm4m90cm": ["Drift", {"length": 2.7596209049224854, "tracking_method": "linear"}],
-        "xcem4": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dem4a": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "qem4": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.420485258102417, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbem4": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dmm5a": ["Drift", {"length": 0.6905699968338013, "tracking_method": "linear"}],
-        "pc08": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm08": ["Marker", {}],
-        "dmm5b": ["Drift", {"length": 1.1163899898529053, "tracking_method": "linear"}],
-        "dbmark36": ["Marker", {}],
-        "ws31": ["Marker", {}],
-        "d40cm": ["Drift", {"length": 0.4000000059604645, "tracking_method": "linear"}],
-        "de3ma": ["Drift", {"length": 5.430109977722168, "tracking_method": "linear"}],
-        "pc09": ["Drift", {"length": 0.06350000202655792, "tracking_method": "linear"}],
-        "btm09": ["Marker", {}],
-        "de3mb": ["Drift", {"length": 2.4422667026519775, "tracking_method": "linear"}],
-        "xce31": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqea": ["Drift", {"length": 0.4259999990463257, "tracking_method": "linear"}],
-        "qe31": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.40275320410728455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dqebx": ["Drift", {"length": 0.7961434721946716, "tracking_method": "linear"}],
-        "dcx31": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "dqebx2": ["Drift", {"length": 7.4857330322265625, "tracking_method": "linear"}],
-        "de3a": ["Drift", {"length": 8.725876808166504, "tracking_method": "linear"}],
-        "yce32": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqeaa": ["Drift", {"length": 0.4359999895095825, "tracking_method": "linear"}],
-        "qe32": ["Quadrupole", {"length": 0.1080000028014183, "k1": -0.40275320410728455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbe32": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dqeby1": ["Drift", {"length": 0.5961434841156006, "tracking_method": "linear"}],
-        "dcy32": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "dqeby2": ["Drift", {"length": 7.885733127593994, "tracking_method": "linear"}],
-        "ws32": ["Marker", {}],
-        "de3m80cmb": ["Drift", {"length": 7.905876636505127, "tracking_method": "linear"}],
-        "xce33": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqeab": ["Drift", {"length": 0.4560000002384186, "tracking_method": "linear"}],
-        "qe33": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.40275320410728455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dqeca": ["Drift", {"length": 7.9507269859313965, "tracking_method": "linear"}],
-        "yagpsi": ["Marker", {}],
-        "dqecb": ["Drift", {"length": 0.8111496567726135, "tracking_method": "linear"}],
-        "otr33": ["Marker", {}],
-        "de3m40cm": ["Drift", {"length": 8.33587646484375, "tracking_method": "linear"}],
-        "yce34": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qe34": ["Quadrupole", {"length": 0.1080000028014183, "k1": -0.40275320410728455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbe34": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dqec1": ["Drift", {"length": 8.56187629699707, "tracking_method": "linear"}],
-        "ws33": ["Marker", {}],
-        "de3m80cm": ["Drift", {"length": 7.755876541137695, "tracking_method": "linear"}],
-        "xce35": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqeac": ["Drift", {"length": 0.6060000061988831, "tracking_method": "linear"}],
-        "qe35": ["Quadrupole", {"length": 0.1080000028014183, "k1": 0.40275320410728455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dcx35": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "de3": ["Drift", {"length": 8.73587703704834, "tracking_method": "linear"}],
-        "yce36": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "qe36": ["Quadrupole", {"length": 0.1080000028014183, "k1": -0.40275320410728455, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbe36": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dcy36": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "ws34": ["Marker", {}],
-        "d40cmg": ["Drift", {"length": 0.3682999908924103, "tracking_method": "linear"}],
-        "dws35": ["Marker", {}],
-        "d40cmh": ["Drift", {"length": 0.031700000166893005, "tracking_method": "linear"}],
-        "du1m80cma": ["Drift", {"length": 0.1651500016450882, "tracking_method": "linear"}],
-        "dws36": ["Marker", {}],
-        "du1m80cmb": ["Drift", {"length": 4.384850025177002, "tracking_method": "linear"}],
-        "dcx37": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "d32cmc": ["Drift", {"length": 0.30046001076698303, "tracking_method": "linear"}],
-        "xcum1": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dum1a": ["Drift", {"length": 0.49000000953674316, "tracking_method": "linear"}],
-        "qum1": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.2727414071559906, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dum1b": ["Drift", {"length": 0.4704599976539612, "tracking_method": "linear"}],
-        "d32cm": ["Drift", {"length": 0.3199999928474426, "tracking_method": "linear"}],
-        "du2m120cm": ["Drift", {"length": 4.730000019073486, "tracking_method": "linear"}],
-        "dcy38": ["Drift", {"length": 0.07999999821186066, "tracking_method": "linear"}],
-        "d32cma": ["Drift", {"length": 0.4204599857330322, "tracking_method": "linear"}],
-        "ycum2": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dum2a": ["Drift", {"length": 0.3700000047683716, "tracking_method": "linear"}],
-        "qum2": ["Quadrupole", {"length": 0.3199999928474426, "k1": -0.2706012725830078, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dum2b": ["Drift", {"length": 0.4704599976539612, "tracking_method": "linear"}],
-        "du3m80cm": ["Drift", {"length": 7.290460109710693, "tracking_method": "linear"}],
-        "xcum3": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dum3a": ["Drift", {"length": 0.3799999952316284, "tracking_method": "linear"}],
-        "qum3": ["Quadrupole", {"length": 0.3199999928474426, "k1": 0.27876266837120056, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dum3b": ["Drift", {"length": 0.4704599976539612, "tracking_method": "linear"}],
-        "d40cma": ["Drift", {"length": 1.807939052581787, "tracking_method": "linear"}],
-        "eoblm": ["Marker", {}],
-        "du4m120cm": ["Drift", {"length": 1.3625210523605347, "tracking_method": "linear"}],
-        "ycum4": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dum4a": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "qum4": ["Quadrupole", {"length": 0.3199999928474426, "k1": -0.247470885515213, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dum4b": ["Drift", {"length": 0.5974599719047546, "tracking_method": "linear"}],
-        "rfb07": ["Marker", {}],
-        "du5m80cm": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "imundi": ["Marker", {}],
-        "d40cmwa": ["Drift", {"length": 0.25154349207878113, "tracking_method": "linear"}],
-        "bltof": ["Marker", {}],
-        "d40cmwb": ["Drift", {"length": 0.1400420069694519, "tracking_method": "linear"}],
-        "muhwall1": ["Marker", {}],
-        "duhwall1": ["Drift", {"length": 0.2508249878883362, "tracking_method": "linear"}],
-        "duhvesta": ["Drift", {"length": 1.6056840419769287, "tracking_method": "linear"}],
-        "rfb08": ["Marker", {}],
-        "duhvestb": ["Drift", {"length": 0.40349099040031433, "tracking_method": "linear"}],
-        "muhwall2": ["Marker", {}],
-        "duhwall2": ["Drift", {"length": 0.2508249878883362, "tracking_method": "linear"}],
-        "dw2tdund": ["Drift", {"length": 0.20153699815273285, "tracking_method": "linear"}],
-        "dtdund1": ["Drift", {"length": 0.8558530211448669, "tracking_method": "linear"}],
-        "tdund": ["Marker", {}],
-        "dtdund2": ["Drift", {"length": 0.34785300493240356, "tracking_method": "linear"}],
-        "dpcmuon": ["Drift", {"length": 0.03149800002574921, "tracking_method": "linear"}],
-        "pcmuon_drift": ["Drift", {"length": 1.1684000492095947, "tracking_method": "linear"}],
-        "pcmuon_aperture": ["Aperture", {"x_max": 0.00215999991632998, "y_max": 0.00431999983265996, "shape": "elliptical", "is_active": true}],
-        "dmuon1": ["Drift", {"length": 0.18674398958683014, "tracking_method": "linear"}],
-        "vv999": ["Marker", {}],
-        "dmuon2": ["Drift", {"length": 0.01811501570045948, "tracking_method": "linear"}],
-        "rwwake4h": ["Marker", {}],
-        "endltuh": ["Marker", {}],
-        "begundh": ["Marker", {}],
-        "dmuon3": ["Drift", {"length": 0.1416112333536148, "tracking_method": "linear"}],
-        "rfbhx12": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "dmuon4": ["Drift", {"length": 0.06898076832294464, "tracking_method": "linear"}],
-        "mm3": ["Marker", {}],
-        "pfilt1": ["Marker", {}],
-        "dbmark37": ["Marker", {}],
-        "du0h": ["Drift", {"length": 0.06939198076725006, "tracking_method": "linear"}],
-        "du8h": ["Drift", {"length": 0.02500000037252903, "tracking_method": "linear"}],
-        "hxrstart": ["Marker", {}],
-        "du1h": ["Drift", {"length": 0.04098400101065636, "tracking_method": "linear"}],
-        "du2h": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "hxrcb1beg": ["Marker", {}],
-        "d0cb1": ["Drift", {"length": 0.039618998765945435, "tracking_method": "linear"}],
-        "bcxcbx11": ["Dipole", {"length": 0.36800000071525574, "angle": -0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d1cb1a": ["Drift", {"length": 0.47221601009368896, "tracking_method": "linear"}],
-        "mcbx4": ["Marker", {}],
-        "d1cb1b": ["Drift", {"length": 0.10589999705553055, "tracking_method": "linear"}],
-        "bodcbx42": ["Marker", {}],
-        "d1cb1c": ["Drift", {"length": 0.2842339873313904, "tracking_method": "linear"}],
-        "bcxcbx12": ["Dipole", {"length": 0.36800000071525574, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dchcb1": ["Drift", {"length": 0.08388149738311768, "tracking_method": "linear"}],
-        "center1": ["Marker", {}],
-        "bcxcbx13": ["Dipole", {"length": 0.36800000071525574, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d2cb": ["Drift", {"length": 0.8623499870300293, "tracking_method": "linear"}],
-        "bcxcbx14": ["Dipole", {"length": 0.36800000071525574, "angle": -0.0, "k1": 0.0, "dipole_e1": -0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d3cb1": ["Drift", {"length": -0.0320499986410141, "tracking_method": "linear"}],
-        "hxrcb1end": ["Marker", {}],
-        "du3hcb1": ["Drift", {"length": 0.23541200160980225, "tracking_method": "linear"}],
-        "qhxh13": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "du4hcb1": ["Drift", {"length": 0.06282400339841843, "tracking_method": "linear"}],
-        "rfbhx13": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "du5hcb1": ["Drift", {"length": -0.05550200119614601, "tracking_method": "linear"}],
-        "dpshx13": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "du6h": ["Drift", {"length": 0.0844929963350296, "tracking_method": "linear"}],
-        "du7h": ["Drift", {"length": 0.08892367035150528, "tracking_method": "linear"}],
-        "dthxu": ["Drift", {"length": 0.009015999734401703, "tracking_method": "linear"}],
-        "umahxh14": ["Undulator", {"length": 3.3540000915527344}],
-        "du3h": ["Drift", {"length": 0.050992000848054886, "tracking_method": "linear"}],
-        "mblmh14": ["Marker", {}],
-        "qhxh14": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "du4h": ["Drift", {"length": 0.06300000101327896, "tracking_method": "linear"}],
-        "rfbhx14": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "du5h": ["Drift", {"length": 0.07774999737739563, "tracking_method": "linear"}],
-        "pshxh14": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu14": ["Marker", {}],
-        "umahxh15": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh15": ["Marker", {}],
-        "qhxh15": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx15": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh15": ["Undulator", {"length": 0.0494999997317791}],
-        "dvvhxu": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "umahxh16": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh16": ["Marker", {}],
-        "qhxh16": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx16": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh16": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh17": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh17": ["Marker", {}],
-        "qhxh17": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx17": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh17": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu17": ["Marker", {}],
-        "umahxh18": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh18": ["Marker", {}],
-        "qhxh18": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx18": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh18": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh19": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh19": ["Marker", {}],
-        "qhxh19": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx19": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh19": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh20": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh20": ["Marker", {}],
-        "qhxh20": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx20": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh20": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu20": ["Marker", {}],
-        "hxrcb2beg": ["Marker", {}],
-        "d0cb2": ["Drift", {"length": 0.039625998586416245, "tracking_method": "linear"}],
-        "bcxcbx21": ["Dipole", {"length": 0.36800000071525574, "angle": -0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d1cb2a": ["Drift", {"length": 0.421122670173645, "tracking_method": "linear"}],
-        "dsscbx11": ["Marker", {}],
-        "d1cb2b": ["Drift", {"length": 0.05019000172615051, "tracking_method": "linear"}],
-        "mcbx1": ["Marker", {}],
-        "d1cb2c": ["Drift", {"length": 0.39103734493255615, "tracking_method": "linear"}],
-        "bcxcbx22": ["Dipole", {"length": 0.36800000071525574, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dchcb2": ["Drift", {"length": 0.08388149738311768, "tracking_method": "linear"}],
-        "center2": ["Marker", {}],
-        "bcxcbx23": ["Dipole", {"length": 0.36800000071525574, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bcxcbx24": ["Dipole", {"length": 0.36800000071525574, "angle": -0.0, "k1": 0.0, "dipole_e1": -0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.007000000216066837, "gap_exit": 0.007000000216066837, "fringe_integral": 1.0407999753952026, "fringe_integral_exit": 1.0407999753952026, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d3cb2": ["Drift", {"length": -0.03205699846148491, "tracking_method": "linear"}],
-        "hxrcb2end": ["Marker", {}],
-        "du3hcb2": ["Drift", {"length": 0.23541900515556335, "tracking_method": "linear"}],
-        "qhxh21": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "du4hcb2": ["Drift", {"length": 0.06282400339841843, "tracking_method": "linear"}],
-        "rfbhx21": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "du5hcb2": ["Drift", {"length": -0.05550900101661682, "tracking_method": "linear"}],
-        "dpshx21": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "umahxh22": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh22": ["Marker", {}],
-        "qhxh22": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx22": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh22": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu22": ["Marker", {}],
-        "umahxh23": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh23": ["Marker", {}],
-        "qhxh23": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx23": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh23": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh24": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh24": ["Marker", {}],
-        "qhxh24": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx24": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh24": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu24": ["Marker", {}],
-        "umahxh25": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh25": ["Marker", {}],
-        "qhxh25": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx25": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh25": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh26": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh26": ["Marker", {}],
-        "qhxh26": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx26": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh26": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh27": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh27": ["Marker", {}],
-        "qhxh27": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx27": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh27": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu27": ["Marker", {}],
-        "hxrssbeg": ["Marker", {}],
-        "dmono": ["Drift", {"length": 0.07921549677848816, "tracking_method": "linear"}],
-        "bcxhs1": ["Dipole", {"length": 0.3636009991168976, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.008000999689102173, "gap_exit": 0.008000999689102173, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "d1": ["Drift", {"length": 0.5933989882469177, "tracking_method": "linear"}],
-        "bcxhs2": ["Dipole", {"length": 0.3636009991168976, "angle": -0.0, "k1": 0.0, "dipole_e1": -0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.008000999689102173, "gap_exit": 0.008000999689102173, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dch": ["Drift", {"length": 0.28619951009750366, "tracking_method": "linear"}],
-        "diamond": ["Marker", {}],
-        "bcxhs3": ["Dipole", {"length": 0.3636009991168976, "angle": -0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.0, "tilt": 0.0, "gap": 0.008000999689102173, "gap_exit": 0.008000999689102173, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bcxhs4": ["Dipole", {"length": 0.3636009991168976, "angle": 0.0, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.008000999689102173, "gap_exit": 0.008000999689102173, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "hxrssend": ["Marker", {}],
-        "mblmh28": ["Marker", {}],
-        "qhxh28": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx28": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "dpshx28": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "umahxh29": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh29": ["Marker", {}],
-        "qhxh29": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx29": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh29": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu29": ["Marker", {}],
-        "umahxh30": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh30": ["Marker", {}],
-        "qhxh30": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx30": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh30": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh31": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh31": ["Marker", {}],
-        "qhxh31": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx31": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh31": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh32": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh32": ["Marker", {}],
-        "qhxh32": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx32": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh32": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu32": ["Marker", {}],
-        "umahxh33": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh33": ["Marker", {}],
-        "qhxh33": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx33": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh33": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh34": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh34": ["Marker", {}],
-        "qhxh34": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx34": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh34": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh35": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh35": ["Marker", {}],
-        "qhxh35": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx35": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh35": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu35": ["Marker", {}],
-        "umahxh36": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh36": ["Marker", {}],
-        "qhxh36": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx36": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh36": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh37": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh37": ["Marker", {}],
-        "qhxh37": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx37": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh37": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu37": ["Marker", {}],
-        "umahxh38": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh38": ["Marker", {}],
-        "qhxh38": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx38": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh38": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh39": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh39": ["Marker", {}],
-        "qhxh39": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx39": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh39": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh40": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh40": ["Marker", {}],
-        "qhxh40": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx40": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh40": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu40": ["Marker", {}],
-        "umahxh41": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh41": ["Marker", {}],
-        "qhxh41": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx41": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh41": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh42": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh42": ["Marker", {}],
-        "qhxh42": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx42": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh42": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh43": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh43": ["Marker", {}],
-        "qhxh43": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx43": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh43": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu43": ["Marker", {}],
-        "umahxh44": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh44": ["Marker", {}],
-        "qhxh44": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx44": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh44": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh45": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh45": ["Marker", {}],
-        "qhxh45": ["Quadrupole", {"length": 0.08399999886751175, "k1": 1.3383592367172241, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx45": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh45": ["Undulator", {"length": 0.0494999997317791}],
-        "vvhxu45": ["Marker", {}],
-        "umahxh46": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh46": ["Marker", {}],
-        "qhxh46": ["Quadrupole", {"length": 0.08399999886751175, "k1": -1.7346242666244507, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx46": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "pshxh46": ["Undulator", {"length": 0.0494999997317791}],
-        "umahxh47": ["Undulator", {"length": 3.3540000915527344}],
-        "mblmh47": ["Marker", {}],
-        "qhxh47": ["Quadrupole", {"length": 0.08399999886751175, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "rfbhx47": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "dpshx47": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "dusegh48": ["Drift", {"length": 3.3720319271087646, "tracking_method": "linear"}],
-        "dqhx48": ["Drift", {"length": 0.08399999886751175, "tracking_method": "linear"}],
-        "drfbh48": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "dpshx48": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "dusegh49": ["Drift", {"length": 3.3720319271087646, "tracking_method": "linear"}],
-        "dqhx49": ["Drift", {"length": 0.08399999886751175, "tracking_method": "linear"}],
-        "drfbh49": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "dpshx49": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "dusegh50": ["Drift", {"length": 3.3720319271087646, "tracking_method": "linear"}],
-        "dqhx50": ["Drift", {"length": 0.08399999886751175, "tracking_method": "linear"}],
-        "drfbh50": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "dpshx50": ["Drift", {"length": 0.0494999997317791, "tracking_method": "linear"}],
-        "rwwake5h": ["Marker", {}],
-        "hxrterm": ["Marker", {}],
-        "due1a": ["Drift", {"length": 2.8031747341156006, "tracking_method": "linear"}],
-        "rfbhx51": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "due1e": ["Drift", {"length": 0.05700000002980232, "tracking_method": "linear"}],
-        "endundh": ["Marker", {}],
-        "begdmph_1": ["Marker", {}],
-        "uebeg": ["Marker", {}],
-        "due1d": ["Drift", {"length": 0.10000000149011612, "tracking_method": "linear"}],
-        "vv36": ["Marker", {}],
-        "due1b": ["Drift", {"length": 1.5, "tracking_method": "linear"}],
-        "mimundo": ["Marker", {}],
-        "due1c": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "due2a": ["Drift", {"length": 0.5, "tracking_method": "linear"}],
-        "ycue1": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "due2b": ["Drift", {"length": 0.6295549869537354, "tracking_method": "linear"}],
-        "ph31": ["Marker", {}],
-        "due2d": ["Drift", {"length": 0.17599999904632568, "tracking_method": "linear"}],
-        "ph32": ["Marker", {}],
-        "ph33": ["Marker", {}],
-        "ph34": ["Marker", {}],
-        "due2e": ["Drift", {"length": 0.5824999809265137, "tracking_method": "linear"}],
-        "xcue2": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "due2c": ["Drift", {"length": 0.5550000071525574, "tracking_method": "linear"}],
-        "que1": ["Quadrupole", {"length": 0.550000011920929, "k1": 0.1691092550754547, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "due3a": ["Drift", {"length": 0.3668209910392761, "tracking_method": "linear"}],
-        "bpmue1": ["Marker", {}],
-        "due3b": ["Drift", {"length": 1.2117325067520142, "tracking_method": "linear"}],
-        "true1": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "due3c": ["Drift", {"length": 0.3984377384185791, "tracking_method": "linear"}],
-        "dbkxdmph": ["Drift", {"length": 1.0, "tracking_method": "linear"}],
-        "pctcx_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "pctcx_aperture": ["Aperture", {"x_max": 0.0044999998062849045, "y_max": 0.0044999998062849045, "shape": "elliptical", "is_active": true}],
-        "dpcvv": ["Drift", {"length": 0.3970000147819519, "tracking_method": "linear"}],
-        "vvtcx": ["Marker", {}],
-        "dvvtcx": ["Drift", {"length": 0.3199999928474426, "tracking_method": "linear"}],
-        "mtcx01": ["Marker", {}],
-        "tcx01": ["Cavity", {"length": 1.0, "voltage": 0.0, "phase": -0.0, "frequency": 11424000000.0}],
-        "dtcx12": ["Drift", {"length": 0.18649999797344208, "tracking_method": "linear"}],
-        "mtcx": ["Marker", {}],
-        "tcx02": ["Cavity", {"length": 1.0, "voltage": 0.0, "phase": -0.0, "frequency": 11424000000.0}],
-        "dtcxsp": ["Drift", {"length": 0.38100001215934753, "tracking_method": "linear"}],
-        "sptcx": ["Marker", {}],
-        "due4": ["Drift", {"length": 0.39399999380111694, "tracking_method": "linear"}],
-        "que2": ["Quadrupole", {"length": 0.550000011920929, "k1": -0.13784082233905792, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "due5a": ["Drift", {"length": 0.3668209910392761, "tracking_method": "linear"}],
-        "bpmue2": ["BPM", {"is_active": true}],
-        "due5b": ["Drift", {"length": 0.3149780035018921, "tracking_method": "linear"}],
-        "btmque": ["Marker", {}],
-        "due5c": ["Drift", {"length": 0.26739999651908875, "tracking_method": "linear"}],
-        "pcpm0_drift": ["Drift", {"length": 0.07599999755620956, "tracking_method": "linear"}],
-        "pcpm0_aperture": ["Aperture", {"x_max": 0.017500000074505806, "y_max": 0.017500000074505806, "shape": "elliptical", "is_active": true}],
-        "due5f": ["Drift", {"length": 0.05000000074505806, "tracking_method": "linear"}],
-        "btm0": ["Marker", {}],
-        "due5d": ["Drift", {"length": 0.08705499768257141, "tracking_method": "linear"}],
-        "mimbcs3": ["Marker", {}],
-        "due5e": ["Drift", {"length": 0.11576925218105316, "tracking_method": "linear"}],
-        "mdlwall": ["Marker", {}],
-        "ddlwall": ["Drift", {"length": 0.25082576274871826, "tracking_method": "linear"}],
-        "ueend": ["Marker", {}],
-        "dlstart": ["Marker", {}],
-        "dsb0a": ["Drift", {"length": 0.2601499855518341, "tracking_method": "linear"}],
-        "ycd3": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dsb0b": ["Drift", {"length": 0.3440000116825104, "tracking_method": "linear"}],
-        "xcd3": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dsb0c": ["Drift", {"length": 0.32646000385284424, "tracking_method": "linear"}],
-        "vv37": ["Marker", {}],
-        "dsb0d": ["Drift", {"length": 0.12336599826812744, "tracking_method": "linear"}],
-        "dsb0e": ["Drift", {"length": 0.10552899539470673, "tracking_method": "linear"}],
-        "enddmph_1": ["Marker", {}],
-        "begdmph_2": ["Marker", {}],
-        "rodmp1h": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "bydsh": ["Dipole", {"length": 0.5, "angle": 0.0006000000284984708, "k1": 0.0, "dipole_e1": 0.0003000000142492354, "dipole_e2": 0.0003000000142492354, "tilt": 1.5707963705062866, "gap": 0.03200000151991844, "gap_exit": 0.03200000151991844, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ds1": ["Drift", {"length": 0.315876305103302, "tracking_method": "linear"}],
-        "byd1": ["Dipole", {"length": 1.4520303010940552, "angle": 0.022400734946131706, "k1": 0.0, "dipole_e1": 0.011200367473065853, "dipole_e2": 0.011200367473065853, "tilt": 1.5707963705062866, "gap": 0.0430000014603138, "gap_exit": 0.0430000014603138, "fringe_integral": 0.5699999928474426, "fringe_integral_exit": 0.5699999928474426, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ds": ["Drift", {"length": 0.24794599413871765, "tracking_method": "linear"}],
-        "byd2": ["Dipole", {"length": 1.4520303010940552, "angle": 0.022400734946131706, "k1": 0.0, "dipole_e1": 0.011200367473065853, "dipole_e2": 0.011200367473065853, "tilt": 1.5707963705062866, "gap": 0.0430000014603138, "gap_exit": 0.0430000014603138, "fringe_integral": 0.5699999928474426, "fringe_integral_exit": 0.5699999928474426, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "byd3": ["Dipole", {"length": 1.4520303010940552, "angle": 0.022400734946131706, "k1": 0.0, "dipole_e1": 0.011200367473065853, "dipole_e2": 0.011200367473065853, "tilt": 1.5707963705062866, "gap": 0.0430000014603138, "gap_exit": 0.0430000014603138, "fringe_integral": 0.5699999928474426, "fringe_integral_exit": 0.5699999928474426, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dd1a": ["Drift", {"length": 0.577681303024292, "tracking_method": "linear"}],
-        "pcpm1l_drift": ["Drift", {"length": 0.07599999755620956, "tracking_method": "linear"}],
-        "pcpm1l_aperture": ["Aperture", {"x_max": 0.014287499710917473, "y_max": 0.014287499710917473, "shape": "elliptical", "is_active": true}],
-        "btm1l": ["Marker", {}],
-        "dd1b": ["Drift", {"length": 1.0000874996185303, "tracking_method": "linear"}],
-        "mimdump": ["Marker", {}],
-        "dd1c": ["Drift", {"length": 0.30480000376701355, "tracking_method": "linear"}],
-        "mimbcs4": ["Marker", {}],
-        "dd1d": ["Drift", {"length": 8.822711944580078, "tracking_method": "linear"}],
-        "ycdd": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dd1e": ["Drift", {"length": 0.24963811039924622, "tracking_method": "linear"}],
-        "pcpm2l_drift": ["Drift", {"length": 0.07599999755620956, "tracking_method": "linear"}],
-        "pcpm2l_aperture": ["Aperture", {"x_max": 0.038100000470876694, "y_max": 0.038100000470876694, "shape": "elliptical", "is_active": true}],
-        "btm2l": ["Marker", {}],
-        "dd1f": ["Drift", {"length": 0.40924006700515747, "tracking_method": "linear"}],
-        "qdmp1": ["Quadrupole", {"length": 0.4300000071525574, "k1": -0.15521271526813507, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dd12a": ["Drift", {"length": 0.3020628094673157, "tracking_method": "linear"}],
-        "bpmqd": ["BPM", {"is_active": true}],
-        "dd12b": ["Drift", {"length": 0.007937200367450714, "tracking_method": "linear"}],
-        "mqdmp": ["Marker", {}],
-        "dd12c": ["Drift", {"length": 0.3100000023841858, "tracking_method": "linear"}],
-        "qdmp2": ["Quadrupole", {"length": 0.4300000071525574, "k1": -0.15521271526813507, "misalignment": [0.0, 0.0], "tilt": 0.0}],
-        "dd2a": ["Drift", {"length": 0.4749999940395355, "tracking_method": "linear"}],
-        "xcdd": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dd2b": ["Drift", {"length": 6.202253341674805, "tracking_method": "linear"}],
-        "dd2c": ["Drift", {"length": 1.0, "tracking_method": "linear"}],
-        "dd3a": ["Drift", {"length": 0.351267009973526, "tracking_method": "linear"}],
-        "bpmdd": ["BPM", {"is_active": true}],
-        "dd3b": ["Drift", {"length": 0.1537144035100937, "tracking_method": "linear"}],
-        "otrdmp": ["Marker", {}],
-        "dwsdumpa1": ["Drift", {"length": 0.07596510648727417, "tracking_method": "linear"}],
-        "pcebd_drift": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "pcebd_aperture": ["Aperture", {"x_max": 0.03400000184774399, "y_max": 0.03400000184774399, "shape": "elliptical", "is_active": true}],
-        "dwsdumpa2": ["Drift", {"length": 0.1448148936033249, "tracking_method": "linear"}],
-        "rfbdd": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dwsdumpb": ["Drift", {"length": 0.22078000009059906, "tracking_method": "linear"}],
-        "wsdump": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dwsdumpc": ["Drift", {"length": 2.2870752811431885, "tracking_method": "linear"}],
-        "rodmp2h": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dumpface": ["Marker", {}],
-        "ddump": ["Drift", {"length": 1.552448034286499, "tracking_method": "linear"}],
-        "dmpend": ["Marker", {}],
-        "btmdump": ["Marker", {}],
-        "dbmark38": ["Marker", {}],
-        "enddmph_2": ["Marker", {}]
+        "dl00": [
+            "Drift",
+            {
+                "length": -0.869047999382019,
+                "tracking_method": "linear"
+            }
+        ],
+        "loadlock": [
+            "Drift",
+            {
+                "length": 0.869047999382019,
+                "tracking_method": "linear"
+            }
+        ],
+        "beggun": [
+            "Marker",
+            {}
+        ],
+        "sol1bk": [
+            "Solenoid",
+            {
+                "length": 0.0,
+                "k": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "metadata": {
+                    "alias": "SOLN:IN20:111"
+                }
+            }
+        ],
+        "dbmark80": [
+            "Marker",
+            {}
+        ],
+        "cathode": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "CATH:IN20:111"
+                }
+            }
+        ],
+        "dl01a": [
+            "Drift",
+            {
+                "length": 0.0960099995136261,
+                "tracking_method": "linear"
+            }
+        ],
+        "sol1": [
+            "Solenoid",
+            {
+                "length": 0.20000000298023224,
+                "k": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "metadata": {
+                    "alias": "SOLN:IN20:121"
+                }
+            }
+        ],
+        "dl01a1": [
+            "Drift",
+            {
+                "length": 0.07851000130176544,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv01": [
+            "Marker",
+            {}
+        ],
+        "dl01a2": [
+            "Drift",
+            {
+                "length": 0.11608999967575073,
+                "tracking_method": "linear"
+            }
+        ],
+        "am00": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "MIRR:IN20:181"
+                }
+            }
+        ],
+        "dl01a3": [
+            "Drift",
+            {
+                "length": 0.10461000353097916,
+                "tracking_method": "linear"
+            }
+        ],
+        "am01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "MIRR:IN20:191"
+                }
+            }
+        ],
+        "dl01a4": [
+            "Drift",
+            {
+                "length": 0.018400000408291817,
+                "tracking_method": "linear"
+            }
+        ],
+        "yag01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "YAGS:IN20:211"
+                }
+            }
+        ],
+        "dl01a5": [
+            "Drift",
+            {
+                "length": 0.010970000177621841,
+                "tracking_method": "linear"
+            }
+        ],
+        "fc01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "FARC:IN20:212"
+                }
+            }
+        ],
+        "dl01b": [
+            "Drift",
+            {
+                "length": 0.08250000327825546,
+                "tracking_method": "linear"
+            }
+        ],
+        "im01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:IN20:215"
+                }
+            }
+        ],
+        "dl01c": [
+            "Drift",
+            {
+                "length": 0.12729500234127045,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc01": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:IN20:221"
+                }
+            }
+        ],
+        "yc01": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:IN20:222"
+                }
+            }
+        ],
+        "dl01h": [
+            "Drift",
+            {
+                "length": 0.05818859860301018,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpm2": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:IN20:221"
+                }
+            }
+        ],
+        "dl01d": [
+            "Drift",
+            {
+                "length": 0.0852707028388977,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbmark81": [
+            "Marker",
+            {}
+        ],
+        "endgun": [
+            "Marker",
+            {}
+        ],
+        "begl0": [
+            "Marker",
+            {}
+        ],
+        "dbxg": [
+            "Drift",
+            {
+                "length": 0.13261835277080536,
+                "tracking_method": "linear"
+            }
+        ],
+        "dl01e": [
+            "Drift",
+            {
+                "length": 0.10619734227657318,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpm3": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:IN20:235"
+                }
+            }
+        ],
+        "dl01f": [
+            "Drift",
+            {
+                "length": 0.1423799991607666,
+                "tracking_method": "linear"
+            }
+        ],
+        "cr01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "CRAD:IN20:237"
+                }
+            }
+        ],
+        "dl01f2": [
+            "Drift",
+            {
+                "length": 0.029370000585913658,
+                "tracking_method": "linear"
+            }
+        ],
+        "yag02": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "YAGS:IN20:241"
+                }
+            }
+        ],
+        "dl01g": [
+            "Drift",
+            {
+                "length": 0.07058999687433243,
+                "tracking_method": "linear"
+            }
+        ],
+        "zlin00": [
+            "Marker",
+            {}
+        ],
+        "l0a": [
+            "Cavity",
+            {
+                "length": 3.0952439308166504,
+                "voltage": 58010692.0,
+                "phase": 1.0999999999999999,
+                "frequency": 2856000000.0
+            }
+        ],
+        "l0awake": [
+            "Marker",
+            {}
+        ],
+        "l0bbeg": [
+            "Marker",
+            {}
+        ],
+        "dl02a1": [
+            "Drift",
+            {
+                "length": 0.060294605791568756,
+                "tracking_method": "linear"
+            }
+        ],
+        "yag03": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "YAGS:IN20:351"
+                }
+            }
+        ],
+        "dl02a2": [
+            "Drift",
+            {
+                "length": 0.11278499662876129,
+                "tracking_method": "linear"
+            }
+        ],
+        "dl02a3": [
+            "Drift",
+            {
+                "length": 0.07361000031232834,
+                "tracking_method": "linear"
+            }
+        ],
+        "qa01": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -9.879051208496094,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:361"
+                }
+            }
+        ],
+        "dl02b1": [
+            "Drift",
+            {
+                "length": 0.09448400139808655,
+                "tracking_method": "linear"
+            }
+        ],
+        "ph01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:IN20:365"
+                }
+            }
+        ],
+        "dl02b2": [
+            "Drift",
+            {
+                "length": 0.12589199841022491,
+                "tracking_method": "linear"
+            }
+        ],
+        "qa02": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 10.775527000427246,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:371"
+                }
+            }
+        ],
+        "dl02c": [
+            "Drift",
+            {
+                "length": 0.06588800251483917,
+                "tracking_method": "linear"
+            }
+        ],
+        "l0b": [
+            "Cavity",
+            {
+                "length": 3.0952439308166504,
+                "voltage": 71013088.0,
+                "phase": 1.0999999999999999,
+                "frequency": 2856000000.0
+            }
+        ],
+        "endl0": [
+            "Marker",
+            {}
+        ],
+        "begdl1_1": [
+            "Marker",
+            {}
+        ],
+        "emat": [
+            "Marker",
+            {}
+        ],
+        "de00": [
+            "Drift",
+            {
+                "length": 0.024994000792503357,
+                "tracking_method": "linear"
+            }
+        ],
+        "de00a": [
+            "Drift",
+            {
+                "length": 0.016612999141216278,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe01": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -0.2743176221847534,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:425"
+                }
+            }
+        ],
+        "de01a": [
+            "Drift",
+            {
+                "length": 0.07637300342321396,
+                "tracking_method": "linear"
+            }
+        ],
+        "im02": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:IN20:431"
+                }
+            }
+        ],
+        "de01b": [
+            "Drift",
+            {
+                "length": 0.12235900014638901,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv02": [
+            "Marker",
+            {}
+        ],
+        "de01c": [
+            "Drift",
+            {
+                "length": 0.09478099644184113,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe02": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.7829366326332092,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:441"
+                }
+            }
+        ],
+        "dh00": [
+            "Drift",
+            {
+                "length": 0.1273304522037506,
+                "tracking_method": "linear"
+            }
+        ],
+        "lhbeg": [
+            "Marker",
+            {}
+        ],
+        "bxh1": [
+            "Dipole",
+            {
+                "length": 0.12476039677858353,
+                "angle": -0.13170939683914185,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.13170939683914185,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.4000000059604645,
+                "fringe_integral_exit": 0.4000000059604645,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:IN20:451"
+                }
+            }
+        ],
+        "dh01": [
+            "Drift",
+            {
+                "length": 0.14182840287685394,
+                "tracking_method": "linear"
+            }
+        ],
+        "bxh2": [
+            "Dipole",
+            {
+                "length": 0.12476039677858353,
+                "angle": 0.13170939683914185,
+                "k1": 0.0,
+                "dipole_e1": 0.13170939683914185,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.4000000059604645,
+                "fringe_integral_exit": 0.4000000059604645,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:IN20:461"
+                }
+            }
+        ],
+        "dh02a": [
+            "Drift",
+            {
+                "length": 0.059970200061798096,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrh1": [
+            "Screen",
+            {
+                "resolution": [
+                    1040,
+                    1392
+                ],
+                "pixel_size": [
+                    1.859e-05,
+                    1.859e-05
+                ],
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:IN20:465"
+                }
+            }
+        ],
+        "dh03a": [
+            "Drift",
+            {
+                "length": 0.07603974640369415,
+                "tracking_method": "linear"
+            }
+        ],
+        "lh_und": [
+            "Undulator",
+            {
+                "length": 0.5400000214576721,
+                "metadata": {
+                    "alias": "USEG:IN20:466"
+                }
+            }
+        ],
+        "dh03b": [
+            "Drift",
+            {
+                "length": 0.0671498030424118,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrh2": [
+            "Screen",
+            {
+                "resolution": [
+                    1392,
+                    1040
+                ],
+                "pixel_size": [
+                    1.916e-05,
+                    1.916e-05
+                ],
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:IN20:471"
+                }
+            }
+        ],
+        "dh02b": [
+            "Drift",
+            {
+                "length": 0.08783020079135895,
+                "tracking_method": "linear"
+            }
+        ],
+        "bxh3": [
+            "Dipole",
+            {
+                "length": 0.12476039677858353,
+                "angle": 0.13170939683914185,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.13170939683914185,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.4000000059604645,
+                "fringe_integral_exit": 0.4000000059604645,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:IN20:475"
+                }
+            }
+        ],
+        "bxh4": [
+            "Dipole",
+            {
+                "length": 0.12476039677858353,
+                "angle": -0.13170939683914185,
+                "k1": 0.0,
+                "dipole_e1": -0.13170939683914185,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.4000000059604645,
+                "fringe_integral_exit": 0.4000000059604645,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:IN20:481"
+                }
+            }
+        ],
+        "lhend": [
+            "Marker",
+            {}
+        ],
+        "dh06": [
+            "Drift",
+            {
+                "length": 0.12290070205926895,
+                "tracking_method": "linear"
+            }
+        ],
+        "tcav0": [
+            "Cavity",
+            {
+                "length": 0.6680235862731934,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "TCAV:IN20:490"
+                }
+            }
+        ],
+        "de02": [
+            "Drift",
+            {
+                "length": 0.03573950007557869,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe03": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 11.568048477172852,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:511"
+                }
+            }
+        ],
+        "de03a": [
+            "Drift",
+            {
+                "length": 0.11432000249624252,
+                "tracking_method": "linear"
+            }
+        ],
+        "de03b": [
+            "Drift",
+            {
+                "length": 0.04758099839091301,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc07": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:IN20:521"
+                }
+            }
+        ],
+        "yc07": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:IN20:522"
+                }
+            }
+        ],
+        "de03c": [
+            "Drift",
+            {
+                "length": 0.13649900257587433,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe04": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -6.789909839630127,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:525"
+                }
+            }
+        ],
+        "de04": [
+            "Drift",
+            {
+                "length": 0.14368799328804016,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:IN20:531"
+                }
+            }
+        ],
+        "de05": [
+            "Drift",
+            {
+                "length": 0.15196800231933594,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr1": [
+            "Screen",
+            {
+                "resolution": [
+                    1392,
+                    1040
+                ],
+                "pixel_size": [
+                    1.266e-05,
+                    1.266e-05
+                ],
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:IN20:541"
+                }
+            }
+        ],
+        "de05c": [
+            "Drift",
+            {
+                "length": 0.10446999967098236,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv03": [
+            "Marker",
+            {}
+        ],
+        "de06a": [
+            "Drift",
+            {
+                "length": 1.409488558769226,
+                "tracking_method": "linear"
+            }
+        ],
+        "rst1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "STPR:IN20:551"
+                }
+            }
+        ],
+        "de06b": [
+            "Drift",
+            {
+                "length": 0.24780240654945374,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws02": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:IN20:561"
+                }
+            }
+        ],
+        "de05a": [
+            "Drift",
+            {
+                "length": 0.07598400115966797,
+                "tracking_method": "linear"
+            }
+        ],
+        "mrk0": [
+            "Marker",
+            {}
+        ],
+        "otr2": [
+            "Screen",
+            {
+                "resolution": [
+                    1392,
+                    1040
+                ],
+                "pixel_size": [
+                    1.266e-05,
+                    1.266e-05
+                ],
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:IN20:571"
+                }
+            }
+        ],
+        "de06d": [
+            "Drift",
+            {
+                "length": 0.1638306975364685,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpm10": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:IN20:581"
+                }
+            }
+        ],
+        "de06e": [
+            "Drift",
+            {
+                "length": 1.5979303121566772,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws03": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:IN20:611"
+                }
+            }
+        ],
+        "otr3": [
+            "Screen",
+            {
+                "resolution": [
+                    1392,
+                    1040
+                ],
+                "pixel_size": [
+                    1.212e-05,
+                    1.212e-05
+                ],
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:IN20:621"
+                }
+            }
+        ],
+        "de07": [
+            "Drift",
+            {
+                "length": 0.15080569684505463,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm01": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 15.08299732208252,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:631"
+                }
+            }
+        ],
+        "de08": [
+            "Drift",
+            {
+                "length": 0.14787210524082184,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc08": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:IN20:641"
+                }
+            }
+        ],
+        "yc08": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:IN20:642"
+                }
+            }
+        ],
+        "de08a": [
+            "Drift",
+            {
+                "length": 0.1833299994468689,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv04": [
+            "Marker",
+            {}
+        ],
+        "de08b": [
+            "Drift",
+            {
+                "length": 0.11661999672651291,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm02": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -11.969358444213867,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:651"
+                }
+            }
+        ],
+        "de09": [
+            "Drift",
+            {
+                "length": 0.22345000505447388,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbmark82": [
+            "Marker",
+            {}
+        ],
+        "enddl1_1": [
+            "Marker",
+            {}
+        ],
+        "begdl1_2": [
+            "Marker",
+            {}
+        ],
+        "bx01": [
+            "Dipole",
+            {
+                "length": 0.20399200916290283,
+                "angle": -0.30543261766433716,
+                "k1": 0.0,
+                "dipole_e1": -0.15271630883216858,
+                "dipole_e2": -0.15271630883216858,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.44999998807907104,
+                "fringe_integral_exit": 0.44999998807907104,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:IN20:661"
+                }
+            }
+        ],
+        "db00a": [
+            "Drift",
+            {
+                "length": 0.39969944953918457,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr4": [
+            "Screen",
+            {
+                "resolution": [
+                    1392,
+                    1040
+                ],
+                "pixel_size": [
+                    1.706e-05,
+                    1.706e-05
+                ],
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:IN20:711"
+                }
+            }
+        ],
+        "db00b": [
+            "Drift",
+            {
+                "length": 0.16099999845027924,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc09": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:IN20:721"
+                }
+            }
+        ],
+        "yc09": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:IN20:722"
+                }
+            }
+        ],
+        "db00c": [
+            "Drift",
+            {
+                "length": 0.1657000035047531,
+                "tracking_method": "linear"
+            }
+        ],
+        "qb": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 22.169715881347656,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:731"
+                }
+            }
+        ],
+        "db00d": [
+            "Drift",
+            {
+                "length": 0.28859999775886536,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws04": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:IN20:741"
+                }
+            }
+        ],
+        "db00e": [
+            "Drift",
+            {
+                "length": 0.43779945373535156,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx02": [
+            "Dipole",
+            {
+                "length": 0.20399200916290283,
+                "angle": -0.30543261766433716,
+                "k1": 0.0,
+                "dipole_e1": -0.15271630883216858,
+                "dipole_e2": -0.15271630883216858,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.44999998807907104,
+                "fringe_integral_exit": 0.44999998807907104,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:IN20:751"
+                }
+            }
+        ],
+        "cnt0": [
+            "Marker",
+            {}
+        ],
+        "dbmark83": [
+            "Marker",
+            {}
+        ],
+        "dm00": [
+            "Drift",
+            {
+                "length": 0.22130104899406433,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc10": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:IN20:761"
+                }
+            }
+        ],
+        "yc10": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:IN20:762"
+                }
+            }
+        ],
+        "dm00a": [
+            "Drift",
+            {
+                "length": 0.14068299531936646,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm03": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -8.29494571685791,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:771"
+                }
+            }
+        ],
+        "dm01": [
+            "Drift",
+            {
+                "length": 0.08836700022220612,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm01a": [
+            "Drift",
+            {
+                "length": 0.20880000293254852,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm04": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 13.337873458862305,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:IN20:781"
+                }
+            }
+        ],
+        "dm02": [
+            "Drift",
+            {
+                "length": 0.14020000398159027,
+                "tracking_method": "linear"
+            }
+        ],
+        "im03": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:IN20:791"
+                }
+            }
+        ],
+        "dm02a": [
+            "Drift",
+            {
+                "length": 0.15744799375534058,
+                "tracking_method": "linear"
+            }
+        ],
+        "enddl1_2": [
+            "Marker",
+            {}
+        ],
+        "begl1": [
+            "Marker",
+            {}
+        ],
+        "zlin01": [
+            "Marker",
+            {}
+        ],
+        "k21_1b": [
+            "Cavity",
+            {
+                "length": 2.8691999912261963,
+                "voltage": 45397560.0,
+                "phase": 21.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:11"
+                }
+            }
+        ],
+        "daqa1": [
+            "Drift",
+            {
+                "length": 0.03686999902129173,
+                "tracking_method": "linear"
+            }
+        ],
+        "qa11": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -3.7779366970062256,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:131"
+                }
+            }
+        ],
+        "daqa2": [
+            "Drift",
+            {
+                "length": 0.03002999909222126,
+                "tracking_method": "linear"
+            }
+        ],
+        "k21_1c": [
+            "Cavity",
+            {
+                "length": 2.8691999912261963,
+                "voltage": 32100922.0,
+                "phase": 21.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:11"
+                }
+            }
+        ],
+        "daqa3": [
+            "Drift",
+            {
+                "length": 0.03344999998807907,
+                "tracking_method": "linear"
+            }
+        ],
+        "qa12": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 1.8813942670822144,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:161"
+                }
+            }
+        ],
+        "daqa4": [
+            "Drift",
+            {
+                "length": 0.03344999998807907,
+                "tracking_method": "linear"
+            }
+        ],
+        "k21_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 34057724.0,
+                "phase": 21.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:11"
+                }
+            }
+        ],
+        "endl1": [
+            "Marker",
+            {}
+        ],
+        "begbc1": [
+            "Marker",
+            {}
+        ],
+        "dl1xa": [
+            "Drift",
+            {
+                "length": 0.0933689996600151,
+                "tracking_method": "linear"
+            }
+        ],
+        "vvx1": [
+            "Marker",
+            {}
+        ],
+        "dl1xb": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "l1x": [
+            "Cavity",
+            {
+                "length": 0.5947999954223633,
+                "voltage": 20000000.0,
+                "phase": 160.0,
+                "frequency": 11424000000.0
+            }
+        ],
+        "dm10a": [
+            "Drift",
+            {
+                "length": 0.20507800579071045,
+                "tracking_method": "linear"
+            }
+        ],
+        "vvx2": [
+            "Marker",
+            {}
+        ],
+        "dm10c": [
+            "Drift",
+            {
+                "length": 0.11993200331926346,
+                "tracking_method": "linear"
+            }
+        ],
+        "q21201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -9.33825397491455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:201"
+                }
+            }
+        ],
+        "dm10x": [
+            "Drift",
+            {
+                "length": 0.0860069990158081,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbc1i": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LI21:205"
+                }
+            }
+        ],
+        "dm11": [
+            "Drift",
+            {
+                "length": 0.2788830101490021,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm11": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 7.949062347412109,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:211"
+                }
+            }
+        ],
+        "dm12": [
+            "Drift",
+            {
+                "length": 0.12780100107192993,
+                "tracking_method": "linear"
+            }
+        ],
+        "bc1cbeg": [
+            "Marker",
+            {}
+        ],
+        "bx11": [
+            "Dipole",
+            {
+                "length": 0.20349685847759247,
+                "angle": -0.09357535094022751,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.09357535094022751,
+                "tilt": 0.0,
+                "gap": 0.04328000172972679,
+                "gap_exit": 0.04328000172972679,
+                "fringe_integral": 0.3869999945163727,
+                "fringe_integral_exit": 0.3869999945163727,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI21:215"
+                }
+            }
+        ],
+        "dbq1": [
+            "Drift",
+            {
+                "length": 0.2458566129207611,
+                "tracking_method": "linear"
+            }
+        ],
+        "cq11": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:221"
+                }
+            }
+        ],
+        "d11o": [
+            "Drift",
+            {
+                "length": 2.091742515563965,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx12": [
+            "Dipole",
+            {
+                "length": 0.20349685847759247,
+                "angle": 0.09357535094022751,
+                "k1": 0.0,
+                "dipole_e1": 0.09357535094022751,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.04328000172972679,
+                "gap_exit": 0.04328000172972679,
+                "fringe_integral": 0.3869999945163727,
+                "fringe_integral_exit": 0.3869999945163727,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI21:231"
+                }
+            }
+        ],
+        "ddg1": [
+            "Drift",
+            {
+                "length": 0.2486400008201599,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpms11": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:LI21:233"
+                }
+            }
+        ],
+        "ddg2": [
+            "Drift",
+            {
+                "length": 0.16446000337600708,
+                "tracking_method": "linear"
+            }
+        ],
+        "ce11_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "ce11_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "ddg3": [
+            "Drift",
+            {
+                "length": 0.18260599672794342,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr11": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:LI21:237"
+                }
+            }
+        ],
+        "ddg4": [
+            "Drift",
+            {
+                "length": 0.23449400067329407,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx13": [
+            "Dipole",
+            {
+                "length": 0.20349685847759247,
+                "angle": 0.09357535094022751,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.09357535094022751,
+                "tilt": 0.0,
+                "gap": 0.04328000172972679,
+                "gap_exit": 0.04328000172972679,
+                "fringe_integral": 0.3869999945163727,
+                "fringe_integral_exit": 0.3869999945163727,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI21:241"
+                }
+            }
+        ],
+        "d11oa": [
+            "Drift",
+            {
+                "length": 0.2624492049217224,
+                "tracking_method": "linear"
+            }
+        ],
+        "sq13": [
+            "Quadrupole",
+            {
+                "length": 0.1599999964237213,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.7853981852531433,
+                "metadata": {
+                    "alias": "QUAD:LI21:243"
+                }
+            }
+        ],
+        "d11ob": [
+            "Drift",
+            {
+                "length": 1.6692934036254883,
+                "tracking_method": "linear"
+            }
+        ],
+        "cq12": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:251"
+                }
+            }
+        ],
+        "bx14": [
+            "Dipole",
+            {
+                "length": 0.20349685847759247,
+                "angle": -0.09357535094022751,
+                "k1": 0.0,
+                "dipole_e1": -0.09357535094022751,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.04328000172972679,
+                "gap_exit": 0.04328000172972679,
+                "fringe_integral": 0.3869999945163727,
+                "fringe_integral_exit": 0.3869999945163727,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI21:261"
+                }
+            }
+        ],
+        "cnt1": [
+            "Marker",
+            {}
+        ],
+        "bc1cend": [
+            "Marker",
+            {}
+        ],
+        "dm13a": [
+            "Drift",
+            {
+                "length": 0.1617249995470047,
+                "tracking_method": "linear"
+            }
+        ],
+        "bl11": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BLEN:LI21:265"
+                }
+            }
+        ],
+        "dm13b": [
+            "Drift",
+            {
+                "length": 0.1617249995470047,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm12": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -8.326568603515625,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:271"
+                }
+            }
+        ],
+        "dm14a": [
+            "Drift",
+            {
+                "length": 0.17384999990463257,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm14b": [
+            "Drift",
+            {
+                "length": 0.20713874697685242,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbc1o": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LI21:277"
+                }
+            }
+        ],
+        "dm14c": [
+            "Drift",
+            {
+                "length": 0.18178875744342804,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm13": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 9.937676429748535,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:278"
+                }
+            }
+        ],
+        "dm15a": [
+            "Drift",
+            {
+                "length": 0.10047200322151184,
+                "tracking_method": "linear"
+            }
+        ],
+        "bl12": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BLEN:LI21:280"
+                }
+            }
+        ],
+        "dm15b": [
+            "Drift",
+            {
+                "length": 0.2010740041732788,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc21275": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LI21:275"
+                }
+            }
+        ],
+        "yc21276": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LI21:276"
+                }
+            }
+        ],
+        "dm15c": [
+            "Drift",
+            {
+                "length": 0.23499999940395355,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws11": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI21:285"
+                }
+            }
+        ],
+        "dww1a": [
+            "Drift",
+            {
+                "length": 1.6561959981918335,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws12": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI21:293"
+                }
+            }
+        ],
+        "dww1b": [
+            "Drift",
+            {
+                "length": 0.29499998688697815,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr12": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:LI21:291"
+                }
+            }
+        ],
+        "dww1c1": [
+            "Drift",
+            {
+                "length": 0.4153299927711487,
+                "tracking_method": "linear"
+            }
+        ],
+        "ph02": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:LI21:300"
+                }
+            }
+        ],
+        "dww1c2": [
+            "Drift",
+            {
+                "length": 0.30240100622177124,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc21302": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LI21:302"
+                }
+            }
+        ],
+        "dww1d": [
+            "Drift",
+            {
+                "length": 0.34609898924827576,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc21303": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LI21:303"
+                }
+            }
+        ],
+        "dww1e": [
+            "Drift",
+            {
+                "length": 0.2973659932613373,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws13": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI21:301"
+                }
+            }
+        ],
+        "dm16": [
+            "Drift",
+            {
+                "length": 0.255730003118515,
+                "tracking_method": "linear"
+            }
+        ],
+        "q21301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.1347000002861023,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:301"
+                }
+            }
+        ],
+        "dm17a": [
+            "Drift",
+            {
+                "length": 0.26010408997535706,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm17b": [
+            "Drift",
+            {
+                "length": 0.40088289976119995,
+                "tracking_method": "linear"
+            }
+        ],
+        "td11": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "DUMP:LI21:305"
+                }
+            }
+        ],
+        "dm17c": [
+            "Drift",
+            {
+                "length": 0.3875870108604431,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm14": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 7.054168701171875,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:315"
+                }
+            }
+        ],
+        "dm18a": [
+            "Drift",
+            {
+                "length": 0.22612999379634857,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc21325": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LI21:325"
+                }
+            }
+        ],
+        "yc21325": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LI21:325"
+                }
+            }
+        ],
+        "dm18b": [
+            "Drift",
+            {
+                "length": 0.23068000376224518,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm15": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -6.723000526428223,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:335"
+                }
+            }
+        ],
+        "dbmark28": [
+            "Marker",
+            {}
+        ],
+        "dm19": [
+            "Drift",
+            {
+                "length": 0.09692099690437317,
+                "tracking_method": "linear"
+            }
+        ],
+        "endbc1": [
+            "Marker",
+            {}
+        ],
+        "begl2": [
+            "Marker",
+            {}
+        ],
+        "li21beg": [
+            "Marker",
+            {}
+        ],
+        "zlin04": [
+            "Marker",
+            {}
+        ],
+        "k21_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 72760504.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:31"
+                }
+            }
+        ],
+        "k21_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:31"
+                }
+            }
+        ],
+        "k21_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:31"
+                }
+            }
+        ],
+        "daq1": [
+            "Drift",
+            {
+                "length": 0.03420000150799751,
+                "tracking_method": "linear"
+            }
+        ],
+        "q21401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 1.0301234722137451,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:401"
+                }
+            }
+        ],
+        "daq2": [
+            "Drift",
+            {
+                "length": 0.027000000700354576,
+                "tracking_method": "linear"
+            }
+        ],
+        "k21_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:41"
+                }
+            }
+        ],
+        "k21_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:41"
+                }
+            }
+        ],
+        "k21_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:41"
+                }
+            }
+        ],
+        "k21_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:41"
+                }
+            }
+        ],
+        "q21501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.8207575678825378,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:501"
+                }
+            }
+        ],
+        "k21_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:51"
+                }
+            }
+        ],
+        "k21_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:51"
+                }
+            }
+        ],
+        "k21_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:51"
+                }
+            }
+        ],
+        "k21_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:51"
+                }
+            }
+        ],
+        "q21601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7139142751693726,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:601"
+                }
+            }
+        ],
+        "k21_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:61"
+                }
+            }
+        ],
+        "k21_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:61"
+                }
+            }
+        ],
+        "k21_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:61"
+                }
+            }
+        ],
+        "k21_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:61"
+                }
+            }
+        ],
+        "q21701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7058273553848267,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:701"
+                }
+            }
+        ],
+        "k21_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:71"
+                }
+            }
+        ],
+        "k21_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:71"
+                }
+            }
+        ],
+        "k21_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:71"
+                }
+            }
+        ],
+        "k21_7d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:71"
+                }
+            }
+        ],
+        "q21801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7356926202774048,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:801"
+                }
+            }
+        ],
+        "k21_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:81"
+                }
+            }
+        ],
+        "k21_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:81"
+                }
+            }
+        ],
+        "k21_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:81"
+                }
+            }
+        ],
+        "k21_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI21:81"
+                }
+            }
+        ],
+        "daq3": [
+            "Drift",
+            {
+                "length": 0.353300005197525,
+                "tracking_method": "linear"
+            }
+        ],
+        "q21901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7182051539421082,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI21:901"
+                }
+            }
+        ],
+        "d219a": [
+            "Drift",
+            {
+                "length": 0.3109000027179718,
+                "tracking_method": "linear"
+            }
+        ],
+        "bky21929": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LI21:929"
+                }
+            }
+        ],
+        "d219b": [
+            "Drift",
+            {
+                "length": 0.24390000104904175,
+                "tracking_method": "linear"
+            }
+        ],
+        "bkx21957": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LI21:957"
+                }
+            }
+        ],
+        "d219c": [
+            "Drift",
+            {
+                "length": 1.3978999853134155,
+                "tracking_method": "linear"
+            }
+        ],
+        "li21end": [
+            "Marker",
+            {}
+        ],
+        "li22beg": [
+            "Marker",
+            {}
+        ],
+        "zlin05": [
+            "Marker",
+            {}
+        ],
+        "k22_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:11"
+                }
+            }
+        ],
+        "k22_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:11"
+                }
+            }
+        ],
+        "k22_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:11"
+                }
+            }
+        ],
+        "k22_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:11"
+                }
+            }
+        ],
+        "q22201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7146031856536865,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:201"
+                }
+            }
+        ],
+        "k22_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:21"
+                }
+            }
+        ],
+        "k22_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:21"
+                }
+            }
+        ],
+        "k22_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:21"
+                }
+            }
+        ],
+        "k22_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:21"
+                }
+            }
+        ],
+        "q22301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7621889114379883,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:301"
+                }
+            }
+        ],
+        "k22_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:31"
+                }
+            }
+        ],
+        "k22_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:31"
+                }
+            }
+        ],
+        "k22_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:31"
+                }
+            }
+        ],
+        "k22_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:31"
+                }
+            }
+        ],
+        "q22401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:401"
+                }
+            }
+        ],
+        "k22_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:41"
+                }
+            }
+        ],
+        "k22_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:41"
+                }
+            }
+        ],
+        "k22_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:41"
+                }
+            }
+        ],
+        "k22_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:41"
+                }
+            }
+        ],
+        "q22501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:501"
+                }
+            }
+        ],
+        "k22_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:51"
+                }
+            }
+        ],
+        "k22_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:51"
+                }
+            }
+        ],
+        "k22_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:51"
+                }
+            }
+        ],
+        "k22_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:51"
+                }
+            }
+        ],
+        "q22601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:601"
+                }
+            }
+        ],
+        "k22_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:61"
+                }
+            }
+        ],
+        "k22_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:61"
+                }
+            }
+        ],
+        "k22_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:61"
+                }
+            }
+        ],
+        "k22_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:61"
+                }
+            }
+        ],
+        "q22701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:701"
+                }
+            }
+        ],
+        "k22_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:71"
+                }
+            }
+        ],
+        "k22_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:71"
+                }
+            }
+        ],
+        "k22_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:71"
+                }
+            }
+        ],
+        "k22_7d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:71"
+                }
+            }
+        ],
+        "q22801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.747560441493988,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:801"
+                }
+            }
+        ],
+        "k22_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:81"
+                }
+            }
+        ],
+        "k22_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:81"
+                }
+            }
+        ],
+        "k22_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:81"
+                }
+            }
+        ],
+        "k22_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI22:81"
+                }
+            }
+        ],
+        "q22901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7099809050559998,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI22:901"
+                }
+            }
+        ],
+        "d229a": [
+            "Drift",
+            {
+                "length": 0.3109000027179718,
+                "tracking_method": "linear"
+            }
+        ],
+        "bky22929": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LI22:929"
+                }
+            }
+        ],
+        "d229b": [
+            "Drift",
+            {
+                "length": 0.24390000104904175,
+                "tracking_method": "linear"
+            }
+        ],
+        "bkx22957": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LI22:957"
+                }
+            }
+        ],
+        "d229c": [
+            "Drift",
+            {
+                "length": 1.3978999853134155,
+                "tracking_method": "linear"
+            }
+        ],
+        "li22end": [
+            "Marker",
+            {}
+        ],
+        "li23beg": [
+            "Marker",
+            {}
+        ],
+        "zlin06": [
+            "Marker",
+            {}
+        ],
+        "k23_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:11"
+                }
+            }
+        ],
+        "k23_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:11"
+                }
+            }
+        ],
+        "k23_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:11"
+                }
+            }
+        ],
+        "k23_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:11"
+                }
+            }
+        ],
+        "q23201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7207915186882019,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:201"
+                }
+            }
+        ],
+        "k23_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:21"
+                }
+            }
+        ],
+        "k23_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:21"
+                }
+            }
+        ],
+        "k23_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:21"
+                }
+            }
+        ],
+        "k23_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:21"
+                }
+            }
+        ],
+        "q23301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7418510317802429,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:301"
+                }
+            }
+        ],
+        "k23_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:31"
+                }
+            }
+        ],
+        "k23_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:31"
+                }
+            }
+        ],
+        "k23_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:31"
+                }
+            }
+        ],
+        "k23_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:31"
+                }
+            }
+        ],
+        "q23401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:401"
+                }
+            }
+        ],
+        "k23_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:41"
+                }
+            }
+        ],
+        "k23_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:41"
+                }
+            }
+        ],
+        "k23_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:41"
+                }
+            }
+        ],
+        "k23_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:41"
+                }
+            }
+        ],
+        "q23501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:501"
+                }
+            }
+        ],
+        "k23_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:51"
+                }
+            }
+        ],
+        "k23_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:51"
+                }
+            }
+        ],
+        "k23_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:51"
+                }
+            }
+        ],
+        "k23_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:51"
+                }
+            }
+        ],
+        "q23601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:601"
+                }
+            }
+        ],
+        "k23_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:61"
+                }
+            }
+        ],
+        "k23_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:61"
+                }
+            }
+        ],
+        "k23_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:61"
+                }
+            }
+        ],
+        "k23_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:61"
+                }
+            }
+        ],
+        "q23701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7083885073661804,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:701"
+                }
+            }
+        ],
+        "k23_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:71"
+                }
+            }
+        ],
+        "k23_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:71"
+                }
+            }
+        ],
+        "k23_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:71"
+                }
+            }
+        ],
+        "k23_7d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:71"
+                }
+            }
+        ],
+        "q23801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7706663608551025,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:801"
+                }
+            }
+        ],
+        "k23_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:81"
+                }
+            }
+        ],
+        "k23_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:81"
+                }
+            }
+        ],
+        "k23_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:81"
+                }
+            }
+        ],
+        "k23_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI23:81"
+                }
+            }
+        ],
+        "q23901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.7268516421318054,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI23:901"
+                }
+            }
+        ],
+        "daq4": [
+            "Drift",
+            {
+                "length": 2.5527000427246094,
+                "tracking_method": "linear"
+            }
+        ],
+        "li23end": [
+            "Marker",
+            {}
+        ],
+        "li24beg": [
+            "Marker",
+            {}
+        ],
+        "zlin07": [
+            "Marker",
+            {}
+        ],
+        "k24_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:11"
+                }
+            }
+        ],
+        "k24_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:11"
+                }
+            }
+        ],
+        "k24_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:11"
+                }
+            }
+        ],
+        "k24_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:11"
+                }
+            }
+        ],
+        "q24201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.7792933583259583,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:201"
+                }
+            }
+        ],
+        "k24_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:21"
+                }
+            }
+        ],
+        "k24_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:21"
+                }
+            }
+        ],
+        "k24_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:21"
+                }
+            }
+        ],
+        "k24_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:21"
+                }
+            }
+        ],
+        "q24301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.8564971685409546,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:301"
+                }
+            }
+        ],
+        "k24_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:31"
+                }
+            }
+        ],
+        "k24_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:31"
+                }
+            }
+        ],
+        "k24_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:31"
+                }
+            }
+        ],
+        "k24_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:31"
+                }
+            }
+        ],
+        "q24401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 1.0248178243637085,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:401"
+                }
+            }
+        ],
+        "k24_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:41"
+                }
+            }
+        ],
+        "k24_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:41"
+                }
+            }
+        ],
+        "k24_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:41"
+                }
+            }
+        ],
+        "k24_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:41"
+                }
+            }
+        ],
+        "q24501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.9540035724639893,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:501"
+                }
+            }
+        ],
+        "k24_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:51"
+                }
+            }
+        ],
+        "k24_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:51"
+                }
+            }
+        ],
+        "k24_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:51"
+                }
+            }
+        ],
+        "k24_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:51"
+                }
+            }
+        ],
+        "q24601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.6081355214118958,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:601"
+                }
+            }
+        ],
+        "k24_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:61"
+                }
+            }
+        ],
+        "k24_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:61"
+                }
+            }
+        ],
+        "k24_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:61"
+                }
+            }
+        ],
+        "k24_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 51449448.0,
+                "phase": 33.5,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI24:61"
+                }
+            }
+        ],
+        "li24term": [
+            "Marker",
+            {}
+        ],
+        "endl2": [
+            "Marker",
+            {}
+        ],
+        "begbc2": [
+            "Marker",
+            {}
+        ],
+        "dm20": [
+            "Drift",
+            {
+                "length": 0.03420000150799751,
+                "tracking_method": "linear"
+            }
+        ],
+        "q24701a": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -1.307122826576233,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:701"
+                }
+            }
+        ],
+        "d10cma": [
+            "Drift",
+            {
+                "length": 0.12700000405311584,
+                "tracking_method": "linear"
+            }
+        ],
+        "q24701b": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -1.307122826576233,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:702"
+                }
+            }
+        ],
+        "dm21z": [
+            "Drift",
+            {
+                "length": 0.055800601840019226,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm21a": [
+            "Drift",
+            {
+                "length": 0.3199993968009949,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws24": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI24:705"
+                }
+            }
+        ],
+        "dm21h": [
+            "Drift",
+            {
+                "length": 0.19300000369548798,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbc2i": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LI24:707"
+                }
+            }
+        ],
+        "dm21b": [
+            "Drift",
+            {
+                "length": 0.6340001821517944,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv21": [
+            "Marker",
+            {}
+        ],
+        "dm21c": [
+            "Drift",
+            {
+                "length": 0.32024040818214417,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm21": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.5118958950042725,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:713"
+                }
+            }
+        ],
+        "dm21d": [
+            "Drift",
+            {
+                "length": 0.13953599333763123,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm21e": [
+            "Drift",
+            {
+                "length": 0.19510340690612793,
+                "tracking_method": "linear"
+            }
+        ],
+        "bc2cbeg": [
+            "Marker",
+            {}
+        ],
+        "bx21": [
+            "Dipole",
+            {
+                "length": 0.549125075340271,
+                "angle": -0.0369713231921196,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.0369713231921196,
+                "tilt": 0.0,
+                "gap": 0.03334999829530716,
+                "gap_exit": 0.03334999829530716,
+                "fringe_integral": 0.6330000162124634,
+                "fringe_integral_exit": 0.6330000162124634,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI24:720"
+                }
+            }
+        ],
+        "dbq2a": [
+            "Drift",
+            {
+                "length": 1.9568371772766113,
+                "tracking_method": "linear"
+            }
+        ],
+        "cq21": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:740"
+                }
+            }
+        ],
+        "d21oa": [
+            "Drift",
+            {
+                "length": 7.80210542678833,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx22": [
+            "Dipole",
+            {
+                "length": 0.549125075340271,
+                "angle": 0.0369713231921196,
+                "k1": 0.0,
+                "dipole_e1": 0.0369713231921196,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03334999829530716,
+                "gap_exit": 0.03334999829530716,
+                "fringe_integral": 0.6330000162124634,
+                "fringe_integral_exit": 0.6330000162124634,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI24:790"
+                }
+            }
+        ],
+        "ddg0": [
+            "Drift",
+            {
+                "length": 0.13118499517440796,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpms21": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:LI24:801"
+                }
+            }
+        ],
+        "ce21_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "ce21_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "otr21": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:LI24:807"
+                }
+            }
+        ],
+        "ddga": [
+            "Drift",
+            {
+                "length": 0.13121500611305237,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx23": [
+            "Dipole",
+            {
+                "length": 0.549125075340271,
+                "angle": 0.0369713231921196,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0369713231921196,
+                "tilt": 0.0,
+                "gap": 0.03334999829530716,
+                "gap_exit": 0.03334999829530716,
+                "fringe_integral": 0.6330000162124634,
+                "fringe_integral_exit": 0.6330000162124634,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI24:810"
+                }
+            }
+        ],
+        "d21ob": [
+            "Drift",
+            {
+                "length": 7.80210542678833,
+                "tracking_method": "linear"
+            }
+        ],
+        "cq22": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:860"
+                }
+            }
+        ],
+        "dbq2b": [
+            "Drift",
+            {
+                "length": 1.9568371772766113,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx24": [
+            "Dipole",
+            {
+                "length": 0.549125075340271,
+                "angle": -0.0369713231921196,
+                "k1": 0.0,
+                "dipole_e1": -0.0369713231921196,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03334999829530716,
+                "gap_exit": 0.03334999829530716,
+                "fringe_integral": 0.6330000162124634,
+                "fringe_integral_exit": 0.6330000162124634,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LI24:880"
+                }
+            }
+        ],
+        "cnt2": [
+            "Marker",
+            {}
+        ],
+        "bc2cend": [
+            "Marker",
+            {}
+        ],
+        "d21w": [
+            "Drift",
+            {
+                "length": 0.30649998784065247,
+                "tracking_method": "linear"
+            }
+        ],
+        "d21x": [
+            "Drift",
+            {
+                "length": 0.2087000012397766,
+                "tracking_method": "linear"
+            }
+        ],
+        "bl21": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BLEN:LI24:886"
+                }
+            }
+        ],
+        "d21y": [
+            "Drift",
+            {
+                "length": 0.11423499882221222,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm23b": [
+            "Drift",
+            {
+                "length": 0.050404999405145645,
+                "tracking_method": "linear"
+            }
+        ],
+        "qm22": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.5894557237625122,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:892"
+                }
+            }
+        ],
+        "dm24a": [
+            "Drift",
+            {
+                "length": 0.12943999469280243,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv22": [
+            "Marker",
+            {}
+        ],
+        "dm24b": [
+            "Drift",
+            {
+                "length": 0.17800000309944153,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm24d": [
+            "Drift",
+            {
+                "length": 0.07069999724626541,
+                "tracking_method": "linear"
+            }
+        ],
+        "q24901a": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 1.08145272731781,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:901"
+                }
+            }
+        ],
+        "dm24c": [
+            "Drift",
+            {
+                "length": 0.1062999963760376,
+                "tracking_method": "linear"
+            }
+        ],
+        "q24901b": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 1.08145272731781,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI24:902"
+                }
+            }
+        ],
+        "dm25": [
+            "Drift",
+            {
+                "length": 0.16040000319480896,
+                "tracking_method": "linear"
+            }
+        ],
+        "endbc2": [
+            "Marker",
+            {}
+        ],
+        "begl3": [
+            "Marker",
+            {}
+        ],
+        "li25beg": [
+            "Marker",
+            {}
+        ],
+        "zlin09": [
+            "Marker",
+            {}
+        ],
+        "k25_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:11"
+                }
+            }
+        ],
+        "k25_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:11"
+                }
+            }
+        ],
+        "d25_1c": [
+            "Drift",
+            {
+                "length": 3.044100046157837,
+                "tracking_method": "linear"
+            }
+        ],
+        "k25_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 68162928.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:11"
+                }
+            }
+        ],
+        "q25201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.6983538866043091,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:201"
+                }
+            }
+        ],
+        "k25_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:21"
+                }
+            }
+        ],
+        "k25_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:21"
+                }
+            }
+        ],
+        "k25_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 68162928.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:21"
+                }
+            }
+        ],
+        "d255a": [
+            "Drift",
+            {
+                "length": 0.06469999998807907,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbc2o": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LI25:235"
+                }
+            }
+        ],
+        "d255b": [
+            "Drift",
+            {
+                "length": 0.11334999650716782,
+                "tracking_method": "linear"
+            }
+        ],
+        "d255c": [
+            "Drift",
+            {
+                "length": 0.15254999697208405,
+                "tracking_method": "linear"
+            }
+        ],
+        "tcav3": [
+            "Cavity",
+            {
+                "length": 2.437999963760376,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "TCAV:LI24:800"
+                }
+            }
+        ],
+        "d255d": [
+            "Drift",
+            {
+                "length": 0.30970001220703125,
+                "tracking_method": "linear"
+            }
+        ],
+        "q25301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.4798545241355896,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:301"
+                }
+            }
+        ],
+        "k25_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:31"
+                }
+            }
+        ],
+        "k25_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:31"
+                }
+            }
+        ],
+        "k25_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 68162928.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:31"
+                }
+            }
+        ],
+        "d256a": [
+            "Drift",
+            {
+                "length": 0.5989999771118164,
+                "tracking_method": "linear"
+            }
+        ],
+        "ph03": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:LI25:300"
+                }
+            }
+        ],
+        "d256b": [
+            "Drift",
+            {
+                "length": 0.5590999722480774,
+                "tracking_method": "linear"
+            }
+        ],
+        "bl22": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BLEN:LI25:340"
+                }
+            }
+        ],
+        "d256c": [
+            "Drift",
+            {
+                "length": 0.6147500276565552,
+                "tracking_method": "linear"
+            }
+        ],
+        "bxkik": [
+            "Drift",
+            {
+                "length": 1.0600999593734741,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LI25:344"
+                }
+            }
+        ],
+        "d256d": [
+            "Drift",
+            {
+                "length": 0.21115000545978546,
+                "tracking_method": "linear"
+            }
+        ],
+        "q25401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.4298321604728699,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:401"
+                }
+            }
+        ],
+        "k25_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:41"
+                }
+            }
+        ],
+        "k25_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:41"
+                }
+            }
+        ],
+        "k25_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:41"
+                }
+            }
+        ],
+        "k25_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:41"
+                }
+            }
+        ],
+        "q25501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.400216281414032,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:501"
+                }
+            }
+        ],
+        "k25_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:51"
+                }
+            }
+        ],
+        "k25_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:51"
+                }
+            }
+        ],
+        "k25_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:51"
+                }
+            }
+        ],
+        "k25_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:51"
+                }
+            }
+        ],
+        "q25601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:601"
+                }
+            }
+        ],
+        "k25_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:61"
+                }
+            }
+        ],
+        "k25_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:61"
+                }
+            }
+        ],
+        "k25_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:61"
+                }
+            }
+        ],
+        "k25_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:61"
+                }
+            }
+        ],
+        "q25701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:701"
+                }
+            }
+        ],
+        "k25_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:71"
+                }
+            }
+        ],
+        "k25_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:71"
+                }
+            }
+        ],
+        "k25_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:71"
+                }
+            }
+        ],
+        "k25_7d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:71"
+                }
+            }
+        ],
+        "q25801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.4075244665145874,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:801"
+                }
+            }
+        ],
+        "k25_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:81"
+                }
+            }
+        ],
+        "k25_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:81"
+                }
+            }
+        ],
+        "k25_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:81"
+                }
+            }
+        ],
+        "k25_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI25:81"
+                }
+            }
+        ],
+        "daq7": [
+            "Drift",
+            {
+                "length": 0.27480000257492065,
+                "tracking_method": "linear"
+            }
+        ],
+        "q25901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3886786997318268,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI25:901"
+                }
+            }
+        ],
+        "daq8a": [
+            "Drift",
+            {
+                "length": 0.5031999945640564,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr_tcav": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:LI25:920"
+                }
+            }
+        ],
+        "daq8b": [
+            "Drift",
+            {
+                "length": 2.128000020980835,
+                "tracking_method": "linear"
+            }
+        ],
+        "li25end": [
+            "Marker",
+            {}
+        ],
+        "li26beg": [
+            "Marker",
+            {}
+        ],
+        "zlin10": [
+            "Marker",
+            {}
+        ],
+        "k26_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:11"
+                }
+            }
+        ],
+        "k26_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:11"
+                }
+            }
+        ],
+        "k26_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:11"
+                }
+            }
+        ],
+        "k26_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:11"
+                }
+            }
+        ],
+        "q26201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.3888441324234009,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:201"
+                }
+            }
+        ],
+        "k26_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:21"
+                }
+            }
+        ],
+        "k26_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:21"
+                }
+            }
+        ],
+        "k26_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:21"
+                }
+            }
+        ],
+        "k26_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:21"
+                }
+            }
+        ],
+        "q26301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.4053811728954315,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:301"
+                }
+            }
+        ],
+        "k26_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:31"
+                }
+            }
+        ],
+        "k26_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:31"
+                }
+            }
+        ],
+        "k26_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:31"
+                }
+            }
+        ],
+        "k26_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:31"
+                }
+            }
+        ],
+        "q26401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:401"
+                }
+            }
+        ],
+        "k26_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:41"
+                }
+            }
+        ],
+        "k26_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:41"
+                }
+            }
+        ],
+        "k26_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:41"
+                }
+            }
+        ],
+        "k26_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:41"
+                }
+            }
+        ],
+        "q26501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:501"
+                }
+            }
+        ],
+        "k26_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:51"
+                }
+            }
+        ],
+        "k26_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:51"
+                }
+            }
+        ],
+        "k26_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:51"
+                }
+            }
+        ],
+        "k26_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:51"
+                }
+            }
+        ],
+        "q26601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:601"
+                }
+            }
+        ],
+        "k26_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:61"
+                }
+            }
+        ],
+        "k26_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:61"
+                }
+            }
+        ],
+        "k26_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:61"
+                }
+            }
+        ],
+        "k26_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:61"
+                }
+            }
+        ],
+        "q26701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:701"
+                }
+            }
+        ],
+        "k26_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:71"
+                }
+            }
+        ],
+        "k26_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:71"
+                }
+            }
+        ],
+        "k26_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:71"
+                }
+            }
+        ],
+        "k26_7d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:71"
+                }
+            }
+        ],
+        "q26801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.4060079753398895,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:801"
+                }
+            }
+        ],
+        "k26_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:81"
+                }
+            }
+        ],
+        "k26_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:81"
+                }
+            }
+        ],
+        "k26_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:81"
+                }
+            }
+        ],
+        "k26_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 48198468.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI26:81"
+                }
+            }
+        ],
+        "q26901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3887695372104645,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI26:901"
+                }
+            }
+        ],
+        "daq8": [
+            "Drift",
+            {
+                "length": 2.631200075149536,
+                "tracking_method": "linear"
+            }
+        ],
+        "li26end": [
+            "Marker",
+            {}
+        ],
+        "li27beg": [
+            "Marker",
+            {}
+        ],
+        "zlin11": [
+            "Marker",
+            {}
+        ],
+        "k27_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:11"
+                }
+            }
+        ],
+        "k27_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:11"
+                }
+            }
+        ],
+        "k27_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:11"
+                }
+            }
+        ],
+        "k27_1d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:11"
+                }
+            }
+        ],
+        "q27201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.3910715579986572,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:201"
+                }
+            }
+        ],
+        "k27_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:21"
+                }
+            }
+        ],
+        "k27_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:21"
+                }
+            }
+        ],
+        "k27_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:21"
+                }
+            }
+        ],
+        "k27_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:21"
+                }
+            }
+        ],
+        "q27301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.4071718752384186,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:301"
+                }
+            }
+        ],
+        "k27_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:31"
+                }
+            }
+        ],
+        "k27_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:31"
+                }
+            }
+        ],
+        "k27_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:31"
+                }
+            }
+        ],
+        "k27_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:31"
+                }
+            }
+        ],
+        "q27401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:401"
+                }
+            }
+        ],
+        "k27_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:41"
+                }
+            }
+        ],
+        "k27_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:41"
+                }
+            }
+        ],
+        "k27_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:41"
+                }
+            }
+        ],
+        "k27_4d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:41"
+                }
+            }
+        ],
+        "q27501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:501"
+                }
+            }
+        ],
+        "k27_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:51"
+                }
+            }
+        ],
+        "k27_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:51"
+                }
+            }
+        ],
+        "k27_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:51"
+                }
+            }
+        ],
+        "k27_5d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:51"
+                }
+            }
+        ],
+        "q27601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:601"
+                }
+            }
+        ],
+        "k27_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:61"
+                }
+            }
+        ],
+        "k27_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:61"
+                }
+            }
+        ],
+        "k27_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:61"
+                }
+            }
+        ],
+        "daq5a": [
+            "Drift",
+            {
+                "length": 2.3434998989105225,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws27644": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI27:644"
+                }
+            }
+        ],
+        "daq6a": [
+            "Drift",
+            {
+                "length": 0.7347999811172485,
+                "tracking_method": "linear"
+            }
+        ],
+        "q27701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:701"
+                }
+            }
+        ],
+        "k27_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:71"
+                }
+            }
+        ],
+        "k27_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:71"
+                }
+            }
+        ],
+        "k27_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:71"
+                }
+            }
+        ],
+        "k27_7d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:71"
+                }
+            }
+        ],
+        "q27801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.4068216383457184,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:801"
+                }
+            }
+        ],
+        "k27_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:81"
+                }
+            }
+        ],
+        "k27_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:81"
+                }
+            }
+        ],
+        "k27_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:81"
+                }
+            }
+        ],
+        "k27_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI27:81"
+                }
+            }
+        ],
+        "q27901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.38950514793395996,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI27:901"
+                }
+            }
+        ],
+        "li27end": [
+            "Marker",
+            {}
+        ],
+        "li28beg": [
+            "Marker",
+            {}
+        ],
+        "zlin12": [
+            "Marker",
+            {}
+        ],
+        "k28_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:11"
+                }
+            }
+        ],
+        "k28_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:11"
+                }
+            }
+        ],
+        "k28_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:11"
+                }
+            }
+        ],
+        "daq5b1": [
+            "Drift",
+            {
+                "length": 2.0906999111175537,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc29092": [
+            "Marker",
+            {}
+        ],
+        "daq5b2": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc29092": [
+            "Marker",
+            {}
+        ],
+        "daq5b3": [
+            "Drift",
+            {
+                "length": 0.4542999863624573,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws28144": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI28:144"
+                }
+            }
+        ],
+        "daq6b": [
+            "Drift",
+            {
+                "length": 0.23729999363422394,
+                "tracking_method": "linear"
+            }
+        ],
+        "q28201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.3908107280731201,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:201"
+                }
+            }
+        ],
+        "k28_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:21"
+                }
+            }
+        ],
+        "k28_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:21"
+                }
+            }
+        ],
+        "k28_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:21"
+                }
+            }
+        ],
+        "k28_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:21"
+                }
+            }
+        ],
+        "q28301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.40650999546051025,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:301"
+                }
+            }
+        ],
+        "k28_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:31"
+                }
+            }
+        ],
+        "k28_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:31"
+                }
+            }
+        ],
+        "k28_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:31"
+                }
+            }
+        ],
+        "k28_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:31"
+                }
+            }
+        ],
+        "q28401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:401"
+                }
+            }
+        ],
+        "k28_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:41"
+                }
+            }
+        ],
+        "k28_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:41"
+                }
+            }
+        ],
+        "k28_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:41"
+                }
+            }
+        ],
+        "daq5c1": [
+            "Drift",
+            {
+                "length": 2.080699920654297,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc29095": [
+            "Marker",
+            {}
+        ],
+        "daq5c2": [
+            "Drift",
+            {
+                "length": 0.28600001335144043,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc29095": [
+            "Marker",
+            {}
+        ],
+        "daq5c3": [
+            "Drift",
+            {
+                "length": 0.47429999709129333,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws28444": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI28:444"
+                }
+            }
+        ],
+        "daq6c": [
+            "Drift",
+            {
+                "length": 0.23729999363422394,
+                "tracking_method": "linear"
+            }
+        ],
+        "q28501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:501"
+                }
+            }
+        ],
+        "k28_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:51"
+                }
+            }
+        ],
+        "k28_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:51"
+                }
+            }
+        ],
+        "k28_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:51"
+                }
+            }
+        ],
+        "d28_5d": [
+            "Drift",
+            {
+                "length": 3.044100046157837,
+                "tracking_method": "linear"
+            }
+        ],
+        "q28601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:601"
+                }
+            }
+        ],
+        "k28_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:61"
+                }
+            }
+        ],
+        "k28_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:61"
+                }
+            }
+        ],
+        "k28_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:61"
+                }
+            }
+        ],
+        "k28_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:61"
+                }
+            }
+        ],
+        "q28701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:701"
+                }
+            }
+        ],
+        "k28_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:71"
+                }
+            }
+        ],
+        "k28_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:71"
+                }
+            }
+        ],
+        "k28_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:71"
+                }
+            }
+        ],
+        "daq5d": [
+            "Drift",
+            {
+                "length": 2.3440001010894775,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws28744": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LI28:744"
+                }
+            }
+        ],
+        "daq6d": [
+            "Drift",
+            {
+                "length": 0.7343000173568726,
+                "tracking_method": "linear"
+            }
+        ],
+        "q28801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.40682169795036316,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:801"
+                }
+            }
+        ],
+        "k28_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:81"
+                }
+            }
+        ],
+        "k28_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:81"
+                }
+            }
+        ],
+        "k28_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:81"
+                }
+            }
+        ],
+        "k28_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI28:81"
+                }
+            }
+        ],
+        "q28901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.38950520753860474,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI28:901"
+                }
+            }
+        ],
+        "daq8c": [
+            "Drift",
+            {
+                "length": 0.3352000117301941,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29096_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29096_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "daq8d1": [
+            "Drift",
+            {
+                "length": 0.743399977684021,
+                "tracking_method": "linear"
+            }
+        ],
+        "st28950": [
+            "Drift",
+            {
+                "length": 0.20319999754428864,
+                "tracking_method": "linear"
+            }
+        ],
+        "daq8d2": [
+            "Drift",
+            {
+                "length": 0.21580000221729279,
+                "tracking_method": "linear"
+            }
+        ],
+        "st28960": [
+            "Drift",
+            {
+                "length": 0.20319999754428864,
+                "tracking_method": "linear"
+            }
+        ],
+        "daq8d3": [
+            "Drift",
+            {
+                "length": 0.930400013923645,
+                "tracking_method": "linear"
+            }
+        ],
+        "li28end": [
+            "Marker",
+            {}
+        ],
+        "li29beg": [
+            "Marker",
+            {}
+        ],
+        "zlin13": [
+            "Marker",
+            {}
+        ],
+        "k29_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:11"
+                }
+            }
+        ],
+        "k29_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:11"
+                }
+            }
+        ],
+        "k29_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:11"
+                }
+            }
+        ],
+        "d10ca": [
+            "Drift",
+            {
+                "length": 2.815700054168701,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29146_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29146_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "d10cb": [
+            "Drift",
+            {
+                "length": 0.22840000689029694,
+                "tracking_method": "linear"
+            }
+        ],
+        "q29201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.39081063866615295,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:201"
+                }
+            }
+        ],
+        "k29_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:21"
+                }
+            }
+        ],
+        "k29_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:21"
+                }
+            }
+        ],
+        "k29_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:21"
+                }
+            }
+        ],
+        "k29_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:21"
+                }
+            }
+        ],
+        "q29301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.4065098166465759,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:301"
+                }
+            }
+        ],
+        "k29_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:31"
+                }
+            }
+        ],
+        "k29_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:31"
+                }
+            }
+        ],
+        "k29_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:31"
+                }
+            }
+        ],
+        "k29_3d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:31"
+                }
+            }
+        ],
+        "q29401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:401"
+                }
+            }
+        ],
+        "k29_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:41"
+                }
+            }
+        ],
+        "k29_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:41"
+                }
+            }
+        ],
+        "k29_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:41"
+                }
+            }
+        ],
+        "d10cc": [
+            "Drift",
+            {
+                "length": 2.8159000873565674,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29446_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29446_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "d10cd": [
+            "Drift",
+            {
+                "length": 0.2282000035047531,
+                "tracking_method": "linear"
+            }
+        ],
+        "q29501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:501"
+                }
+            }
+        ],
+        "k29_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:51"
+                }
+            }
+        ],
+        "k29_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:51"
+                }
+            }
+        ],
+        "k29_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:51"
+                }
+            }
+        ],
+        "d10ce": [
+            "Drift",
+            {
+                "length": 2.8160998821258545,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29546_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29546_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "d10cf": [
+            "Drift",
+            {
+                "length": 0.2280000001192093,
+                "tracking_method": "linear"
+            }
+        ],
+        "q29601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:601"
+                }
+            }
+        ],
+        "k29_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:61"
+                }
+            }
+        ],
+        "k29_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:61"
+                }
+            }
+        ],
+        "k29_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:61"
+                }
+            }
+        ],
+        "k29_6d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:61"
+                }
+            }
+        ],
+        "q29701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:701"
+                }
+            }
+        ],
+        "k29_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:71"
+                }
+            }
+        ],
+        "k29_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:71"
+                }
+            }
+        ],
+        "k29_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:71"
+                }
+            }
+        ],
+        "k29_7d": [
+            "Cavity",
+            {
+                "length": 2.8691999912261963,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:71"
+                }
+            }
+        ],
+        "daq9a": [
+            "Drift",
+            {
+                "length": 0.08110000193119049,
+                "tracking_method": "linear"
+            }
+        ],
+        "pk297": [
+            "Marker",
+            {}
+        ],
+        "daq9b": [
+            "Drift",
+            {
+                "length": 0.12800000607967377,
+                "tracking_method": "linear"
+            }
+        ],
+        "q29801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.4067477583885193,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:801"
+                }
+            }
+        ],
+        "k29_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:81"
+                }
+            }
+        ],
+        "k29_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:81"
+                }
+            }
+        ],
+        "k29_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:81"
+                }
+            }
+        ],
+        "k29_8d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI29:81"
+                }
+            }
+        ],
+        "q29901": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3893742561340332,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI29:901"
+                }
+            }
+        ],
+        "daq4a": [
+            "Drift",
+            {
+                "length": 0.25270000100135803,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30013": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:13"
+                }
+            }
+        ],
+        "daq4b": [
+            "Drift",
+            {
+                "length": 0.2029999941587448,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30014": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:14"
+                }
+            }
+        ],
+        "daq4c": [
+            "Drift",
+            {
+                "length": 0.9150000214576721,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29956_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c29956_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "daq4d": [
+            "Drift",
+            {
+                "length": 0.2720000147819519,
+                "tracking_method": "linear"
+            }
+        ],
+        "pk299": [
+            "Marker",
+            {}
+        ],
+        "daq4e": [
+            "Drift",
+            {
+                "length": 0.9100000262260437,
+                "tracking_method": "linear"
+            }
+        ],
+        "li29end": [
+            "Marker",
+            {}
+        ],
+        "li30beg": [
+            "Marker",
+            {}
+        ],
+        "zlin14": [
+            "Marker",
+            {}
+        ],
+        "k30_1a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:11"
+                }
+            }
+        ],
+        "k30_1b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:11"
+                }
+            }
+        ],
+        "k30_1c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:11"
+                }
+            }
+        ],
+        "k30_1d": [
+            "Cavity",
+            {
+                "length": 2.1693999767303467,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:11"
+                }
+            }
+        ],
+        "daq10a": [
+            "Drift",
+            {
+                "length": 0.13330000638961792,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30143": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:143"
+                }
+            }
+        ],
+        "daq10b": [
+            "Drift",
+            {
+                "length": 0.2029999941587448,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30144": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:144"
+                }
+            }
+        ],
+        "daq10c": [
+            "Drift",
+            {
+                "length": 0.2150000035762787,
+                "tracking_method": "linear"
+            }
+        ],
+        "c30146_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c30146_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "daq10d": [
+            "Drift",
+            {
+                "length": 0.35760000348091125,
+                "tracking_method": "linear"
+            }
+        ],
+        "q30201": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.3905400335788727,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:201"
+                }
+            }
+        ],
+        "k30_2a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:21"
+                }
+            }
+        ],
+        "k30_2b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:21"
+                }
+            }
+        ],
+        "k30_2c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:21"
+                }
+            }
+        ],
+        "k30_2d": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:21"
+                }
+            }
+        ],
+        "q30301": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.4062204658985138,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:301"
+                }
+            }
+        ],
+        "k30_3a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:31"
+                }
+            }
+        ],
+        "k30_3b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:31"
+                }
+            }
+        ],
+        "k30_3c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:31"
+                }
+            }
+        ],
+        "k30_3d": [
+            "Cavity",
+            {
+                "length": 2.1693999767303467,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:31"
+                }
+            }
+        ],
+        "daq10e": [
+            "Drift",
+            {
+                "length": 0.7764999866485596,
+                "tracking_method": "linear"
+            }
+        ],
+        "pk303": [
+            "Marker",
+            {}
+        ],
+        "daq10f": [
+            "Drift",
+            {
+                "length": 0.1324000060558319,
+                "tracking_method": "linear"
+            }
+        ],
+        "q30401": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:401"
+                }
+            }
+        ],
+        "k30_4a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:41"
+                }
+            }
+        ],
+        "k30_4b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:41"
+                }
+            }
+        ],
+        "k30_4c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:41"
+                }
+            }
+        ],
+        "k30_4d": [
+            "Cavity",
+            {
+                "length": 2.1693999767303467,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:41"
+                }
+            }
+        ],
+        "daq10g": [
+            "Drift",
+            {
+                "length": 0.13009999692440033,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30443": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:443"
+                }
+            }
+        ],
+        "daq10h": [
+            "Drift",
+            {
+                "length": 0.2029999941587448,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30444": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:444"
+                }
+            }
+        ],
+        "daq10i": [
+            "Drift",
+            {
+                "length": 0.20600000023841858,
+                "tracking_method": "linear"
+            }
+        ],
+        "c30446_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c30446_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "daq10j": [
+            "Drift",
+            {
+                "length": 0.2370000034570694,
+                "tracking_method": "linear"
+            }
+        ],
+        "pk304": [
+            "Marker",
+            {}
+        ],
+        "daq10k": [
+            "Drift",
+            {
+                "length": 0.13279999792575836,
+                "tracking_method": "linear"
+            }
+        ],
+        "q30501": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3956492841243744,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:501"
+                }
+            }
+        ],
+        "k30_5a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:51"
+                }
+            }
+        ],
+        "k30_5b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:51"
+                }
+            }
+        ],
+        "k30_5c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:51"
+                }
+            }
+        ],
+        "k30_5d": [
+            "Cavity",
+            {
+                "length": 2.1693999767303467,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:51"
+                }
+            }
+        ],
+        "daq11a": [
+            "Drift",
+            {
+                "length": 0.13169999420642853,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30543": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:543"
+                }
+            }
+        ],
+        "daq11b": [
+            "Drift",
+            {
+                "length": 0.210999995470047,
+                "tracking_method": "linear"
+            }
+        ],
+        "p30544": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "LI30:PROF:544"
+                }
+            }
+        ],
+        "daq11c": [
+            "Drift",
+            {
+                "length": 0.210999995470047,
+                "tracking_method": "linear"
+            }
+        ],
+        "c30546_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "c30546_aperture": [
+            "Aperture",
+            {
+                "x_max": Infinity,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "daq11d": [
+            "Drift",
+            {
+                "length": 0.15360000729560852,
+                "tracking_method": "linear"
+            }
+        ],
+        "q30601": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.395798921585083,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:601"
+                }
+            }
+        ],
+        "daq12": [
+            "Drift",
+            {
+                "length": 0.22859999537467957,
+                "tracking_method": "linear"
+            }
+        ],
+        "k30_6a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:61"
+                }
+            }
+        ],
+        "k30_6b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:61"
+                }
+            }
+        ],
+        "k30_6c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:61"
+                }
+            }
+        ],
+        "k30_6d": [
+            "Cavity",
+            {
+                "length": 2.8691999912261963,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:61"
+                }
+            }
+        ],
+        "daq13": [
+            "Drift",
+            {
+                "length": 0.023099999874830246,
+                "tracking_method": "linear"
+            }
+        ],
+        "q30701": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": -0.3962310254573822,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:701"
+                }
+            }
+        ],
+        "daq14": [
+            "Drift",
+            {
+                "length": 0.21299999952316284,
+                "tracking_method": "linear"
+            }
+        ],
+        "k30_7a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:71"
+                }
+            }
+        ],
+        "k30_7b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:71"
+                }
+            }
+        ],
+        "k30_7c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:71"
+                }
+            }
+        ],
+        "k30_7d": [
+            "Cavity",
+            {
+                "length": 2.8691999912261963,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:71"
+                }
+            }
+        ],
+        "daq15": [
+            "Drift",
+            {
+                "length": 0.008700000122189522,
+                "tracking_method": "linear"
+            }
+        ],
+        "q30801": [
+            "Quadrupole",
+            {
+                "length": 0.10679999738931656,
+                "k1": 0.48059216141700745,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LI30:801"
+                }
+            }
+        ],
+        "daq16": [
+            "Drift",
+            {
+                "length": 0.227400004863739,
+                "tracking_method": "linear"
+            }
+        ],
+        "k30_8a": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:81"
+                }
+            }
+        ],
+        "k30_8b": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:81"
+                }
+            }
+        ],
+        "k30_8c": [
+            "Cavity",
+            {
+                "length": 3.044100046157837,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 2856000000.0,
+                "metadata": {
+                    "alias": "KLYS:LI30:81"
+                }
+            }
+        ],
+        "daq17": [
+            "Drift",
+            {
+                "length": 0.061900001019239426,
+                "tracking_method": "linear"
+            }
+        ],
+        "li30term": [
+            "Marker",
+            {}
+        ],
+        "dbmark29": [
+            "Marker",
+            {}
+        ],
+        "endl3": [
+            "Marker",
+            {}
+        ],
+        "begclth_0": [
+            "Marker",
+            {}
+        ],
+        "bsybeg": [
+            "Marker",
+            {}
+        ],
+        "bsy1beg": [
+            "Marker",
+            {}
+        ],
+        "dbsy01a": [
+            "Drift",
+            {
+                "length": 0.728600025177002,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:104"
+                }
+            }
+        ],
+        "dbsy01b": [
+            "Drift",
+            {
+                "length": 0.25005000829696655,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy2": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:105"
+                }
+            }
+        ],
+        "dbsy01c": [
+            "Drift",
+            {
+                "length": 0.25005000829696655,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy3": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:107"
+                }
+            }
+        ],
+        "dbsy01d": [
+            "Drift",
+            {
+                "length": 0.41429999470710754,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy34": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:108"
+                }
+            }
+        ],
+        "dbsy01e": [
+            "Drift",
+            {
+                "length": 2.904599905014038,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy1b": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:122"
+                }
+            }
+        ],
+        "dbsy01f": [
+            "Drift",
+            {
+                "length": 0.31575000286102295,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy2b": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:124"
+                }
+            }
+        ],
+        "dbsy01g": [
+            "Drift",
+            {
+                "length": 0.31575000286102295,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbsy3b": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:CLTH:126"
+                }
+            }
+        ],
+        "dbsy01h": [
+            "Drift",
+            {
+                "length": 0.7975000143051147,
+                "tracking_method": "linear"
+            }
+        ],
+        "fftborgn": [
+            "Marker",
+            {}
+        ],
+        "dbsy01i": [
+            "Drift",
+            {
+                "length": 0.018400000408291817,
+                "tracking_method": "linear"
+            }
+        ],
+        "s100": [
+            "Marker",
+            {}
+        ],
+        "zlin15": [
+            "Marker",
+            {}
+        ],
+        "dbsy50a": [
+            "Drift",
+            {
+                "length": 0.5781999826431274,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycbsyq1": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:CLTH:133"
+                }
+            }
+        ],
+        "dbsy50b": [
+            "Drift",
+            {
+                "length": 1.4345760345458984,
+                "tracking_method": "linear"
+            }
+        ],
+        "q50q1": [
+            "Quadrupole",
+            {
+                "length": 0.2630000114440918,
+                "k1": -0.23152229189872742,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:CLTH:140"
+                }
+            }
+        ],
+        "dbsy02a": [
+            "Drift",
+            {
+                "length": 0.2362239956855774,
+                "tracking_method": "linear"
+            }
+        ],
+        "wooddoor": [
+            "Marker",
+            {}
+        ],
+        "endclth_0": [
+            "Marker",
+            {}
+        ],
+        "begclth_1": [
+            "Marker",
+            {}
+        ],
+        "dbsy02b": [
+            "Drift",
+            {
+                "length": 0.2198999971151352,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmbsyq1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BPMS:CLTH:140"
+                }
+            }
+        ],
+        "dbsy51a": [
+            "Drift",
+            {
+                "length": 5.021975994110107,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcbsyq2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:CLTH:168"
+                }
+            }
+        ],
+        "dbsy51b": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "q50q2": [
+            "Quadrupole",
+            {
+                "length": 0.32430198788642883,
+                "k1": 0.10207433253526688,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:CLTH:170"
+                }
+            }
+        ],
+        "dbsy52a": [
+            "Drift",
+            {
+                "length": 0.07914900034666061,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmbsyq2": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BPMS:CLTH:170"
+                }
+            }
+        ],
+        "dbsy52b": [
+            "Drift",
+            {
+                "length": 1.7995890378952026,
+                "tracking_method": "linear"
+            }
+        ],
+        "endclth_1": [
+            "Marker",
+            {}
+        ],
+        "begclth_2": [
+            "Marker",
+            {}
+        ],
+        "dbrcusdc1a": [
+            "Drift",
+            {
+                "length": 0.13455000519752502,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbrcusdc1b": [
+            "Drift",
+            {
+                "length": 0.13455000519752502,
+                "tracking_method": "linear"
+            }
+        ],
+        "dckdc1": [
+            "Drift",
+            {
+                "length": 0.3521620035171509,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrcusa": [
+            "Drift",
+            {
+                "length": 0.5300499796867371,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrcusb": [
+            "Drift",
+            {
+                "length": 0.5300499796867371,
+                "tracking_method": "linear"
+            }
+        ],
+        "dckdc2": [
+            "Drift",
+            {
+                "length": 0.3521620035171509,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbrcusdc2a": [
+            "Drift",
+            {
+                "length": 0.13455000519752502,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbrcusdc2b": [
+            "Drift",
+            {
+                "length": 0.13455000519752502,
+                "tracking_method": "linear"
+            }
+        ],
+        "dcusblra": [
+            "Drift",
+            {
+                "length": 4.574337959289551,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmcus": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:CLTH:215"
+                }
+            }
+        ],
+        "dcusblrb": [
+            "Drift",
+            {
+                "length": 10.951299667358398,
+                "tracking_method": "linear"
+            }
+        ],
+        "dblrcusa": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "dblrcusb": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbsy52c": [
+            "Drift",
+            {
+                "length": 32.67631530761719,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbxsp1ha": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbxsp1hb": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "bsy1end": [
+            "Marker",
+            {}
+        ],
+        "endclth_2": [
+            "Marker",
+            {}
+        ],
+        "begbsyh_1": [
+            "Marker",
+            {}
+        ],
+        "dbsy52d": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "q50q3": [
+            "Quadrupole",
+            {
+                "length": 0.2865079939365387,
+                "k1": 0.38484084606170654,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:BSYH:445"
+                }
+            }
+        ],
+        "dbsy53a": [
+            "Drift",
+            {
+                "length": 0.09169600158929825,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmbsyq3": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:BSYH:445"
+                }
+            }
+        ],
+        "rfbbsyq3": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:BSYH:446"
+                }
+            }
+        ],
+        "dbsy53b": [
+            "Drift",
+            {
+                "length": 0.6107050180435181,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbsy53c": [
+            "Drift",
+            {
+                "length": 0.7799450159072876,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcbsyq3": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:BSYH:452"
+                }
+            }
+        ],
+        "dbsy53d": [
+            "Drift",
+            {
+                "length": 2.0176539421081543,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycbsyq4": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:BSYH:461"
+                }
+            }
+        ],
+        "dbsy53f": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "q4": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.219396710395813,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:BSYH:465"
+                }
+            }
+        ],
+        "dbsy53ga": [
+            "Drift",
+            {
+                "length": 0.9129300117492676,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcbsy3": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "COLL:BSYH:471"
+                }
+            }
+        ],
+        "dbsy53gb": [
+            "Drift",
+            {
+                "length": 0.22357000410556793,
+                "tracking_method": "linear"
+            }
+        ],
+        "mrgaline": [
+            "Marker",
+            {}
+        ],
+        "endbsyh_1": [
+            "Marker",
+            {}
+        ],
+        "begbsyh_2": [
+            "Marker",
+            {}
+        ],
+        "dbkrapm1a": [
+            "Drift",
+            {
+                "length": 0.5274994969367981,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrapm1b": [
+            "Drift",
+            {
+                "length": 0.5274994969367981,
+                "tracking_method": "linear"
+            }
+        ],
+        "dzapm1": [
+            "Drift",
+            {
+                "length": 0.20634886622428894,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm1_drift": [
+            "Drift",
+            {
+                "length": 0.18240000307559967,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm1_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.044449999928474426,
+                "y_max": 0.00634999992325902,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dbkrapm2a": [
+            "Drift",
+            {
+                "length": 0.5274954438209534,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrapm2b": [
+            "Drift",
+            {
+                "length": 0.5274954438209534,
+                "tracking_method": "linear"
+            }
+        ],
+        "dzapm2a": [
+            "Drift",
+            {
+                "length": 0.10317272692918777,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcapm2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0
+            }
+        ],
+        "ycapm2": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0
+            }
+        ],
+        "dzapm2b": [
+            "Drift",
+            {
+                "length": 0.10317272692918777,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm2_drift": [
+            "Drift",
+            {
+                "length": 0.18240000307559967,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm2_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.044449999928474426,
+                "y_max": 0.00634999992325902,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dzapm2": [
+            "Drift",
+            {
+                "length": 0.20634545385837555,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrapm3a": [
+            "Drift",
+            {
+                "length": 0.5274873971939087,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrapm3b": [
+            "Drift",
+            {
+                "length": 0.5274873971939087,
+                "tracking_method": "linear"
+            }
+        ],
+        "dzapm3": [
+            "Drift",
+            {
+                "length": 0.2063397616147995,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm3_drift": [
+            "Drift",
+            {
+                "length": 0.18240000307559967,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm3_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.044449999928474426,
+                "y_max": 0.00634999992325902,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dbkrapm4a": [
+            "Drift",
+            {
+                "length": 0.5274752974510193,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkrapm4b": [
+            "Drift",
+            {
+                "length": 0.5274752974510193,
+                "tracking_method": "linear"
+            }
+        ],
+        "dzapm4": [
+            "Drift",
+            {
+                "length": 0.2063317894935608,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm4_drift": [
+            "Drift",
+            {
+                "length": 0.18240000307559967,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcapm4_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.044449999928474426,
+                "y_max": 0.00634999992325902,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dza01": [
+            "Drift",
+            {
+                "length": 0.19716443121433258,
+                "tracking_method": "linear"
+            }
+        ],
+        "dza02": [
+            "Drift",
+            {
+                "length": 2.824061870574951,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcbsyh": [
+            "Drift",
+            {
+                "length": 0.44999998807907104,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "COLL:BSYH:520"
+                }
+            }
+        ],
+        "dbsy53h": [
+            "Drift",
+            {
+                "length": 23.390478134155273,
+                "tracking_method": "linear"
+            }
+        ],
+        "q5": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.16570885479450226,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:BSYH:640"
+                }
+            }
+        ],
+        "dbsy54a": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcbsyq5": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:BSYH:642"
+                }
+            }
+        ],
+        "dbsy54b": [
+            "Drift",
+            {
+                "length": 3.2245399951934814,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbsy54c": [
+            "Drift",
+            {
+                "length": 15.535515785217285,
+                "tracking_method": "linear"
+            }
+        ],
+        "q6": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.11356910318136215,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:BSYH:735"
+                }
+            }
+        ],
+        "drfb": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbbsyq6": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:BSYH:736"
+                }
+            }
+        ],
+        "dbsy55a": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycbsyq6": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:BSYH:739"
+                }
+            }
+        ],
+        "dbsy55b": [
+            "Drift",
+            {
+                "length": 4.226741790771484,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc90_drift": [
+            "Drift",
+            {
+                "length": 0.4536440074443817,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc90_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.010200000368058681,
+                "y_max": 0.010200000368058681,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dbsy55c": [
+            "Drift",
+            {
+                "length": 8.01602840423584,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcbsy4": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "COLL:BSYH:802"
+                }
+            }
+        ],
+        "dbsy55d": [
+            "Drift",
+            {
+                "length": 6.466827869415283,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc119_drift": [
+            "Drift",
+            {
+                "length": 0.4536440074443817,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc119_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.010200000368058681,
+                "y_max": 0.010200000368058681,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dbsy55e": [
+            "Drift",
+            {
+                "length": 1.4463779926300049,
+                "tracking_method": "linear"
+            }
+        ],
+        "d2": [
+            "Drift",
+            {
+                "length": 0.4300000071525574,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "STPR:BSYH:847"
+                }
+            }
+        ],
+        "dm3": [
+            "Drift",
+            {
+                "length": 0.8438000082969666,
+                "tracking_method": "linear"
+            }
+        ],
+        "st60": [
+            "Drift",
+            {
+                "length": 0.7599999904632568,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "STPR:BSYH:854"
+                }
+            }
+        ],
+        "dm4a": [
+            "Drift",
+            {
+                "length": 0.4410000145435333,
+                "tracking_method": "linear"
+            }
+        ],
+        "dm60": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:BSYH:858"
+                }
+            }
+        ],
+        "dm4b": [
+            "Drift",
+            {
+                "length": 5.192866802215576,
+                "tracking_method": "linear"
+            }
+        ],
+        "cc31beg": [
+            "Marker",
+            {}
+        ],
+        "bcx311": [
+            "Drift",
+            {
+                "length": 0.3499999940395355,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:BSYH:880"
+                }
+            }
+        ],
+        "dcc31o": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx312": [
+            "Drift",
+            {
+                "length": 0.3499999940395355,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:BSYH:882"
+                }
+            }
+        ],
+        "dcc31i": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx313": [
+            "Drift",
+            {
+                "length": 0.3499999940395355,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:BSYH:884"
+                }
+            }
+        ],
+        "bcx314": [
+            "Drift",
+            {
+                "length": 0.3499999940395355,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:BSYH:886"
+                }
+            }
+        ],
+        "cc31end": [
+            "Marker",
+            {}
+        ],
+        "dm4c": [
+            "Drift",
+            {
+                "length": 0.30113300681114197,
+                "tracking_method": "linear"
+            }
+        ],
+        "cxq6_drift": [
+            "Drift",
+            {
+                "length": 0.05999999865889549,
+                "tracking_method": "linear"
+            }
+        ],
+        "cxq6_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.0017000000225380063,
+                "y_max": 0.019999999552965164,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "dm4da": [
+            "Drift",
+            {
+                "length": 0.27684998512268066,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcbsy5": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "COLL:BSYH:893"
+                }
+            }
+        ],
+        "dm4db": [
+            "Drift",
+            {
+                "length": 0.7985169887542725,
+                "tracking_method": "linear"
+            }
+        ],
+        "xca0": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:BSYH:900"
+                }
+            }
+        ],
+        "dxca0": [
+            "Drift",
+            {
+                "length": 0.3100000023841858,
+                "tracking_method": "linear"
+            }
+        ],
+        "yca0": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:BSYH:901"
+                }
+            }
+        ],
+        "dyca0": [
+            "Drift",
+            {
+                "length": 0.509020984172821,
+                "tracking_method": "linear"
+            }
+        ],
+        "st61": [
+            "Drift",
+            {
+                "length": 0.7599999904632568,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "STPR:BSYH:905"
+                }
+            }
+        ],
+        "dm5": [
+            "Drift",
+            {
+                "length": 0.7909790277481079,
+                "tracking_method": "linear"
+            }
+        ],
+        "qa0": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.10921010375022888,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:BSYH:910"
+                }
+            }
+        ],
+        "dm6": [
+            "Drift",
+            {
+                "length": 0.5675879716873169,
+                "tracking_method": "linear"
+            }
+        ],
+        "dmoni": [
+            "Drift",
+            {
+                "length": 0.009525000117719173,
+                "tracking_method": "linear"
+            }
+        ],
+        "muwall": [
+            "Marker",
+            {}
+        ],
+        "dwalla": [
+            "Drift",
+            {
+                "length": 1.840975046157837,
+                "tracking_method": "linear"
+            }
+        ],
+        "dumpbsyh": [
+            "Marker",
+            {}
+        ],
+        "dwallb": [
+            "Drift",
+            {
+                "length": 14.923025131225586,
+                "tracking_method": "linear"
+            }
+        ],
+        "bsyend": [
+            "Marker",
+            {}
+        ],
+        "rwwake3h": [
+            "Marker",
+            {}
+        ],
+        "endbsyh_2": [
+            "Marker",
+            {}
+        ],
+        "begltuh": [
+            "Marker",
+            {}
+        ],
+        "dycvm1": [
+            "Drift",
+            {
+                "length": 0.4000000059604645,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycvm1": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:105"
+                }
+            }
+        ],
+        "dqvm1": [
+            "Drift",
+            {
+                "length": 0.3400000035762787,
+                "tracking_method": "linear"
+            }
+        ],
+        "qvm1": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.3374372720718384,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:110"
+                }
+            }
+        ],
+        "dqvm2a": [
+            "Drift",
+            {
+                "length": 0.2504599988460541,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcvm2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:115"
+                }
+            }
+        ],
+        "dqvm2b": [
+            "Drift",
+            {
+                "length": 0.24954000115394592,
+                "tracking_method": "linear"
+            }
+        ],
+        "qvm2": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.23657725751399994,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:120"
+                }
+            }
+        ],
+        "dwsvm2a": [
+            "Drift",
+            {
+                "length": 0.2541399896144867,
+                "tracking_method": "linear"
+            }
+        ],
+        "wsvm2": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:122"
+                }
+            }
+        ],
+        "dwsvm2b": [
+            "Drift",
+            {
+                "length": 0.2458599954843521,
+                "tracking_method": "linear"
+            }
+        ],
+        "vbin": [
+            "Marker",
+            {}
+        ],
+        "by1": [
+            "Dipole",
+            {
+                "length": 1.024999976158142,
+                "angle": -0.002334257122129202,
+                "k1": 0.0,
+                "dipole_e1": -0.001167128561064601,
+                "dipole_e2": -0.001167128561064601,
+                "tilt": 1.5707963705062866,
+                "gap": 0.03492499887943268,
+                "gap_exit": 0.03492499887943268,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:125"
+                }
+            }
+        ],
+        "dvb1": [
+            "Drift",
+            {
+                "length": 7.375,
+                "tracking_method": "linear"
+            }
+        ],
+        "qvb1": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.4222303628921509,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:130"
+                }
+            }
+        ],
+        "d40cmc": [
+            "Drift",
+            {
+                "length": 0.4000000059604645,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycvb1": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:133"
+                }
+            }
+        ],
+        "dvb2m80cm": [
+            "Drift",
+            {
+                "length": 3.200000047683716,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcvb2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:144"
+                }
+            }
+        ],
+        "qvb2": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.4222303628921509,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:150"
+                }
+            }
+        ],
+        "dvb2ha": [
+            "Drift",
+            {
+                "length": 0.8704320192337036,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc01": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:156"
+                }
+            }
+        ],
+        "dvb2hb": [
+            "Drift",
+            {
+                "length": 3.066067934036255,
+                "tracking_method": "linear"
+            }
+        ],
+        "qvb3": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.4222303628921509,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:170"
+                }
+            }
+        ],
+        "ycvb3": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:171"
+                }
+            }
+        ],
+        "dvb1m40cm": [
+            "Drift",
+            {
+                "length": 6.974999904632568,
+                "tracking_method": "linear"
+            }
+        ],
+        "by2": [
+            "Dipole",
+            {
+                "length": 1.024999976158142,
+                "angle": -0.002334257122129202,
+                "k1": 0.0,
+                "dipole_e1": -0.001167128561064601,
+                "dipole_e2": -0.001167128561064601,
+                "tilt": 1.5707963705062866,
+                "gap": 0.03492499887943268,
+                "gap_exit": 0.03492499887943268,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:175"
+                }
+            }
+        ],
+        "cntlt1h": [
+            "Marker",
+            {}
+        ],
+        "vbout": [
+            "Marker",
+            {}
+        ],
+        "dvb25cmc": [
+            "Drift",
+            {
+                "length": 0.25,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcvm3": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:178"
+                }
+            }
+        ],
+        "d25cm": [
+            "Drift",
+            {
+                "length": 0.25,
+                "tracking_method": "linear"
+            }
+        ],
+        "qvm3": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.7151508331298828,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:180"
+                }
+            }
+        ],
+        "dvbem25cm": [
+            "Drift",
+            {
+                "length": 0.25,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycvm4": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:185"
+                }
+            }
+        ],
+        "qvm4": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.6816501617431641,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:190"
+                }
+            }
+        ],
+        "dvbem15cm": [
+            "Drift",
+            {
+                "length": 0.1726129949092865,
+                "tracking_method": "linear"
+            }
+        ],
+        "im31": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LTUH:195"
+                }
+            }
+        ],
+        "d10cmb": [
+            "Drift",
+            {
+                "length": 0.10648690164089203,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbcs1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LTUH:196"
+                }
+            }
+        ],
+        "d25cma": [
+            "Drift",
+            {
+                "length": 0.22090010344982147,
+                "tracking_method": "linear"
+            }
+        ],
+        "mm1": [
+            "Marker",
+            {}
+        ],
+        "dbmark34": [
+            "Marker",
+            {}
+        ],
+        "bx31": [
+            "Dipole",
+            {
+                "length": 2.6230082511901855,
+                "angle": 0.008726643398404121,
+                "k1": 0.0,
+                "dipole_e1": 0.004363321699202061,
+                "dipole_e2": 0.004363321699202061,
+                "tilt": 0.0,
+                "gap": 0.01724660024046898,
+                "gap_exit": 0.01724660024046898,
+                "fringe_integral": 0.5236999988555908,
+                "fringe_integral_exit": 0.5236999988555908,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:220"
+                }
+            }
+        ],
+        "ddl10wa": [
+            "Drift",
+            {
+                "length": 0.986719012260437,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc02": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm02": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:224"
+                }
+            }
+        ],
+        "ddl10wb": [
+            "Drift",
+            {
+                "length": 10.944183349609375,
+                "tracking_method": "linear"
+            }
+        ],
+        "dwsdl31a": [
+            "Drift",
+            {
+                "length": 0.09623699635267258,
+                "tracking_method": "linear"
+            }
+        ],
+        "wsdl31": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:246"
+                }
+            }
+        ],
+        "dwsdl31b": [
+            "Drift",
+            {
+                "length": 0.15376299619674683,
+                "tracking_method": "linear"
+            }
+        ],
+        "ddl10x": [
+            "Drift",
+            {
+                "length": 0.12631399929523468,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdl1": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:248"
+                }
+            }
+        ],
+        "d31a": [
+            "Drift",
+            {
+                "length": 0.5604649782180786,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdl31": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.4371839761734009,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:250"
+                }
+            }
+        ],
+        "rfbdl1": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:LTUH:251"
+                }
+            }
+        ],
+        "d31b": [
+            "Drift",
+            {
+                "length": 0.36043810844421387,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdl1": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:253"
+                }
+            }
+        ],
+        "d32cmb": [
+            "Drift",
+            {
+                "length": 0.6638033986091614,
+                "tracking_method": "linear"
+            }
+        ],
+        "cedl1_drift": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "cedl1_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.002300000051036477,
+                "y_max": 0.019999999552965164,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "d31c": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "wig1h": [
+            "Drift",
+            {
+                "length": 0.24400000274181366,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:255"
+                }
+            }
+        ],
+        "dwgh": [
+            "Drift",
+            {
+                "length": 0.12652499973773956,
+                "tracking_method": "linear"
+            }
+        ],
+        "wig2h": [
+            "Drift",
+            {
+                "length": 0.4880000054836273,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:256"
+                }
+            }
+        ],
+        "wig3h": [
+            "Drift",
+            {
+                "length": 0.24400000274181366,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:257"
+                }
+            }
+        ],
+        "cntwigh": [
+            "Marker",
+            {}
+        ],
+        "ddl10em80cma": [
+            "Drift",
+            {
+                "length": 3.703274965286255,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc22": [
+            "Drift",
+            {
+                "length": 0.20319999754428864,
+                "tracking_method": "linear"
+            }
+        ],
+        "ddl10em80cmb": [
+            "Drift",
+            {
+                "length": 5.1214118003845215,
+                "tracking_method": "linear"
+            }
+        ],
+        "cybx32_drift": [
+            "Drift",
+            {
+                "length": 0.05999999865889549,
+                "tracking_method": "linear"
+            }
+        ],
+        "cybx32_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.019999999552965164,
+                "y_max": 0.001500000013038516,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "dcb32": [
+            "Drift",
+            {
+                "length": 0.8100000023841858,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx32": [
+            "Dipole",
+            {
+                "length": 2.6230082511901855,
+                "angle": 0.008726643398404121,
+                "k1": 0.0,
+                "dipole_e1": 0.004363321699202061,
+                "dipole_e2": 0.004363321699202061,
+                "tilt": 0.0,
+                "gap": 0.01724660024046898,
+                "gap_exit": 0.01724660024046898,
+                "fringe_integral": 0.5236999988555908,
+                "fringe_integral_exit": 0.5236999988555908,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:280"
+                }
+            }
+        ],
+        "cntlt2h": [
+            "Marker",
+            {}
+        ],
+        "ddl20e": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt11": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:285"
+                }
+            }
+        ],
+        "ddl30em40cm": [
+            "Drift",
+            {
+                "length": 0.5099869966506958,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcqt12": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:288"
+                }
+            }
+        ],
+        "d40cmb": [
+            "Drift",
+            {
+                "length": 0.4900130033493042,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt12": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.839614748954773,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:290"
+                }
+            }
+        ],
+        "ycqt12": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:293"
+                }
+            }
+        ],
+        "qt13": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:295"
+                }
+            }
+        ],
+        "ss1": [
+            "Marker",
+            {}
+        ],
+        "dx33a": [
+            "Drift",
+            {
+                "length": 1.4154000282287598,
+                "tracking_method": "linear"
+            }
+        ],
+        "cc32beg": [
+            "Marker",
+            {}
+        ],
+        "bcx321": [
+            "Dipole",
+            {
+                "length": 0.3500059247016907,
+                "angle": 0.01008035708218813,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.01008035708218813,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:300"
+                }
+            }
+        ],
+        "dcc32o": [
+            "Drift",
+            {
+                "length": 0.20001016557216644,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx322": [
+            "Dipole",
+            {
+                "length": 0.3500059247016907,
+                "angle": -0.01008035708218813,
+                "k1": 0.0,
+                "dipole_e1": -0.01008035708218813,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:301"
+                }
+            }
+        ],
+        "dcc32i": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx323": [
+            "Dipole",
+            {
+                "length": 0.3500059247016907,
+                "angle": -0.01008035708218813,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.01008035708218813,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:302"
+                }
+            }
+        ],
+        "bcx324": [
+            "Dipole",
+            {
+                "length": 0.3500059247016907,
+                "angle": 0.01008035708218813,
+                "k1": 0.0,
+                "dipole_e1": 0.01008035708218813,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:303"
+                }
+            }
+        ],
+        "cc32end": [
+            "Marker",
+            {}
+        ],
+        "dx33b": [
+            "Drift",
+            {
+                "length": 0.38563698530197144,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc03": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm03": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:312"
+                }
+            }
+        ],
+        "ddl1ab": [
+            "Drift",
+            {
+                "length": 4.049038887023926,
+                "tracking_method": "linear"
+            }
+        ],
+        "bykik1": [
+            "Dipole",
+            {
+                "length": 1.0600999593734741,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 1.5707963705062866,
+                "gap": 0.05079999938607216,
+                "gap_exit": 0.05079999938607216,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LTUH:320"
+                }
+            }
+        ],
+        "ddl1d": [
+            "Drift",
+            {
+                "length": 0.07917600125074387,
+                "tracking_method": "linear"
+            }
+        ],
+        "bykik2": [
+            "Dipole",
+            {
+                "length": 1.0600999593734741,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 1.5707963705062866,
+                "gap": 0.05079999938607216,
+                "gap_exit": 0.05079999938607216,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:LTUH:340"
+                }
+            }
+        ],
+        "ddl1e": [
+            "Drift",
+            {
+                "length": 4.891592025756836,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdl2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:348"
+                }
+            }
+        ],
+        "d32a": [
+            "Drift",
+            {
+                "length": 0.4704599976539612,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdl32": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.4371839761734009,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:350"
+                }
+            }
+        ],
+        "d32b": [
+            "Drift",
+            {
+                "length": 0.4704599976539612,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdl2": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:353"
+                }
+            }
+        ],
+        "dsplr": [
+            "Drift",
+            {
+                "length": 0.43035998940467834,
+                "tracking_method": "linear"
+            }
+        ],
+        "spoiler": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "SPLR:LTUH:359"
+                }
+            }
+        ],
+        "ddl1cm40cm": [
+            "Drift",
+            {
+                "length": 5.295199871063232,
+                "tracking_method": "linear"
+            }
+        ],
+        "tdkik": [
+            "Drift",
+            {
+                "length": 0.6096000075340271,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "DUMP:LTUH:360"
+                }
+            }
+        ],
+        "d30cma": [
+            "Drift",
+            {
+                "length": 0.257425993680954,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik1_drift": [
+            "Drift",
+            {
+                "length": 0.8127999901771545,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik1_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.011112499982118607,
+                "y_max": 0.011112499982118607,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dpc1": [
+            "Drift",
+            {
+                "length": 0.2666969895362854,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik2_drift": [
+            "Drift",
+            {
+                "length": 0.8127999901771545,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik2_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.011112499982118607,
+                "y_max": 0.011112499982118607,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dpc2": [
+            "Drift",
+            {
+                "length": 0.2666969895362854,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik3_drift": [
+            "Drift",
+            {
+                "length": 0.8127999901771545,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik3_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.011112499982118607,
+                "y_max": 0.011112499982118607,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dpc3": [
+            "Drift",
+            {
+                "length": 0.2666969895362854,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik4_drift": [
+            "Drift",
+            {
+                "length": 0.8127999901771545,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctdkik4_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.011112499982118607,
+                "y_max": 0.011112499982118607,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dpc4": [
+            "Drift",
+            {
+                "length": 0.1999099999666214,
+                "tracking_method": "linear"
+            }
+        ],
+        "dspontua": [
+            "Drift",
+            {
+                "length": 0.75,
+                "tracking_method": "linear"
+            }
+        ],
+        "dspontub": [
+            "Drift",
+            {
+                "length": 0.75,
+                "tracking_method": "linear"
+            }
+        ],
+        "ddl1dm30cm": [
+            "Drift",
+            {
+                "length": 0.11693199723958969,
+                "tracking_method": "linear"
+            }
+        ],
+        "dx34a": [
+            "Drift",
+            {
+                "length": 0.12300000339746475,
+                "tracking_method": "linear"
+            }
+        ],
+        "cc35beg": [
+            "Marker",
+            {}
+        ],
+        "bcx351": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": 0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0071278284303843975,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:375"
+                }
+            }
+        ],
+        "dcc35o": [
+            "Drift",
+            {
+                "length": 0.20000508427619934,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx352": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": -0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": -0.0071278284303843975,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:376"
+                }
+            }
+        ],
+        "dcc35i": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx353": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": -0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.0071278284303843975,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:377"
+                }
+            }
+        ],
+        "bcx354": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": 0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": 0.0071278284303843975,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:378"
+                }
+            }
+        ],
+        "cc35end": [
+            "Marker",
+            {}
+        ],
+        "dx34b": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycqt21": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:383"
+                }
+            }
+        ],
+        "ddl20": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt21": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:385"
+                }
+            }
+        ],
+        "xcqt22": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:388"
+                }
+            }
+        ],
+        "qt22": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.839614748954773,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:390"
+                }
+            }
+        ],
+        "d46cm": [
+            "Drift",
+            {
+                "length": 0.4699999988079071,
+                "tracking_method": "linear"
+            }
+        ],
+        "cxqt22_drift": [
+            "Drift",
+            {
+                "length": 0.05999999865889549,
+                "tracking_method": "linear"
+            }
+        ],
+        "cxqt22_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.0015999999595806003,
+                "y_max": 0.019999999552965164,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "qt23": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:395"
+                }
+            }
+        ],
+        "dl23beg": [
+            "Marker",
+            {}
+        ],
+        "bx35": [
+            "Dipole",
+            {
+                "length": 2.6230082511901855,
+                "angle": -0.008726643398404121,
+                "k1": 0.0,
+                "dipole_e1": -0.004363321699202061,
+                "dipole_e2": -0.004363321699202061,
+                "tilt": 0.0,
+                "gap": 0.01724660024046898,
+                "gap_exit": 0.01724660024046898,
+                "fringe_integral": 0.5236999988555908,
+                "fringe_integral_exit": 0.5236999988555908,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:420"
+                }
+            }
+        ],
+        "dcq31aa": [
+            "Drift",
+            {
+                "length": 1.3509670495986938,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc04": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm04": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:432"
+                }
+            }
+        ],
+        "dcq31ab": [
+            "Drift",
+            {
+                "length": 4.622714996337891,
+                "tracking_method": "linear"
+            }
+        ],
+        "cq31": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:440"
+                }
+            }
+        ],
+        "dcq31ba": [
+            "Drift",
+            {
+                "length": 0.8270940184593201,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc42": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm42": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:436"
+                }
+            }
+        ],
+        "dcq31bb": [
+            "Drift",
+            {
+                "length": 4.9210638999938965,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr30": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:LTU1:449"
+                }
+            }
+        ],
+        "d29cma": [
+            "Drift",
+            {
+                "length": 0.5843420028686523,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdl3": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:448"
+                }
+            }
+        ],
+        "d33a": [
+            "Drift",
+            {
+                "length": 0.38999998569488525,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdl33": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.4371839761734009,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:450"
+                }
+            }
+        ],
+        "d33b": [
+            "Drift",
+            {
+                "length": 0.3199999928474426,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdl3": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:453"
+                }
+            }
+        ],
+        "d32cmd": [
+            "Drift",
+            {
+                "length": 0.9042415022850037,
+                "tracking_method": "linear"
+            }
+        ],
+        "cedl3_drift": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "cedl3_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.002300000051036477,
+                "y_max": 0.019999999552965164,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "dcq32a": [
+            "Drift",
+            {
+                "length": 5.4817585945129395,
+                "tracking_method": "linear"
+            }
+        ],
+        "cq32": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:460"
+                }
+            }
+        ],
+        "dcq32b": [
+            "Drift",
+            {
+                "length": 5.167178630828857,
+                "tracking_method": "linear"
+            }
+        ],
+        "cybx36_drift": [
+            "Drift",
+            {
+                "length": 0.05999999865889549,
+                "tracking_method": "linear"
+            }
+        ],
+        "cybx36_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.019999999552965164,
+                "y_max": 0.001500000013038516,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "dcb36": [
+            "Drift",
+            {
+                "length": 0.8100000023841858,
+                "tracking_method": "linear"
+            }
+        ],
+        "bx36": [
+            "Dipole",
+            {
+                "length": 2.6230082511901855,
+                "angle": -0.008726643398404121,
+                "k1": 0.0,
+                "dipole_e1": -0.004363321699202061,
+                "dipole_e2": -0.004363321699202061,
+                "tilt": 0.0,
+                "gap": 0.01724660024046898,
+                "gap_exit": 0.01724660024046898,
+                "fringe_integral": 0.5236999988555908,
+                "fringe_integral_exit": 0.5236999988555908,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:480"
+                }
+            }
+        ],
+        "cntlt3h": [
+            "Marker",
+            {}
+        ],
+        "qt31": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:485"
+                }
+            }
+        ],
+        "ddl30em40cma": [
+            "Drift",
+            {
+                "length": 0.5104600191116333,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcqt32": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:488"
+                }
+            }
+        ],
+        "d40cmd": [
+            "Drift",
+            {
+                "length": 0.4895400106906891,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt32": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.839614748954773,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:490"
+                }
+            }
+        ],
+        "d40cme": [
+            "Drift",
+            {
+                "length": 0.5004600286483765,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycqt32": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:493"
+                }
+            }
+        ],
+        "ddl30em40cmb": [
+            "Drift",
+            {
+                "length": 0.4995400011539459,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt33": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:495"
+                }
+            }
+        ],
+        "ss3": [
+            "Marker",
+            {}
+        ],
+        "d37a": [
+            "Drift",
+            {
+                "length": 0.27031999826431274,
+                "tracking_method": "linear"
+            }
+        ],
+        "cc36beg": [
+            "Marker",
+            {}
+        ],
+        "bcx361": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": 0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0071278284303843975,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:505"
+                }
+            }
+        ],
+        "dcc36o": [
+            "Drift",
+            {
+                "length": 0.20000508427619934,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx362": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": -0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": -0.0071278284303843975,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:506"
+                }
+            }
+        ],
+        "dcc36i": [
+            "Drift",
+            {
+                "length": 0.20000000298023224,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcx363": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": -0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.0071278284303843975,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:507"
+                }
+            }
+        ],
+        "bcx364": [
+            "Dipole",
+            {
+                "length": 0.3500029742717743,
+                "angle": 0.0071278284303843975,
+                "k1": 0.0,
+                "dipole_e1": 0.0071278284303843975,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.8435999751091003,
+                "fringe_integral_exit": 0.8435999751091003,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:LTUH:508"
+                }
+            }
+        ],
+        "cc36end": [
+            "Marker",
+            {}
+        ],
+        "d37ba": [
+            "Drift",
+            {
+                "length": 0.12488999962806702,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc43": [
+            "Drift",
+            {
+                "length": 0.20319999754428864,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm43": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:509"
+                }
+            }
+        ],
+        "d37bb": [
+            "Drift",
+            {
+                "length": 0.3245899975299835,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbcs2": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LTUH:510"
+                }
+            }
+        ],
+        "d37c": [
+            "Drift",
+            {
+                "length": 1.2619099617004395,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc05": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm05": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:516"
+                }
+            }
+        ],
+        "d37d": [
+            "Drift",
+            {
+                "length": 7.697981357574463,
+                "tracking_method": "linear"
+            }
+        ],
+        "wsdl4": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:538"
+                }
+            }
+        ],
+        "d37e": [
+            "Drift",
+            {
+                "length": 1.0975228548049927,
+                "tracking_method": "linear"
+            }
+        ],
+        "dchirpv": [
+            "Drift",
+            {
+                "length": 2.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "DCHP:LTUH:545"
+                }
+            }
+        ],
+        "d37f": [
+            "Drift",
+            {
+                "length": 0.5102658271789551,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdl34": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.4371839761734009,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:550"
+                }
+            }
+        ],
+        "d38a": [
+            "Drift",
+            {
+                "length": 0.5098704695701599,
+                "tracking_method": "linear"
+            }
+        ],
+        "dchirph": [
+            "Drift",
+            {
+                "length": 2.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "DCHP:LTUH:555"
+                }
+            }
+        ],
+        "d38b": [
+            "Drift",
+            {
+                "length": 0.6091175079345703,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdl4": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:558"
+                }
+            }
+        ],
+        "d38c": [
+            "Drift",
+            {
+                "length": 0.5407059192657471,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdl4": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:563"
+                }
+            }
+        ],
+        "d38da": [
+            "Drift",
+            {
+                "length": 7.151035785675049,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc06": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm06": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:552"
+                }
+            }
+        ],
+        "d38db": [
+            "Drift",
+            {
+                "length": 4.67995023727417,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt41": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:585"
+                }
+            }
+        ],
+        "ddl30em40cmc": [
+            "Drift",
+            {
+                "length": 0.574999988079071,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcqt42": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:588"
+                }
+            }
+        ],
+        "d40cmf": [
+            "Drift",
+            {
+                "length": 0.42500001192092896,
+                "tracking_method": "linear"
+            }
+        ],
+        "qt42": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": 0.839614748954773,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:590"
+                }
+            }
+        ],
+        "ycqt42": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:593"
+                }
+            }
+        ],
+        "qt43": [
+            "Quadrupole",
+            {
+                "length": 0.4609200060367584,
+                "k1": -0.42093783617019653,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:595"
+                }
+            }
+        ],
+        "mm2": [
+            "Marker",
+            {}
+        ],
+        "d25cmb": [
+            "Drift",
+            {
+                "length": 0.26269999146461487,
+                "tracking_method": "linear"
+            }
+        ],
+        "im36": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LTUH:605"
+                }
+            }
+        ],
+        "d25cmc": [
+            "Drift",
+            {
+                "length": 0.23729999363422394,
+                "tracking_method": "linear"
+            }
+        ],
+        "dmm1m90cm": [
+            "Drift",
+            {
+                "length": 1.2004599571228027,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycem1": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:611"
+                }
+            }
+        ],
+        "dem1a": [
+            "Drift",
+            {
+                "length": 0.3700000047683716,
+                "tracking_method": "linear"
+            }
+        ],
+        "qem1": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": -0.3908277451992035,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:620"
+                }
+            }
+        ],
+        "dem1c": [
+            "Drift",
+            {
+                "length": 4.140920162200928,
+                "tracking_method": "linear"
+            }
+        ],
+        "qem2": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.43221572041511536,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:640"
+                }
+            }
+        ],
+        "dem2b": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcem2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:642"
+                }
+            }
+        ],
+        "dmm3ma": [
+            "Drift",
+            {
+                "length": 4.362410068511963,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc07": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm07": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:632"
+                }
+            }
+        ],
+        "dmm3mb": [
+            "Drift",
+            {
+                "length": 6.845009803771973,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycem3": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:657"
+                }
+            }
+        ],
+        "dem3a": [
+            "Drift",
+            {
+                "length": 0.3700000047683716,
+                "tracking_method": "linear"
+            }
+        ],
+        "qem3": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": -0.5934339761734009,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:660"
+                }
+            }
+        ],
+        "dem3b": [
+            "Drift",
+            {
+                "length": 0.773298978805542,
+                "tracking_method": "linear"
+            }
+        ],
+        "qem3v": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:665"
+                }
+            }
+        ],
+        "dmm4m90cm": [
+            "Drift",
+            {
+                "length": 2.7596209049224854,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcem4": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:678"
+                }
+            }
+        ],
+        "dem4a": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "qem4": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.420485258102417,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:680"
+                }
+            }
+        ],
+        "rfbem4": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:LTUH:681"
+                }
+            }
+        ],
+        "dmm5a": [
+            "Drift",
+            {
+                "length": 0.6905699968338013,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc08": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm08": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:658"
+                }
+            }
+        ],
+        "dmm5b": [
+            "Drift",
+            {
+                "length": 1.1163899898529053,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbmark36": [
+            "Marker",
+            {}
+        ],
+        "ws31": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:715"
+                }
+            }
+        ],
+        "d40cm": [
+            "Drift",
+            {
+                "length": 0.4000000059604645,
+                "tracking_method": "linear"
+            }
+        ],
+        "de3ma": [
+            "Drift",
+            {
+                "length": 5.430109977722168,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc09": [
+            "Drift",
+            {
+                "length": 0.06350000202655792,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm09": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:LTUH:694"
+                }
+            }
+        ],
+        "de3mb": [
+            "Drift",
+            {
+                "length": 2.4422667026519775,
+                "tracking_method": "linear"
+            }
+        ],
+        "xce31": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:718"
+                }
+            }
+        ],
+        "dqea": [
+            "Drift",
+            {
+                "length": 0.4259999990463257,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe31": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.40275320410728455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:720"
+                }
+            }
+        ],
+        "dqebx": [
+            "Drift",
+            {
+                "length": 0.7961434721946716,
+                "tracking_method": "linear"
+            }
+        ],
+        "dcx31": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "dqebx2": [
+            "Drift",
+            {
+                "length": 7.4857330322265625,
+                "tracking_method": "linear"
+            }
+        ],
+        "de3a": [
+            "Drift",
+            {
+                "length": 8.725876808166504,
+                "tracking_method": "linear"
+            }
+        ],
+        "yce32": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:727"
+                }
+            }
+        ],
+        "dqeaa": [
+            "Drift",
+            {
+                "length": 0.4359999895095825,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe32": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -0.40275320410728455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:730"
+                }
+            }
+        ],
+        "rfbe32": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:LTUH:731"
+                }
+            }
+        ],
+        "dqeby1": [
+            "Drift",
+            {
+                "length": 0.5961434841156006,
+                "tracking_method": "linear"
+            }
+        ],
+        "dcy32": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "dqeby2": [
+            "Drift",
+            {
+                "length": 7.885733127593994,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws32": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:735"
+                }
+            }
+        ],
+        "de3m80cmb": [
+            "Drift",
+            {
+                "length": 7.905876636505127,
+                "tracking_method": "linear"
+            }
+        ],
+        "xce33": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:738"
+                }
+            }
+        ],
+        "dqeab": [
+            "Drift",
+            {
+                "length": 0.4560000002384186,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe33": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.40275320410728455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:740"
+                }
+            }
+        ],
+        "dqeca": [
+            "Drift",
+            {
+                "length": 7.9507269859313965,
+                "tracking_method": "linear"
+            }
+        ],
+        "yagpsi": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "YAGS:LTUH:743"
+                }
+            }
+        ],
+        "dqecb": [
+            "Drift",
+            {
+                "length": 0.8111496567726135,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr33": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:LTUH:745"
+                }
+            }
+        ],
+        "de3m40cm": [
+            "Drift",
+            {
+                "length": 8.33587646484375,
+                "tracking_method": "linear"
+            }
+        ],
+        "yce34": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:747"
+                }
+            }
+        ],
+        "qe34": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -0.40275320410728455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:750"
+                }
+            }
+        ],
+        "rfbe34": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:LTUH:751"
+                }
+            }
+        ],
+        "dqec1": [
+            "Drift",
+            {
+                "length": 8.56187629699707,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws33": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:755"
+                }
+            }
+        ],
+        "de3m80cm": [
+            "Drift",
+            {
+                "length": 7.755876541137695,
+                "tracking_method": "linear"
+            }
+        ],
+        "xce35": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:758"
+                }
+            }
+        ],
+        "dqeac": [
+            "Drift",
+            {
+                "length": 0.6060000061988831,
+                "tracking_method": "linear"
+            }
+        ],
+        "qe35": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 0.40275320410728455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:760"
+                }
+            }
+        ],
+        "dcx35": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "de3": [
+            "Drift",
+            {
+                "length": 8.73587703704834,
+                "tracking_method": "linear"
+            }
+        ],
+        "yce36": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:767"
+                }
+            }
+        ],
+        "qe36": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -0.40275320410728455,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:770"
+                }
+            }
+        ],
+        "rfbe36": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:LTUH:771"
+                }
+            }
+        ],
+        "dcy36": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws34": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:LTUH:775"
+                }
+            }
+        ],
+        "d40cmg": [
+            "Drift",
+            {
+                "length": 0.3682999908924103,
+                "tracking_method": "linear"
+            }
+        ],
+        "dws35": [
+            "Marker",
+            {}
+        ],
+        "d40cmh": [
+            "Drift",
+            {
+                "length": 0.031700000166893005,
+                "tracking_method": "linear"
+            }
+        ],
+        "du1m80cma": [
+            "Drift",
+            {
+                "length": 0.1651500016450882,
+                "tracking_method": "linear"
+            }
+        ],
+        "dws36": [
+            "Marker",
+            {}
+        ],
+        "du1m80cmb": [
+            "Drift",
+            {
+                "length": 4.384850025177002,
+                "tracking_method": "linear"
+            }
+        ],
+        "dcx37": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "d32cmc": [
+            "Drift",
+            {
+                "length": 0.30046001076698303,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcum1": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:818"
+                }
+            }
+        ],
+        "dum1a": [
+            "Drift",
+            {
+                "length": 0.49000000953674316,
+                "tracking_method": "linear"
+            }
+        ],
+        "qum1": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.2727414071559906,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:820"
+                }
+            }
+        ],
+        "dum1b": [
+            "Drift",
+            {
+                "length": 0.4704599976539612,
+                "tracking_method": "linear"
+            }
+        ],
+        "d32cm": [
+            "Drift",
+            {
+                "length": 0.3199999928474426,
+                "tracking_method": "linear"
+            }
+        ],
+        "du2m120cm": [
+            "Drift",
+            {
+                "length": 4.730000019073486,
+                "tracking_method": "linear"
+            }
+        ],
+        "dcy38": [
+            "Drift",
+            {
+                "length": 0.07999999821186066,
+                "tracking_method": "linear"
+            }
+        ],
+        "d32cma": [
+            "Drift",
+            {
+                "length": 0.4204599857330322,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycum2": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:837"
+                }
+            }
+        ],
+        "dum2a": [
+            "Drift",
+            {
+                "length": 0.3700000047683716,
+                "tracking_method": "linear"
+            }
+        ],
+        "qum2": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": -0.2706012725830078,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:840"
+                }
+            }
+        ],
+        "dum2b": [
+            "Drift",
+            {
+                "length": 0.4704599976539612,
+                "tracking_method": "linear"
+            }
+        ],
+        "du3m80cm": [
+            "Drift",
+            {
+                "length": 7.290460109710693,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcum3": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:LTUH:858"
+                }
+            }
+        ],
+        "dum3a": [
+            "Drift",
+            {
+                "length": 0.3799999952316284,
+                "tracking_method": "linear"
+            }
+        ],
+        "qum3": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": 0.27876266837120056,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:860"
+                }
+            }
+        ],
+        "dum3b": [
+            "Drift",
+            {
+                "length": 0.4704599976539612,
+                "tracking_method": "linear"
+            }
+        ],
+        "d40cma": [
+            "Drift",
+            {
+                "length": 1.807939052581787,
+                "tracking_method": "linear"
+            }
+        ],
+        "eoblm": [
+            "Marker",
+            {}
+        ],
+        "du4m120cm": [
+            "Drift",
+            {
+                "length": 1.3625210523605347,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycum4": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:LTUH:877"
+                }
+            }
+        ],
+        "dum4a": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "qum4": [
+            "Quadrupole",
+            {
+                "length": 0.3199999928474426,
+                "k1": -0.247470885515213,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:LTUH:880"
+                }
+            }
+        ],
+        "dum4b": [
+            "Drift",
+            {
+                "length": 0.5974599719047546,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfb07": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BPMS:LTUH:910"
+                }
+            }
+        ],
+        "du5m80cm": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "imundi": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "TORO:LTUH:920"
+                }
+            }
+        ],
+        "d40cmwa": [
+            "Drift",
+            {
+                "length": 0.25154349207878113,
+                "tracking_method": "linear"
+            }
+        ],
+        "bltof": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "GJET:LTU1:927"
+                }
+            }
+        ],
+        "d40cmwb": [
+            "Drift",
+            {
+                "length": 0.1400420069694519,
+                "tracking_method": "linear"
+            }
+        ],
+        "muhwall1": [
+            "Marker",
+            {}
+        ],
+        "duhwall1": [
+            "Drift",
+            {
+                "length": 0.2508249878883362,
+                "tracking_method": "linear"
+            }
+        ],
+        "duhvesta": [
+            "Drift",
+            {
+                "length": 1.6056840419769287,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfb08": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BPMS:LTUH:960"
+                }
+            }
+        ],
+        "duhvestb": [
+            "Drift",
+            {
+                "length": 0.40349099040031433,
+                "tracking_method": "linear"
+            }
+        ],
+        "muhwall2": [
+            "Marker",
+            {}
+        ],
+        "duhwall2": [
+            "Drift",
+            {
+                "length": 0.2508249878883362,
+                "tracking_method": "linear"
+            }
+        ],
+        "dw2tdund": [
+            "Drift",
+            {
+                "length": 0.20153699815273285,
+                "tracking_method": "linear"
+            }
+        ],
+        "dtdund1": [
+            "Drift",
+            {
+                "length": 0.8558530211448669,
+                "tracking_method": "linear"
+            }
+        ],
+        "tdund": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "DUMP:LTUH:970"
+                }
+            }
+        ],
+        "dtdund2": [
+            "Drift",
+            {
+                "length": 0.34785300493240356,
+                "tracking_method": "linear"
+            }
+        ],
+        "dpcmuon": [
+            "Drift",
+            {
+                "length": 0.03149800002574921,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcmuon_drift": [
+            "Drift",
+            {
+                "length": 1.1684000492095947,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcmuon_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.00215999991632998,
+                "y_max": 0.00431999983265996,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dmuon1": [
+            "Drift",
+            {
+                "length": 0.18674398958683014,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv999": [
+            "Marker",
+            {}
+        ],
+        "dmuon2": [
+            "Drift",
+            {
+                "length": 0.01811501570045948,
+                "tracking_method": "linear"
+            }
+        ],
+        "rwwake4h": [
+            "Marker",
+            {}
+        ],
+        "endltuh": [
+            "Marker",
+            {}
+        ],
+        "begundh": [
+            "Marker",
+            {}
+        ],
+        "dmuon3": [
+            "Drift",
+            {
+                "length": 0.1416112333536148,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhx12": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1305"
+                }
+            }
+        ],
+        "dmuon4": [
+            "Drift",
+            {
+                "length": 0.06898076832294464,
+                "tracking_method": "linear"
+            }
+        ],
+        "mm3": [
+            "Marker",
+            {}
+        ],
+        "pfilt1": [
+            "Marker",
+            {}
+        ],
+        "dbmark37": [
+            "Marker",
+            {}
+        ],
+        "du0h": [
+            "Drift",
+            {
+                "length": 0.06939198076725006,
+                "tracking_method": "linear"
+            }
+        ],
+        "du8h": [
+            "Drift",
+            {
+                "length": 0.02500000037252903,
+                "tracking_method": "linear"
+            }
+        ],
+        "hxrstart": [
+            "Marker",
+            {}
+        ],
+        "du1h": [
+            "Drift",
+            {
+                "length": 0.04098400101065636,
+                "tracking_method": "linear"
+            }
+        ],
+        "du2h": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "hxrcb1beg": [
+            "Marker",
+            {}
+        ],
+        "d0cb1": [
+            "Drift",
+            {
+                "length": 0.039618998765945435,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxcbx11": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": -0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:1330"
+                }
+            }
+        ],
+        "d1cb1a": [
+            "Drift",
+            {
+                "length": 0.47221601009368896,
+                "tracking_method": "linear"
+            }
+        ],
+        "mcbx4": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "MIRR:UNDH:1350"
+                }
+            }
+        ],
+        "d1cb1b": [
+            "Drift",
+            {
+                "length": 0.10589999705553055,
+                "tracking_method": "linear"
+            }
+        ],
+        "bodcbx42": [
+            "Marker",
+            {}
+        ],
+        "d1cb1c": [
+            "Drift",
+            {
+                "length": 0.2842339873313904,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxcbx12": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:1355"
+                }
+            }
+        ],
+        "dchcb1": [
+            "Drift",
+            {
+                "length": 0.08388149738311768,
+                "tracking_method": "linear"
+            }
+        ],
+        "center1": [
+            "Marker",
+            {}
+        ],
+        "bcxcbx13": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:1360"
+                }
+            }
+        ],
+        "d2cb": [
+            "Drift",
+            {
+                "length": 0.8623499870300293,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxcbx14": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": -0.0,
+                "k1": 0.0,
+                "dipole_e1": -0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:1375"
+                }
+            }
+        ],
+        "d3cb1": [
+            "Drift",
+            {
+                "length": -0.0320499986410141,
+                "tracking_method": "linear"
+            }
+        ],
+        "hxrcb1end": [
+            "Marker",
+            {}
+        ],
+        "du3hcb1": [
+            "Drift",
+            {
+                "length": 0.23541200160980225,
+                "tracking_method": "linear"
+            }
+        ],
+        "qhxh13": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1380"
+                }
+            }
+        ],
+        "du4hcb1": [
+            "Drift",
+            {
+                "length": 0.06282400339841843,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhx13": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1390"
+                }
+            }
+        ],
+        "du5hcb1": [
+            "Drift",
+            {
+                "length": -0.05550200119614601,
+                "tracking_method": "linear"
+            }
+        ],
+        "dpshx13": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "du6h": [
+            "Drift",
+            {
+                "length": 0.0844929963350296,
+                "tracking_method": "linear"
+            }
+        ],
+        "du7h": [
+            "Drift",
+            {
+                "length": 0.08892367035150528,
+                "tracking_method": "linear"
+            }
+        ],
+        "dthxu": [
+            "Drift",
+            {
+                "length": 0.009015999734401703,
+                "tracking_method": "linear"
+            }
+        ],
+        "umahxh14": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:1450"
+                }
+            }
+        ],
+        "du3h": [
+            "Drift",
+            {
+                "length": 0.050992000848054886,
+                "tracking_method": "linear"
+            }
+        ],
+        "mblmh14": [
+            "Marker",
+            {}
+        ],
+        "qhxh14": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1480"
+                }
+            }
+        ],
+        "du4h": [
+            "Drift",
+            {
+                "length": 0.06300000101327896,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhx14": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1490"
+                }
+            }
+        ],
+        "du5h": [
+            "Drift",
+            {
+                "length": 0.07774999737739563,
+                "tracking_method": "linear"
+            }
+        ],
+        "pshxh14": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:1495"
+                }
+            }
+        ],
+        "vvhxu14": [
+            "Marker",
+            {}
+        ],
+        "umahxh15": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:1550"
+                }
+            }
+        ],
+        "mblmh15": [
+            "Marker",
+            {}
+        ],
+        "qhxh15": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1580"
+                }
+            }
+        ],
+        "rfbhx15": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1590"
+                }
+            }
+        ],
+        "pshxh15": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:1595"
+                }
+            }
+        ],
+        "dvvhxu": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "umahxh16": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:1650"
+                }
+            }
+        ],
+        "mblmh16": [
+            "Marker",
+            {}
+        ],
+        "qhxh16": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1680"
+                }
+            }
+        ],
+        "rfbhx16": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1690"
+                }
+            }
+        ],
+        "pshxh16": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:1695"
+                }
+            }
+        ],
+        "umahxh17": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:1750"
+                }
+            }
+        ],
+        "mblmh17": [
+            "Marker",
+            {}
+        ],
+        "qhxh17": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1780"
+                }
+            }
+        ],
+        "rfbhx17": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1790"
+                }
+            }
+        ],
+        "pshxh17": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:1795"
+                }
+            }
+        ],
+        "vvhxu17": [
+            "Marker",
+            {}
+        ],
+        "umahxh18": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:1850"
+                }
+            }
+        ],
+        "mblmh18": [
+            "Marker",
+            {}
+        ],
+        "qhxh18": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1880"
+                }
+            }
+        ],
+        "rfbhx18": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1890"
+                }
+            }
+        ],
+        "pshxh18": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:1895"
+                }
+            }
+        ],
+        "umahxh19": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:1950"
+                }
+            }
+        ],
+        "mblmh19": [
+            "Marker",
+            {}
+        ],
+        "qhxh19": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:1980"
+                }
+            }
+        ],
+        "rfbhx19": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:1990"
+                }
+            }
+        ],
+        "pshxh19": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:1995"
+                }
+            }
+        ],
+        "umahxh20": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2050"
+                }
+            }
+        ],
+        "mblmh20": [
+            "Marker",
+            {}
+        ],
+        "qhxh20": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2080"
+                }
+            }
+        ],
+        "rfbhx20": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2090"
+                }
+            }
+        ],
+        "pshxh20": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2095"
+                }
+            }
+        ],
+        "vvhxu20": [
+            "Marker",
+            {}
+        ],
+        "hxrcb2beg": [
+            "Marker",
+            {}
+        ],
+        "d0cb2": [
+            "Drift",
+            {
+                "length": 0.039625998586416245,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxcbx21": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": -0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2130"
+                }
+            }
+        ],
+        "d1cb2a": [
+            "Drift",
+            {
+                "length": 0.421122670173645,
+                "tracking_method": "linear"
+            }
+        ],
+        "dsscbx11": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PROF:UNDH:2140"
+                }
+            }
+        ],
+        "d1cb2b": [
+            "Drift",
+            {
+                "length": 0.05019000172615051,
+                "tracking_method": "linear"
+            }
+        ],
+        "mcbx1": [
+            "Marker",
+            {}
+        ],
+        "d1cb2c": [
+            "Drift",
+            {
+                "length": 0.39103734493255615,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxcbx22": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2155"
+                }
+            }
+        ],
+        "dchcb2": [
+            "Drift",
+            {
+                "length": 0.08388149738311768,
+                "tracking_method": "linear"
+            }
+        ],
+        "center2": [
+            "Marker",
+            {}
+        ],
+        "bcxcbx23": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2160"
+                }
+            }
+        ],
+        "bcxcbx24": [
+            "Dipole",
+            {
+                "length": 0.36800000071525574,
+                "angle": -0.0,
+                "k1": 0.0,
+                "dipole_e1": -0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.007000000216066837,
+                "gap_exit": 0.007000000216066837,
+                "fringe_integral": 1.0407999753952026,
+                "fringe_integral_exit": 1.0407999753952026,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2175"
+                }
+            }
+        ],
+        "d3cb2": [
+            "Drift",
+            {
+                "length": -0.03205699846148491,
+                "tracking_method": "linear"
+            }
+        ],
+        "hxrcb2end": [
+            "Marker",
+            {}
+        ],
+        "du3hcb2": [
+            "Drift",
+            {
+                "length": 0.23541900515556335,
+                "tracking_method": "linear"
+            }
+        ],
+        "qhxh21": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2180"
+                }
+            }
+        ],
+        "du4hcb2": [
+            "Drift",
+            {
+                "length": 0.06282400339841843,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhx21": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2190"
+                }
+            }
+        ],
+        "du5hcb2": [
+            "Drift",
+            {
+                "length": -0.05550900101661682,
+                "tracking_method": "linear"
+            }
+        ],
+        "dpshx21": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "umahxh22": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2250"
+                }
+            }
+        ],
+        "mblmh22": [
+            "Marker",
+            {}
+        ],
+        "qhxh22": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2280"
+                }
+            }
+        ],
+        "rfbhx22": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2290"
+                }
+            }
+        ],
+        "pshxh22": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2295"
+                }
+            }
+        ],
+        "vvhxu22": [
+            "Marker",
+            {}
+        ],
+        "umahxh23": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2350"
+                }
+            }
+        ],
+        "mblmh23": [
+            "Marker",
+            {}
+        ],
+        "qhxh23": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2380"
+                }
+            }
+        ],
+        "rfbhx23": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2390"
+                }
+            }
+        ],
+        "pshxh23": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2395"
+                }
+            }
+        ],
+        "umahxh24": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2450"
+                }
+            }
+        ],
+        "mblmh24": [
+            "Marker",
+            {}
+        ],
+        "qhxh24": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2480"
+                }
+            }
+        ],
+        "rfbhx24": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2490"
+                }
+            }
+        ],
+        "pshxh24": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2495"
+                }
+            }
+        ],
+        "vvhxu24": [
+            "Marker",
+            {}
+        ],
+        "umahxh25": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2550"
+                }
+            }
+        ],
+        "mblmh25": [
+            "Marker",
+            {}
+        ],
+        "qhxh25": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2580"
+                }
+            }
+        ],
+        "rfbhx25": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2590"
+                }
+            }
+        ],
+        "pshxh25": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2595"
+                }
+            }
+        ],
+        "umahxh26": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2650"
+                }
+            }
+        ],
+        "mblmh26": [
+            "Marker",
+            {}
+        ],
+        "qhxh26": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2680"
+                }
+            }
+        ],
+        "rfbhx26": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2690"
+                }
+            }
+        ],
+        "pshxh26": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2695"
+                }
+            }
+        ],
+        "umahxh27": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2750"
+                }
+            }
+        ],
+        "mblmh27": [
+            "Marker",
+            {}
+        ],
+        "qhxh27": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2780"
+                }
+            }
+        ],
+        "rfbhx27": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2790"
+                }
+            }
+        ],
+        "pshxh27": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2795"
+                }
+            }
+        ],
+        "vvhxu27": [
+            "Marker",
+            {}
+        ],
+        "hxrssbeg": [
+            "Marker",
+            {}
+        ],
+        "dmono": [
+            "Drift",
+            {
+                "length": 0.07921549677848816,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxhs1": [
+            "Dipole",
+            {
+                "length": 0.3636009991168976,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.008000999689102173,
+                "gap_exit": 0.008000999689102173,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2810"
+                }
+            }
+        ],
+        "d1": [
+            "Drift",
+            {
+                "length": 0.5933989882469177,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxhs2": [
+            "Dipole",
+            {
+                "length": 0.3636009991168976,
+                "angle": -0.0,
+                "k1": 0.0,
+                "dipole_e1": -0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.008000999689102173,
+                "gap_exit": 0.008000999689102173,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2830"
+                }
+            }
+        ],
+        "dch": [
+            "Drift",
+            {
+                "length": 0.28619951009750366,
+                "tracking_method": "linear"
+            }
+        ],
+        "diamond": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "XTAL:UNDH:2850"
+                }
+            }
+        ],
+        "bcxhs3": [
+            "Dipole",
+            {
+                "length": 0.3636009991168976,
+                "angle": -0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.0,
+                "tilt": 0.0,
+                "gap": 0.008000999689102173,
+                "gap_exit": 0.008000999689102173,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2850"
+                }
+            }
+        ],
+        "bcxhs4": [
+            "Dipole",
+            {
+                "length": 0.3636009991168976,
+                "angle": 0.0,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.008000999689102173,
+                "gap_exit": 0.008000999689102173,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:UNDH:2870"
+                }
+            }
+        ],
+        "hxrssend": [
+            "Marker",
+            {}
+        ],
+        "mblmh28": [
+            "Marker",
+            {}
+        ],
+        "qhxh28": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2880"
+                }
+            }
+        ],
+        "rfbhx28": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2890"
+                }
+            }
+        ],
+        "dpshx28": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "umahxh29": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:2950"
+                }
+            }
+        ],
+        "mblmh29": [
+            "Marker",
+            {}
+        ],
+        "qhxh29": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:2980"
+                }
+            }
+        ],
+        "rfbhx29": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:2990"
+                }
+            }
+        ],
+        "pshxh29": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:2995"
+                }
+            }
+        ],
+        "vvhxu29": [
+            "Marker",
+            {}
+        ],
+        "umahxh30": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3050"
+                }
+            }
+        ],
+        "mblmh30": [
+            "Marker",
+            {}
+        ],
+        "qhxh30": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3080"
+                }
+            }
+        ],
+        "rfbhx30": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3090"
+                }
+            }
+        ],
+        "pshxh30": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3095"
+                }
+            }
+        ],
+        "umahxh31": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3150"
+                }
+            }
+        ],
+        "mblmh31": [
+            "Marker",
+            {}
+        ],
+        "qhxh31": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3180"
+                }
+            }
+        ],
+        "rfbhx31": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3190"
+                }
+            }
+        ],
+        "pshxh31": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3195"
+                }
+            }
+        ],
+        "umahxh32": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3250"
+                }
+            }
+        ],
+        "mblmh32": [
+            "Marker",
+            {}
+        ],
+        "qhxh32": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3280"
+                }
+            }
+        ],
+        "rfbhx32": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3290"
+                }
+            }
+        ],
+        "pshxh32": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3295"
+                }
+            }
+        ],
+        "vvhxu32": [
+            "Marker",
+            {}
+        ],
+        "umahxh33": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3350"
+                }
+            }
+        ],
+        "mblmh33": [
+            "Marker",
+            {}
+        ],
+        "qhxh33": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3380"
+                }
+            }
+        ],
+        "rfbhx33": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3390"
+                }
+            }
+        ],
+        "pshxh33": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3395"
+                }
+            }
+        ],
+        "umahxh34": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3450"
+                }
+            }
+        ],
+        "mblmh34": [
+            "Marker",
+            {}
+        ],
+        "qhxh34": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3480"
+                }
+            }
+        ],
+        "rfbhx34": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3490"
+                }
+            }
+        ],
+        "pshxh34": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3495"
+                }
+            }
+        ],
+        "umahxh35": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3550"
+                }
+            }
+        ],
+        "mblmh35": [
+            "Marker",
+            {}
+        ],
+        "qhxh35": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3580"
+                }
+            }
+        ],
+        "rfbhx35": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3590"
+                }
+            }
+        ],
+        "pshxh35": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3595"
+                }
+            }
+        ],
+        "vvhxu35": [
+            "Marker",
+            {}
+        ],
+        "umahxh36": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3650"
+                }
+            }
+        ],
+        "mblmh36": [
+            "Marker",
+            {}
+        ],
+        "qhxh36": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3680"
+                }
+            }
+        ],
+        "rfbhx36": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3690"
+                }
+            }
+        ],
+        "pshxh36": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3695"
+                }
+            }
+        ],
+        "umahxh37": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3750"
+                }
+            }
+        ],
+        "mblmh37": [
+            "Marker",
+            {}
+        ],
+        "qhxh37": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3780"
+                }
+            }
+        ],
+        "rfbhx37": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3790"
+                }
+            }
+        ],
+        "pshxh37": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3795"
+                }
+            }
+        ],
+        "vvhxu37": [
+            "Marker",
+            {}
+        ],
+        "umahxh38": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3850"
+                }
+            }
+        ],
+        "mblmh38": [
+            "Marker",
+            {}
+        ],
+        "qhxh38": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3880"
+                }
+            }
+        ],
+        "rfbhx38": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3890"
+                }
+            }
+        ],
+        "pshxh38": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3895"
+                }
+            }
+        ],
+        "umahxh39": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:3950"
+                }
+            }
+        ],
+        "mblmh39": [
+            "Marker",
+            {}
+        ],
+        "qhxh39": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:3980"
+                }
+            }
+        ],
+        "rfbhx39": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:3990"
+                }
+            }
+        ],
+        "pshxh39": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:3995"
+                }
+            }
+        ],
+        "umahxh40": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4050"
+                }
+            }
+        ],
+        "mblmh40": [
+            "Marker",
+            {}
+        ],
+        "qhxh40": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4080"
+                }
+            }
+        ],
+        "rfbhx40": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4090"
+                }
+            }
+        ],
+        "pshxh40": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:4095"
+                }
+            }
+        ],
+        "vvhxu40": [
+            "Marker",
+            {}
+        ],
+        "umahxh41": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4150"
+                }
+            }
+        ],
+        "mblmh41": [
+            "Marker",
+            {}
+        ],
+        "qhxh41": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4180"
+                }
+            }
+        ],
+        "rfbhx41": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4190"
+                }
+            }
+        ],
+        "pshxh41": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:4195"
+                }
+            }
+        ],
+        "umahxh42": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4250"
+                }
+            }
+        ],
+        "mblmh42": [
+            "Marker",
+            {}
+        ],
+        "qhxh42": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4280"
+                }
+            }
+        ],
+        "rfbhx42": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4290"
+                }
+            }
+        ],
+        "pshxh42": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:4295"
+                }
+            }
+        ],
+        "umahxh43": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4350"
+                }
+            }
+        ],
+        "mblmh43": [
+            "Marker",
+            {}
+        ],
+        "qhxh43": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4380"
+                }
+            }
+        ],
+        "rfbhx43": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4390"
+                }
+            }
+        ],
+        "pshxh43": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:4395"
+                }
+            }
+        ],
+        "vvhxu43": [
+            "Marker",
+            {}
+        ],
+        "umahxh44": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4450"
+                }
+            }
+        ],
+        "mblmh44": [
+            "Marker",
+            {}
+        ],
+        "qhxh44": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4480"
+                }
+            }
+        ],
+        "rfbhx44": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4490"
+                }
+            }
+        ],
+        "pshxh44": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:4495"
+                }
+            }
+        ],
+        "umahxh45": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4550"
+                }
+            }
+        ],
+        "mblmh45": [
+            "Marker",
+            {}
+        ],
+        "qhxh45": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 1.3383592367172241,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4580"
+                }
+            }
+        ],
+        "rfbhx45": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4590"
+                }
+            }
+        ],
+        "pshxh45": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791,
+                "metadata": {
+                    "alias": "PHAS:UNDH:4595"
+                }
+            }
+        ],
+        "vvhxu45": [
+            "Marker",
+            {}
+        ],
+        "umahxh46": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344,
+                "metadata": {
+                    "alias": "USEG:UNDH:4650"
+                }
+            }
+        ],
+        "mblmh46": [
+            "Marker",
+            {}
+        ],
+        "qhxh46": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": -1.7346242666244507,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4680"
+                }
+            }
+        ],
+        "rfbhx46": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4690"
+                }
+            }
+        ],
+        "pshxh46": [
+            "Undulator",
+            {
+                "length": 0.0494999997317791
+            }
+        ],
+        "umahxh47": [
+            "Undulator",
+            {
+                "length": 3.3540000915527344
+            }
+        ],
+        "mblmh47": [
+            "Marker",
+            {}
+        ],
+        "qhxh47": [
+            "Quadrupole",
+            {
+                "length": 0.08399999886751175,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:UNDH:4780"
+                }
+            }
+        ],
+        "rfbhx47": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:4790"
+                }
+            }
+        ],
+        "dpshx47": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "dusegh48": [
+            "Drift",
+            {
+                "length": 3.3720319271087646,
+                "tracking_method": "linear"
+            }
+        ],
+        "dqhx48": [
+            "Drift",
+            {
+                "length": 0.08399999886751175,
+                "tracking_method": "linear"
+            }
+        ],
+        "drfbh48": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear"
+            }
+        ],
+        "dpshx48": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "dusegh49": [
+            "Drift",
+            {
+                "length": 3.3720319271087646,
+                "tracking_method": "linear"
+            }
+        ],
+        "dqhx49": [
+            "Drift",
+            {
+                "length": 0.08399999886751175,
+                "tracking_method": "linear"
+            }
+        ],
+        "drfbh49": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear"
+            }
+        ],
+        "dpshx49": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "dusegh50": [
+            "Drift",
+            {
+                "length": 3.3720319271087646,
+                "tracking_method": "linear"
+            }
+        ],
+        "dqhx50": [
+            "Drift",
+            {
+                "length": 0.08399999886751175,
+                "tracking_method": "linear"
+            }
+        ],
+        "drfbh50": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear"
+            }
+        ],
+        "dpshx50": [
+            "Drift",
+            {
+                "length": 0.0494999997317791,
+                "tracking_method": "linear"
+            }
+        ],
+        "rwwake5h": [
+            "Marker",
+            {}
+        ],
+        "hxrterm": [
+            "Marker",
+            {}
+        ],
+        "due1a": [
+            "Drift",
+            {
+                "length": 2.8031747341156006,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhx51": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:UNDH:5190"
+                }
+            }
+        ],
+        "due1e": [
+            "Drift",
+            {
+                "length": 0.05700000002980232,
+                "tracking_method": "linear"
+            }
+        ],
+        "endundh": [
+            "Marker",
+            {}
+        ],
+        "begdmph_1": [
+            "Marker",
+            {}
+        ],
+        "uebeg": [
+            "Marker",
+            {}
+        ],
+        "due1d": [
+            "Drift",
+            {
+                "length": 0.10000000149011612,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv36": [
+            "Marker",
+            {}
+        ],
+        "due1b": [
+            "Drift",
+            {
+                "length": 1.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "mimundo": [
+            "Marker",
+            {}
+        ],
+        "due1c": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "due2a": [
+            "Drift",
+            {
+                "length": 0.5,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycue1": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DMPH:201"
+                }
+            }
+        ],
+        "due2b": [
+            "Drift",
+            {
+                "length": 0.6295549869537354,
+                "tracking_method": "linear"
+            }
+        ],
+        "ph31": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:DMPH:225"
+                }
+            }
+        ],
+        "due2d": [
+            "Drift",
+            {
+                "length": 0.17599999904632568,
+                "tracking_method": "linear"
+            }
+        ],
+        "ph32": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:DMPH:230"
+                }
+            }
+        ],
+        "ph33": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:DMPH:175"
+                }
+            }
+        ],
+        "ph34": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "PCAV:DMPH:180"
+                }
+            }
+        ],
+        "due2e": [
+            "Drift",
+            {
+                "length": 0.5824999809265137,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcue2": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DMPH:298"
+                }
+            }
+        ],
+        "due2c": [
+            "Drift",
+            {
+                "length": 0.5550000071525574,
+                "tracking_method": "linear"
+            }
+        ],
+        "que1": [
+            "Quadrupole",
+            {
+                "length": 0.550000011920929,
+                "k1": 0.1691092550754547,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:DMPH:300"
+                }
+            }
+        ],
+        "due3a": [
+            "Drift",
+            {
+                "length": 0.3668209910392761,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmue1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BPMS:DMPH:325"
+                }
+            }
+        ],
+        "due3b": [
+            "Drift",
+            {
+                "length": 1.2117325067520142,
+                "tracking_method": "linear"
+            }
+        ],
+        "true1": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "THZR:DMPH:350"
+                }
+            }
+        ],
+        "due3c": [
+            "Drift",
+            {
+                "length": 0.3984377384185791,
+                "tracking_method": "linear"
+            }
+        ],
+        "dbkxdmph": [
+            "Drift",
+            {
+                "length": 1.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctcx_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "pctcx_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.0044999998062849045,
+                "y_max": 0.0044999998062849045,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dpcvv": [
+            "Drift",
+            {
+                "length": 0.3970000147819519,
+                "tracking_method": "linear"
+            }
+        ],
+        "vvtcx": [
+            "Marker",
+            {}
+        ],
+        "dvvtcx": [
+            "Drift",
+            {
+                "length": 0.3199999928474426,
+                "tracking_method": "linear"
+            }
+        ],
+        "mtcx01": [
+            "Marker",
+            {}
+        ],
+        "tcx01": [
+            "Cavity",
+            {
+                "length": 1.0,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 11424000000.0,
+                "metadata": {
+                    "alias": "TCAV:DMPH:360"
+                }
+            }
+        ],
+        "dtcx12": [
+            "Drift",
+            {
+                "length": 0.18649999797344208,
+                "tracking_method": "linear"
+            }
+        ],
+        "mtcx": [
+            "Marker",
+            {}
+        ],
+        "tcx02": [
+            "Cavity",
+            {
+                "length": 1.0,
+                "voltage": 0.0,
+                "phase": -0.0,
+                "frequency": 11424000000.0
+            }
+        ],
+        "dtcxsp": [
+            "Drift",
+            {
+                "length": 0.38100001215934753,
+                "tracking_method": "linear"
+            }
+        ],
+        "sptcx": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "SPLR:DMPH:373"
+                }
+            }
+        ],
+        "due4": [
+            "Drift",
+            {
+                "length": 0.39399999380111694,
+                "tracking_method": "linear"
+            }
+        ],
+        "que2": [
+            "Quadrupole",
+            {
+                "length": 0.550000011920929,
+                "k1": -0.13784082233905792,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:DMPH:380"
+                }
+            }
+        ],
+        "due5a": [
+            "Drift",
+            {
+                "length": 0.3668209910392761,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmue2": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DMPH:381"
+                }
+            }
+        ],
+        "due5b": [
+            "Drift",
+            {
+                "length": 0.3149780035018921,
+                "tracking_method": "linear"
+            }
+        ],
+        "btmque": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:DMPH:339"
+                }
+            }
+        ],
+        "due5c": [
+            "Drift",
+            {
+                "length": 0.26739999651908875,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcpm0_drift": [
+            "Drift",
+            {
+                "length": 0.07599999755620956,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcpm0_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.017500000074505806,
+                "y_max": 0.017500000074505806,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "due5f": [
+            "Drift",
+            {
+                "length": 0.05000000074505806,
+                "tracking_method": "linear"
+            }
+        ],
+        "btm0": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:DMPH:311"
+                }
+            }
+        ],
+        "due5d": [
+            "Drift",
+            {
+                "length": 0.08705499768257141,
+                "tracking_method": "linear"
+            }
+        ],
+        "mimbcs3": [
+            "Marker",
+            {}
+        ],
+        "due5e": [
+            "Drift",
+            {
+                "length": 0.11576925218105316,
+                "tracking_method": "linear"
+            }
+        ],
+        "mdlwall": [
+            "Marker",
+            {}
+        ],
+        "ddlwall": [
+            "Drift",
+            {
+                "length": 0.25082576274871826,
+                "tracking_method": "linear"
+            }
+        ],
+        "ueend": [
+            "Marker",
+            {}
+        ],
+        "dlstart": [
+            "Marker",
+            {}
+        ],
+        "dsb0a": [
+            "Drift",
+            {
+                "length": 0.2601499855518341,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycd3": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DMPH:391"
+                }
+            }
+        ],
+        "dsb0b": [
+            "Drift",
+            {
+                "length": 0.3440000116825104,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcd3": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DMPH:392"
+                }
+            }
+        ],
+        "dsb0c": [
+            "Drift",
+            {
+                "length": 0.32646000385284424,
+                "tracking_method": "linear"
+            }
+        ],
+        "vv37": [
+            "Marker",
+            {}
+        ],
+        "dsb0d": [
+            "Drift",
+            {
+                "length": 0.12336599826812744,
+                "tracking_method": "linear"
+            }
+        ],
+        "dsb0e": [
+            "Drift",
+            {
+                "length": 0.10552899539470673,
+                "tracking_method": "linear"
+            }
+        ],
+        "enddmph_1": [
+            "Marker",
+            {}
+        ],
+        "begdmph_2": [
+            "Marker",
+            {}
+        ],
+        "rodmp1h": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "bydsh": [
+            "Dipole",
+            {
+                "length": 0.5,
+                "angle": 0.0006000000284984708,
+                "k1": 0.0,
+                "dipole_e1": 0.0003000000142492354,
+                "dipole_e2": 0.0003000000142492354,
+                "tilt": 1.5707963705062866,
+                "gap": 0.03200000151991844,
+                "gap_exit": 0.03200000151991844,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DMPH:395"
+                }
+            }
+        ],
+        "ds1": [
+            "Drift",
+            {
+                "length": 0.315876305103302,
+                "tracking_method": "linear"
+            }
+        ],
+        "byd1": [
+            "Dipole",
+            {
+                "length": 1.4520303010940552,
+                "angle": 0.022400734946131706,
+                "k1": 0.0,
+                "dipole_e1": 0.011200367473065853,
+                "dipole_e2": 0.011200367473065853,
+                "tilt": 1.5707963705062866,
+                "gap": 0.0430000014603138,
+                "gap_exit": 0.0430000014603138,
+                "fringe_integral": 0.5699999928474426,
+                "fringe_integral_exit": 0.5699999928474426,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DMPH:400"
+                }
+            }
+        ],
+        "ds": [
+            "Drift",
+            {
+                "length": 0.24794599413871765,
+                "tracking_method": "linear"
+            }
+        ],
+        "byd2": [
+            "Dipole",
+            {
+                "length": 1.4520303010940552,
+                "angle": 0.022400734946131706,
+                "k1": 0.0,
+                "dipole_e1": 0.011200367473065853,
+                "dipole_e2": 0.011200367473065853,
+                "tilt": 1.5707963705062866,
+                "gap": 0.0430000014603138,
+                "gap_exit": 0.0430000014603138,
+                "fringe_integral": 0.5699999928474426,
+                "fringe_integral_exit": 0.5699999928474426,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DMPH:410"
+                }
+            }
+        ],
+        "byd3": [
+            "Dipole",
+            {
+                "length": 1.4520303010940552,
+                "angle": 0.022400734946131706,
+                "k1": 0.0,
+                "dipole_e1": 0.011200367473065853,
+                "dipole_e2": 0.011200367473065853,
+                "tilt": 1.5707963705062866,
+                "gap": 0.0430000014603138,
+                "gap_exit": 0.0430000014603138,
+                "fringe_integral": 0.5699999928474426,
+                "fringe_integral_exit": 0.5699999928474426,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DMPH:420"
+                }
+            }
+        ],
+        "dd1a": [
+            "Drift",
+            {
+                "length": 0.577681303024292,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcpm1l_drift": [
+            "Drift",
+            {
+                "length": 0.07599999755620956,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcpm1l_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.014287499710917473,
+                "y_max": 0.014287499710917473,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "btm1l": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:DMPH:423"
+                }
+            }
+        ],
+        "dd1b": [
+            "Drift",
+            {
+                "length": 1.0000874996185303,
+                "tracking_method": "linear"
+            }
+        ],
+        "mimdump": [
+            "Marker",
+            {}
+        ],
+        "dd1c": [
+            "Drift",
+            {
+                "length": 0.30480000376701355,
+                "tracking_method": "linear"
+            }
+        ],
+        "mimbcs4": [
+            "Marker",
+            {}
+        ],
+        "dd1d": [
+            "Drift",
+            {
+                "length": 8.822711944580078,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdd": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DMPH:440"
+                }
+            }
+        ],
+        "dd1e": [
+            "Drift",
+            {
+                "length": 0.24963811039924622,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcpm2l_drift": [
+            "Drift",
+            {
+                "length": 0.07599999755620956,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcpm2l_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.038100000470876694,
+                "y_max": 0.038100000470876694,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "btm2l": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:DMPH:451"
+                }
+            }
+        ],
+        "dd1f": [
+            "Drift",
+            {
+                "length": 0.40924006700515747,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdmp1": [
+            "Quadrupole",
+            {
+                "length": 0.4300000071525574,
+                "k1": -0.15521271526813507,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:DMPH:500"
+                }
+            }
+        ],
+        "dd12a": [
+            "Drift",
+            {
+                "length": 0.3020628094673157,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmqd": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DMPH:502"
+                }
+            }
+        ],
+        "dd12b": [
+            "Drift",
+            {
+                "length": 0.007937200367450714,
+                "tracking_method": "linear"
+            }
+        ],
+        "mqdmp": [
+            "Marker",
+            {}
+        ],
+        "dd12c": [
+            "Drift",
+            {
+                "length": 0.3100000023841858,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdmp2": [
+            "Quadrupole",
+            {
+                "length": 0.4300000071525574,
+                "k1": -0.15521271526813507,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "metadata": {
+                    "alias": "QUAD:DMPH:600"
+                }
+            }
+        ],
+        "dd2a": [
+            "Drift",
+            {
+                "length": 0.4749999940395355,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdd": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DMPH:602"
+                }
+            }
+        ],
+        "dd2b": [
+            "Drift",
+            {
+                "length": 6.202253341674805,
+                "tracking_method": "linear"
+            }
+        ],
+        "dd2c": [
+            "Drift",
+            {
+                "length": 1.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "dd3a": [
+            "Drift",
+            {
+                "length": 0.351267009973526,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmdd": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DMPH:693"
+                }
+            }
+        ],
+        "dd3b": [
+            "Drift",
+            {
+                "length": 0.1537144035100937,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrdmp": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:DMPH:695"
+                }
+            }
+        ],
+        "dwsdumpa1": [
+            "Drift",
+            {
+                "length": 0.07596510648727417,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcebd_drift": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "pcebd_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.03400000184774399,
+                "y_max": 0.03400000184774399,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "dwsdumpa2": [
+            "Drift",
+            {
+                "length": 0.1448148936033249,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbdd": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:DMPH:696"
+                }
+            }
+        ],
+        "dwsdumpb": [
+            "Drift",
+            {
+                "length": 0.22078000009059906,
+                "tracking_method": "linear"
+            }
+        ],
+        "wsdump": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "WIRE:DMPH:697"
+                }
+            }
+        ],
+        "dwsdumpc": [
+            "Drift",
+            {
+                "length": 2.2870752811431885,
+                "tracking_method": "linear"
+            }
+        ],
+        "rodmp2h": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "dumpface": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "DUMP:DMPH:699"
+                }
+            }
+        ],
+        "ddump": [
+            "Drift",
+            {
+                "length": 1.552448034286499,
+                "tracking_method": "linear"
+            }
+        ],
+        "dmpend": [
+            "Marker",
+            {}
+        ],
+        "btmdump": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BTM:DMPH:699"
+                }
+            }
+        ],
+        "dbmark38": [
+            "Marker",
+            {}
+        ],
+        "enddmph_2": [
+            "Marker",
+            {}
+        ]
     },
     "lattices": {
-        "cu_hxr": ["dl00", "loadlock", "beggun", "sol1bk", "dbmark80", "cathode", "dl01a", "sol1", "dl01a1", "vv01", "dl01a2", "am00", "dl01a3", "am01", "dl01a4", "yag01", "dl01a5", "fc01", "dl01b", "im01", "dl01c", "xc01", "yc01", "dl01h", "bpm2", "dl01d", "dbmark81", "endgun", "begl0", "dbxg", "dl01e", "bpm3", "dl01f", "cr01", "dl01f2", "yag02", "dl01g", "zlin00", "l0a", "l0awake", "l0bbeg", "dl02a1", "yag03", "dl02a2", "dl02a3", "qa01", "dl02b1", "ph01", "dl02b2", "qa02", "dl02c", "l0b", "endl0", "begdl1_1", "emat", "de00", "de00a", "qe01", "de01a", "im02", "de01b", "vv02", "de01c", "qe02", "dh00", "lhbeg", "bxh1", "dh01", "bxh2", "dh02a", "otrh1", "dh03a", "lh_und", "dh03b", "otrh2", "dh02b", "bxh3", "dh01", "bxh4", "lhend", "dh06", "tcav0", "de02", "qe03", "de03a", "de03b", "xc07", "yc07", "de03c", "qe04", "de04", "ws01", "de05", "otr1", "de05c", "vv03", "de06a", "rst1", "de06b", "ws02", "de05a", "mrk0", "de05a", "otr2", "de06d", "bpm10", "de06e", "ws03", "de05", "otr3", "de07", "qm01", "de08", "xc08", "yc08", "de08a", "vv04", "de08b", "qm02", "de09", "dbmark82", "enddl1_1", "begdl1_2", "bx01", "db00a", "otr4", "db00b", "xc09", "yc09", "db00c", "qb", "db00d", "ws04", "db00e", "bx02", "cnt0", "dbmark83", "dm00", "xc10", "yc10", "dm00a", "qm03", "dm01", "dm01a", "qm04", "dm02", "im03", "dm02a", "enddl1_2", "begl1", "zlin01", "k21_1b", "daqa1", "qa11", "daqa2", "k21_1c", "daqa3", "qa12", "daqa4", "k21_1d", "endl1", "begbc1", "dl1xa", "vvx1", "dl1xb", "l1x", "dm10a", "vvx2", "dm10c", "q21201", "dm10x", "imbc1i", "dm11", "qm11", "dm12", "bc1cbeg", "bx11", "dbq1", "cq11", "d11o", "bx12", "ddg1", "bpms11", "ddg2", "ce11_drift", "ce11_aperture", "ddg3", "otr11", "ddg4", "bx13", "d11oa", "sq13", "d11ob", "cq12", "dbq1", "bx14", "cnt1", "bc1cend", "dm13a", "bl11", "dm13b", "qm12", "dm14a", "dm14b", "imbc1o", "dm14c", "qm13", "dm15a", "bl12", "dm15b", "xc21275", "yc21276", "dm15c", "ws11", "dww1a", "ws12", "dww1b", "otr12", "dww1c1", "ph02", "dww1c2", "xc21302", "dww1d", "yc21303", "dww1e", "ws13", "dm16", "q21301", "dm17a", "dm17b", "td11", "dm17c", "qm14", "dm18a", "xc21325", "yc21325", "dm18b", "qm15", "dbmark28", "dm19", "endbc1", "begl2", "li21beg", "zlin04", "k21_3b", "k21_3c", "k21_3d", "daq1", "q21401", "daq2", "k21_4a", "k21_4b", "k21_4c", "k21_4d", "daq1", "q21501", "daq2", "k21_5a", "k21_5b", "k21_5c", "k21_5d", "daq1", "q21601", "daq2", "k21_6a", "k21_6b", "k21_6c", "k21_6d", "daq1", "q21701", "daq2", "k21_7a", "k21_7b", "k21_7c", "k21_7d", "daq1", "q21801", "daq2", "k21_8a", "k21_8b", "k21_8c", "k21_8d", "daq3", "q21901", "d219a", "bky21929", "d219b", "bkx21957", "d219c", "li21end", "li22beg", "zlin05", "k22_1a", "k22_1b", "k22_1c", "k22_1d", "daq1", "q22201", "daq2", "k22_2a", "k22_2b", "k22_2c", "k22_2d", "daq1", "q22301", "daq2", "k22_3a", "k22_3b", "k22_3c", "k22_3d", "daq1", "q22401", "daq2", "k22_4a", "k22_4b", "k22_4c", "k22_4d", "daq1", "q22501", "daq2", "k22_5a", "k22_5b", "k22_5c", "k22_5d", "daq1", "q22601", "daq2", "k22_6a", "k22_6b", "k22_6c", "k22_6d", "daq1", "q22701", "daq2", "k22_7a", "k22_7b", "k22_7c", "k22_7d", "daq1", "q22801", "daq2", "k22_8a", "k22_8b", "k22_8c", "k22_8d", "daq3", "q22901", "d229a", "bky22929", "d229b", "bkx22957", "d229c", "li22end", "li23beg", "zlin06", "k23_1a", "k23_1b", "k23_1c", "k23_1d", "daq1", "q23201", "daq2", "k23_2a", "k23_2b", "k23_2c", "k23_2d", "daq1", "q23301", "daq2", "k23_3a", "k23_3b", "k23_3c", "k23_3d", "daq1", "q23401", "daq2", "k23_4a", "k23_4b", "k23_4c", "k23_4d", "daq1", "q23501", "daq2", "k23_5a", "k23_5b", "k23_5c", "k23_5d", "daq1", "q23601", "daq2", "k23_6a", "k23_6b", "k23_6c", "k23_6d", "daq1", "q23701", "daq2", "k23_7a", "k23_7b", "k23_7c", "k23_7d", "daq1", "q23801", "daq2", "k23_8a", "k23_8b", "k23_8c", "k23_8d", "daq3", "q23901", "daq4", "li23end", "li24beg", "zlin07", "k24_1a", "k24_1b", "k24_1c", "k24_1d", "daq1", "q24201", "daq2", "k24_2a", "k24_2b", "k24_2c", "k24_2d", "daq1", "q24301", "daq2", "k24_3a", "k24_3b", "k24_3c", "k24_3d", "daq1", "q24401", "daq2", "k24_4a", "k24_4b", "k24_4c", "k24_4d", "daq1", "q24501", "daq2", "k24_5a", "k24_5b", "k24_5c", "k24_5d", "daq1", "q24601", "daq2", "k24_6a", "k24_6b", "k24_6c", "k24_6d", "li24term", "endl2", "begbc2", "dm20", "q24701a", "d10cma", "q24701b", "dm21z", "dm21a", "ws24", "dm21h", "imbc2i", "dm21b", "vv21", "dm21c", "qm21", "dm21d", "dm21e", "bc2cbeg", "bx21", "dbq2a", "cq21", "d21oa", "bx22", "ddg0", "ddg1", "bpms21", "ddg2", "ce21_drift", "ce21_aperture", "ddg3", "otr21", "ddg4", "ddga", "bx23", "d21ob", "cq22", "dbq2b", "bx24", "cnt2", "bc2cend", "d21w", "d21x", "bl21", "d21y", "dm23b", "qm22", "dm24a", "vv22", "dm24b", "dm24d", "q24901a", "dm24c", "q24901b", "dm25", "endbc2", "begl3", "li25beg", "zlin09", "k25_1a", "k25_1b", "d25_1c", "k25_1d", "daq1", "q25201", "daq2", "k25_2a", "k25_2b", "k25_2c", "d255a", "imbc2o", "d255b", "d255c", "tcav3", "d255d", "q25301", "daq2", "k25_3a", "k25_3b", "k25_3c", "d256a", "ph03", "d256b", "bl22", "d256c", "bxkik", "d256d", "daq1", "q25401", "daq2", "k25_4a", "k25_4b", "k25_4c", "k25_4d", "daq1", "q25501", "daq2", "k25_5a", "k25_5b", "k25_5c", "k25_5d", "daq1", "q25601", "daq2", "k25_6a", "k25_6b", "k25_6c", "k25_6d", "daq1", "q25701", "daq2", "k25_7a", "k25_7b", "k25_7c", "k25_7d", "daq1", "q25801", "daq2", "k25_8a", "k25_8b", "k25_8c", "k25_8d", "daq7", "q25901", "daq8a", "otr_tcav", "daq8b", "li25end", "li26beg", "zlin10", "k26_1a", "k26_1b", "k26_1c", "k26_1d", "daq1", "q26201", "daq2", "k26_2a", "k26_2b", "k26_2c", "k26_2d", "daq1", "q26301", "daq2", "k26_3a", "k26_3b", "k26_3c", "k26_3d", "daq1", "q26401", "daq2", "k26_4a", "k26_4b", "k26_4c", "k26_4d", "daq1", "q26501", "daq2", "k26_5a", "k26_5b", "k26_5c", "k26_5d", "daq1", "q26601", "daq2", "k26_6a", "k26_6b", "k26_6c", "k26_6d", "daq1", "q26701", "daq2", "k26_7a", "k26_7b", "k26_7c", "k26_7d", "daq1", "q26801", "daq2", "k26_8a", "k26_8b", "k26_8c", "k26_8d", "daq7", "q26901", "daq8", "li26end", "li27beg", "zlin11", "k27_1a", "k27_1b", "k27_1c", "k27_1d", "daq1", "q27201", "daq2", "k27_2a", "k27_2b", "k27_2c", "k27_2d", "daq1", "q27301", "daq2", "k27_3a", "k27_3b", "k27_3c", "k27_3d", "daq1", "q27401", "daq2", "k27_4a", "k27_4b", "k27_4c", "k27_4d", "daq1", "q27501", "daq2", "k27_5a", "k27_5b", "k27_5c", "k27_5d", "daq1", "q27601", "daq2", "k27_6a", "k27_6b", "k27_6c", "daq5a", "ws27644", "daq6a", "q27701", "daq2", "k27_7a", "k27_7b", "k27_7c", "k27_7d", "daq1", "q27801", "daq2", "k27_8a", "k27_8b", "k27_8c", "k27_8d", "daq7", "q27901", "daq8", "li27end", "li28beg", "zlin12", "k28_1a", "k28_1b", "k28_1c", "daq5b1", "xc29092", "daq5b2", "yc29092", "daq5b3", "ws28144", "daq6b", "q28201", "daq2", "k28_2a", "k28_2b", "k28_2c", "k28_2d", "daq1", "q28301", "daq2", "k28_3a", "k28_3b", "k28_3c", "k28_3d", "daq1", "q28401", "daq2", "k28_4a", "k28_4b", "k28_4c", "daq5c1", "xc29095", "daq5c2", "yc29095", "daq5c3", "ws28444", "daq6c", "q28501", "daq2", "k28_5a", "k28_5b", "k28_5c", "d28_5d", "daq1", "q28601", "daq2", "k28_6a", "k28_6b", "k28_6c", "k28_6d", "daq1", "q28701", "daq2", "k28_7a", "k28_7b", "k28_7c", "daq5d", "ws28744", "daq6d", "q28801", "daq2", "k28_8a", "k28_8b", "k28_8c", "k28_8d", "daq7", "q28901", "daq8c", "c29096_drift", "c29096_aperture", "daq8d1", "st28950", "daq8d2", "st28960", "daq8d3", "li28end", "li29beg", "zlin13", "k29_1a", "k29_1b", "k29_1c", "d10ca", "c29146_drift", "c29146_aperture", "d10cb", "daq1", "q29201", "daq2", "k29_2a", "k29_2b", "k29_2c", "k29_2d", "daq1", "q29301", "daq2", "k29_3a", "k29_3b", "k29_3c", "k29_3d", "daq1", "q29401", "daq2", "k29_4a", "k29_4b", "k29_4c", "d10cc", "c29446_drift", "c29446_aperture", "d10cd", "daq1", "q29501", "daq2", "k29_5a", "k29_5b", "k29_5c", "d10ce", "c29546_drift", "c29546_aperture", "d10cf", "daq1", "q29601", "daq2", "k29_6a", "k29_6b", "k29_6c", "k29_6d", "daq1", "q29701", "daq2", "k29_7a", "k29_7b", "k29_7c", "k29_7d", "daq9a", "pk297", "daq9b", "q29801", "daq2", "k29_8a", "k29_8b", "k29_8c", "k29_8d", "daq3", "q29901", "daq4a", "p30013", "daq4b", "p30014", "daq4c", "c29956_drift", "c29956_aperture", "daq4d", "pk299", "daq4e", "li29end", "li30beg", "zlin14", "k30_1a", "k30_1b", "k30_1c", "k30_1d", "daq10a", "p30143", "daq10b", "p30144", "daq10c", "c30146_drift", "c30146_aperture", "daq10d", "q30201", "daq2", "k30_2a", "k30_2b", "k30_2c", "k30_2d", "daq1", "q30301", "daq2", "k30_3a", "k30_3b", "k30_3c", "k30_3d", "daq10e", "pk303", "daq10f", "q30401", "daq2", "k30_4a", "k30_4b", "k30_4c", "k30_4d", "daq10g", "p30443", "daq10h", "p30444", "daq10i", "c30446_drift", "c30446_aperture", "daq10j", "pk304", "daq10k", "q30501", "daq2", "k30_5a", "k30_5b", "k30_5c", "k30_5d", "daq11a", "p30543", "daq11b", "p30544", "daq11c", "c30546_drift", "c30546_aperture", "daq11d", "q30601", "daq12", "k30_6a", "k30_6b", "k30_6c", "k30_6d", "daq13", "q30701", "daq14", "k30_7a", "k30_7b", "k30_7c", "k30_7d", "daq15", "q30801", "daq16", "k30_8a", "k30_8b", "k30_8c", "daq17", "li30term", "dbmark29", "endl3", "begclth_0", "bsybeg", "bsy1beg", "dbsy01a", "imbsy1", "dbsy01b", "imbsy2", "dbsy01c", "imbsy3", "dbsy01d", "imbsy34", "dbsy01e", "imbsy1b", "dbsy01f", "imbsy2b", "dbsy01g", "imbsy3b", "dbsy01h", "fftborgn", "dbsy01i", "s100", "zlin15", "dbsy50a", "ycbsyq1", "dbsy50b", "q50q1", "dbsy02a", "wooddoor", "endclth_0", "begclth_1", "dbsy02b", "bpmbsyq1", "dbsy51a", "xcbsyq2", "dbsy51b", "q50q2", "dbsy52a", "bpmbsyq2", "dbsy52b", "endclth_1", "begclth_2", "dbrcusdc1a", "dbrcusdc1b", "dckdc1", "dbkrcusa", "dbkrcusb", "dckdc2", "dbrcusdc2a", "dbrcusdc2b", "dcusblra", "bpmcus", "dcusblrb", "dblrcusa", "dblrcusb", "dbsy52c", "dbxsp1ha", "dbxsp1hb", "bsy1end", "endclth_2", "begbsyh_1", "dbsy52d", "q50q3", "dbsy53a", "bpmbsyq3", "rfbbsyq3", "dbsy53b", "dbsy53c", "xcbsyq3", "dbsy53d", "ycbsyq4", "dbsy53f", "q4", "dbsy53ga", "pcbsy3", "dbsy53gb", "mrgaline", "endbsyh_1", "begbsyh_2", "dbkrapm1a", "dbkrapm1b", "dzapm1", "pcapm1_drift", "pcapm1_aperture", "dzapm1", "dbkrapm2a", "dbkrapm2b", "dzapm2a", "xcapm2", "ycapm2", "dzapm2b", "pcapm2_drift", "pcapm2_aperture", "dzapm2", "dbkrapm3a", "dbkrapm3b", "dzapm3", "pcapm3_drift", "pcapm3_aperture", "dzapm3", "dbkrapm4a", "dbkrapm4b", "dzapm4", "pcapm4_drift", "pcapm4_aperture", "dza01", "dza02", "pcbsyh", "dbsy53h", "q5", "dbsy54a", "xcbsyq5", "dbsy54b", "dbsy54c", "q6", "drfb", "rfbbsyq6", "dbsy55a", "ycbsyq6", "dbsy55b", "pc90_drift", "pc90_aperture", "dbsy55c", "pcbsy4", "dbsy55d", "pc119_drift", "pc119_aperture", "dbsy55e", "d2", "dm3", "st60", "dm4a", "dm60", "dm4b", "cc31beg", "bcx311", "dcc31o", "bcx312", "dcc31i", "bcx313", "dcc31o", "bcx314", "cc31end", "dm4c", "cxq6_drift", "cxq6_aperture", "dm4da", "pcbsy5", "dm4db", "xca0", "dxca0", "yca0", "dyca0", "st61", "dm5", "qa0", "dm6", "dmoni", "dmoni", "muwall", "dwalla", "dumpbsyh", "dwallb", "bsyend", "rwwake3h", "endbsyh_2", "begltuh", "dycvm1", "ycvm1", "dqvm1", "qvm1", "dqvm2a", "xcvm2", "dqvm2b", "qvm2", "dwsvm2a", "wsvm2", "dwsvm2b", "vbin", "by1", "dvb1", "qvb1", "d40cmc", "ycvb1", "dvb2m80cm", "xcvb2", "d40cmc", "qvb2", "dvb2ha", "pc01", "btm01", "dvb2hb", "qvb3", "d40cmc", "ycvb3", "dvb1m40cm", "by2", "cntlt1h", "vbout", "dvb25cmc", "xcvm3", "d25cm", "qvm3", "dvbem25cm", "ycvm4", "d25cm", "qvm4", "dvbem15cm", "im31", "d10cmb", "imbcs1", "d25cma", "mm1", "dbmark34", "bx31", "ddl10wa", "pc02", "btm02", "ddl10wb", "dwsdl31a", "wsdl31", "dwsdl31b", "ddl10x", "xcdl1", "d31a", "qdl31", "drfb", "rfbdl1", "d31b", "ycdl1", "d32cmb", "cedl1_drift", "cedl1_aperture", "d31c", "wig1h", "dwgh", "wig2h", "dwgh", "wig3h", "cntwigh", "ddl10em80cma", "pc22", "ddl10em80cmb", "cybx32_drift", "cybx32_aperture", "dcb32", "bx32", "cntlt2h", "ddl20e", "qt11", "ddl30em40cm", "xcqt12", "d40cmb", "qt12", "d40cmb", "ycqt12", "ddl30em40cm", "qt13", "ddl20e", "ss1", "dx33a", "cc32beg", "bcx321", "dcc32o", "bcx322", "dcc32i", "bcx323", "dcc32o", "bcx324", "cc32end", "dx33b", "pc03", "btm03", "ddl1ab", "bykik1", "ddl1d", "ddl1d", "bykik2", "ddl1e", "xcdl2", "d32a", "qdl32", "d32b", "ycdl2", "dsplr", "spoiler", "ddl1cm40cm", "tdkik", "d30cma", "pctdkik1_drift", "pctdkik1_aperture", "dpc1", "pctdkik2_drift", "pctdkik2_aperture", "dpc2", "pctdkik3_drift", "pctdkik3_aperture", "dpc3", "pctdkik4_drift", "pctdkik4_aperture", "dpc4", "dspontua", "dspontub", "ddl1dm30cm", "dx34a", "cc35beg", "bcx351", "dcc35o", "bcx352", "dcc35i", "bcx353", "dcc35o", "bcx354", "cc35end", "dx34b", "ycqt21", "ddl20", "qt21", "ddl30em40cm", "xcqt22", "d40cmb", "qt22", "d46cm", "cxqt22_drift", "cxqt22_aperture", "d46cm", "qt23", "ddl20", "dl23beg", "bx35", "dcq31aa", "pc04", "btm04", "dcq31ab", "cq31", "dcq31ba", "pc42", "btm42", "dcq31bb", "otr30", "d29cma", "xcdl3", "d33a", "qdl33", "d33b", "ycdl3", "d32cmd", "cedl3_drift", "cedl3_aperture", "dcq32a", "cq32", "dcq32b", "cybx36_drift", "cybx36_aperture", "dcb36", "bx36", "cntlt3h", "ddl20e", "qt31", "ddl30em40cma", "xcqt32", "d40cmd", "qt32", "d40cme", "ycqt32", "ddl30em40cmb", "qt33", "ddl20e", "ss3", "d37a", "cc36beg", "bcx361", "dcc36o", "bcx362", "dcc36i", "bcx363", "dcc36o", "bcx364", "cc36end", "d37ba", "pc43", "btm43", "d37bb", "imbcs2", "d37c", "pc05", "btm05", "d37d", "wsdl4", "d37e", "dchirpv", "d37f", "qdl34", "d38a", "dchirph", "d38b", "xcdl4", "d38c", "ycdl4", "d38da", "pc06", "btm06", "d38db", "ddl20", "qt41", "ddl30em40cmc", "xcqt42", "d40cmf", "qt42", "d40cmb", "ycqt42", "ddl30em40cm", "qt43", "ddl20", "mm2", "d25cmb", "im36", "d25cmc", "dmm1m90cm", "ycem1", "dem1a", "qem1", "dem1c", "qem2", "dem2b", "xcem2", "dmm3ma", "pc07", "btm07", "dmm3mb", "ycem3", "dem3a", "qem3", "dem3b", "qem3v", "dmm4m90cm", "xcem4", "dem4a", "qem4", "drfb", "rfbem4", "dmm5a", "pc08", "btm08", "dmm5b", "dbmark36", "ws31", "d40cm", "de3ma", "pc09", "btm09", "de3mb", "xce31", "dqea", "qe31", "dqebx", "dcx31", "dqebx2", "de3a", "yce32", "dqeaa", "qe32", "drfb", "rfbe32", "dqeby1", "dcy32", "dqeby2", "ws32", "d40cm", "de3m80cmb", "xce33", "dqeab", "qe33", "dqeca", "yagpsi", "dqecb", "otr33", "de3m40cm", "yce34", "dqea", "qe34", "drfb", "rfbe34", "dqec1", "ws33", "d40cm", "de3m80cm", "xce35", "dqeac", "qe35", "dqebx", "dcx35", "dqebx2", "de3", "yce36", "dqea", "qe36", "drfb", "rfbe36", "dqeby1", "dcy36", "dqeby2", "ws34", "d40cmg", "dws35", "d40cmh", "du1m80cma", "dws36", "du1m80cmb", "dcx37", "d32cmc", "xcum1", "dum1a", "qum1", "dum1b", "d32cm", "du2m120cm", "dcy38", "d32cma", "ycum2", "dum2a", "qum2", "dum2b", "du3m80cm", "xcum3", "dum3a", "qum3", "dum3b", "d40cma", "eoblm", "du4m120cm", "ycum4", "dum4a", "qum4", "dum4b", "rfb07", "du5m80cm", "imundi", "d40cmwa", "bltof", "d40cmwb", "muhwall1", "duhwall1", "duhvesta", "rfb08", "duhvestb", "muhwall2", "duhwall2", "dw2tdund", "dtdund1", "tdund", "dtdund2", "dpcmuon", "pcmuon_drift", "pcmuon_aperture", "dmuon1", "vv999", "dmuon2", "rwwake4h", "endltuh", "begundh", "dmuon3", "rfbhx12", "dmuon4", "mm3", "pfilt1", "dbmark37", "du0h", "du8h", "hxrstart", "du1h", "du2h", "hxrcb1beg", "d0cb1", "bcxcbx11", "d1cb1a", "mcbx4", "d1cb1b", "bodcbx42", "d1cb1c", "bcxcbx12", "dchcb1", "center1", "dchcb1", "bcxcbx13", "d2cb", "bcxcbx14", "d3cb1", "hxrcb1end", "du3hcb1", "qhxh13", "du4hcb1", "rfbhx13", "du5hcb1", "dpshx13", "du6h", "du7h", "du1h", "du2h", "dthxu", "umahxh14", "dthxu", "du3h", "mblmh14", "du3h", "qhxh14", "du4h", "rfbhx14", "du5h", "pshxh14", "du6h", "vvhxu14", "du7h", "du1h", "du2h", "dthxu", "umahxh15", "dthxu", "du3h", "mblmh15", "du3h", "qhxh15", "du4h", "rfbhx15", "du5h", "pshxh15", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh16", "dthxu", "du3h", "mblmh16", "du3h", "qhxh16", "du4h", "rfbhx16", "du5h", "pshxh16", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh17", "dthxu", "du3h", "mblmh17", "du3h", "qhxh17", "du4h", "rfbhx17", "du5h", "pshxh17", "du6h", "vvhxu17", "du7h", "du1h", "du2h", "dthxu", "umahxh18", "dthxu", "du3h", "mblmh18", "du3h", "qhxh18", "du4h", "rfbhx18", "du5h", "pshxh18", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh19", "dthxu", "du3h", "mblmh19", "du3h", "qhxh19", "du4h", "rfbhx19", "du5h", "pshxh19", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh20", "dthxu", "du3h", "mblmh20", "du3h", "qhxh20", "du4h", "rfbhx20", "du5h", "pshxh20", "du6h", "vvhxu20", "du7h", "du1h", "du2h", "hxrcb2beg", "d0cb2", "bcxcbx21", "d1cb2a", "dsscbx11", "d1cb2b", "mcbx1", "d1cb2c", "bcxcbx22", "dchcb2", "center2", "dchcb2", "bcxcbx23", "d2cb", "bcxcbx24", "d3cb2", "hxrcb2end", "du3hcb2", "qhxh21", "du4hcb2", "rfbhx21", "du5hcb2", "dpshx21", "du6h", "du7h", "du1h", "du2h", "dthxu", "umahxh22", "dthxu", "du3h", "mblmh22", "du3h", "qhxh22", "du4h", "rfbhx22", "du5h", "pshxh22", "du6h", "vvhxu22", "du7h", "du1h", "du2h", "dthxu", "umahxh23", "dthxu", "du3h", "mblmh23", "du3h", "qhxh23", "du4h", "rfbhx23", "du5h", "pshxh23", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh24", "dthxu", "du3h", "mblmh24", "du3h", "qhxh24", "du4h", "rfbhx24", "du5h", "pshxh24", "du6h", "vvhxu24", "du7h", "du1h", "du2h", "dthxu", "umahxh25", "dthxu", "du3h", "mblmh25", "du3h", "qhxh25", "du4h", "rfbhx25", "du5h", "pshxh25", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh26", "dthxu", "du3h", "mblmh26", "du3h", "qhxh26", "du4h", "rfbhx26", "du5h", "pshxh26", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh27", "dthxu", "du3h", "mblmh27", "du3h", "qhxh27", "du4h", "rfbhx27", "du5h", "pshxh27", "du6h", "vvhxu27", "du7h", "du1h", "du2h", "hxrssbeg", "dmono", "bcxhs1", "d1", "bcxhs2", "dch", "diamond", "dch", "bcxhs3", "d1", "bcxhs4", "dmono", "hxrssend", "du3h", "mblmh28", "du3h", "qhxh28", "du4h", "rfbhx28", "du5h", "dpshx28", "du6h", "du7h", "du1h", "du2h", "dthxu", "umahxh29", "dthxu", "du3h", "mblmh29", "du3h", "qhxh29", "du4h", "rfbhx29", "du5h", "pshxh29", "du6h", "vvhxu29", "du7h", "du1h", "du2h", "dthxu", "umahxh30", "dthxu", "du3h", "mblmh30", "du3h", "qhxh30", "du4h", "rfbhx30", "du5h", "pshxh30", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh31", "dthxu", "du3h", "mblmh31", "du3h", "qhxh31", "du4h", "rfbhx31", "du5h", "pshxh31", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh32", "dthxu", "du3h", "mblmh32", "du3h", "qhxh32", "du4h", "rfbhx32", "du5h", "pshxh32", "du6h", "vvhxu32", "du7h", "du1h", "du2h", "dthxu", "umahxh33", "dthxu", "du3h", "mblmh33", "du3h", "qhxh33", "du4h", "rfbhx33", "du5h", "pshxh33", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh34", "dthxu", "du3h", "mblmh34", "du3h", "qhxh34", "du4h", "rfbhx34", "du5h", "pshxh34", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh35", "dthxu", "du3h", "mblmh35", "du3h", "qhxh35", "du4h", "rfbhx35", "du5h", "pshxh35", "du6h", "vvhxu35", "du7h", "du1h", "du2h", "dthxu", "umahxh36", "dthxu", "du3h", "mblmh36", "du3h", "qhxh36", "du4h", "rfbhx36", "du5h", "pshxh36", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh37", "dthxu", "du3h", "mblmh37", "du3h", "qhxh37", "du4h", "rfbhx37", "du5h", "pshxh37", "du6h", "vvhxu37", "du7h", "du1h", "du2h", "dthxu", "umahxh38", "dthxu", "du3h", "mblmh38", "du3h", "qhxh38", "du4h", "rfbhx38", "du5h", "pshxh38", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh39", "dthxu", "du3h", "mblmh39", "du3h", "qhxh39", "du4h", "rfbhx39", "du5h", "pshxh39", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh40", "dthxu", "du3h", "mblmh40", "du3h", "qhxh40", "du4h", "rfbhx40", "du5h", "pshxh40", "du6h", "vvhxu40", "du7h", "du1h", "du2h", "dthxu", "umahxh41", "dthxu", "du3h", "mblmh41", "du3h", "qhxh41", "du4h", "rfbhx41", "du5h", "pshxh41", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh42", "dthxu", "du3h", "mblmh42", "du3h", "qhxh42", "du4h", "rfbhx42", "du5h", "pshxh42", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh43", "dthxu", "du3h", "mblmh43", "du3h", "qhxh43", "du4h", "rfbhx43", "du5h", "pshxh43", "du6h", "vvhxu43", "du7h", "du1h", "du2h", "dthxu", "umahxh44", "dthxu", "du3h", "mblmh44", "du3h", "qhxh44", "du4h", "rfbhx44", "du5h", "pshxh44", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh45", "dthxu", "du3h", "mblmh45", "du3h", "qhxh45", "du4h", "rfbhx45", "du5h", "pshxh45", "du6h", "vvhxu45", "du7h", "du1h", "du2h", "dthxu", "umahxh46", "dthxu", "du3h", "mblmh46", "du3h", "qhxh46", "du4h", "rfbhx46", "du5h", "pshxh46", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dthxu", "umahxh47", "dthxu", "du3h", "mblmh47", "du3h", "qhxh47", "du4h", "rfbhx47", "du5h", "dpshx47", "du6h", "dvvhxu", "du7h", "du1h", "du2h", "dusegh48", "du3h", "du3h", "dqhx48", "du4h", "drfbh48", "du5h", "dpshx48", "du6h", "du7h", "du1h", "du2h", "dusegh49", "du3h", "du3h", "dqhx49", "du4h", "drfbh49", "du5h", "dpshx49", "du6h", "du7h", "du1h", "du2h", "dusegh50", "du3h", "du3h", "dqhx50", "du4h", "drfbh50", "du5h", "dpshx50", "du6h", "du7h", "rwwake5h", "hxrterm", "due1a", "rfbhx51", "due1e", "endundh", "begdmph_1", "uebeg", "due1d", "vv36", "due1b", "mimundo", "due1c", "due2a", "ycue1", "due2b", "ph31", "due2d", "ph32", "due2d", "ph33", "due2d", "ph34", "due2e", "xcue2", "due2c", "que1", "due3a", "bpmue1", "due3b", "true1", "due3c", "dbkxdmph", "due3c", "pctcx_drift", "pctcx_aperture", "dpcvv", "vvtcx", "dvvtcx", "mtcx01", "tcx01", "dtcx12", "mtcx", "dtcx12", "tcx02", "dtcxsp", "sptcx", "due4", "que2", "due5a", "bpmue2", "due5b", "btmque", "due5c", "pcpm0_drift", "pcpm0_aperture", "due5f", "btm0", "due5d", "mimbcs3", "due5e", "mdlwall", "ddlwall", "ueend", "dlstart", "dsb0a", "ycd3", "dsb0b", "xcd3", "dsb0c", "vv37", "dsb0d", "dsb0e", "enddmph_1", "begdmph_2", "rodmp1h", "bydsh", "ds1", "byd1", "ds", "byd2", "ds", "byd3", "dd1a", "pcpm1l_drift", "pcpm1l_aperture", "btm1l", "dd1b", "mimdump", "dd1c", "mimbcs4", "dd1d", "ycdd", "dd1e", "pcpm2l_drift", "pcpm2l_aperture", "btm2l", "dd1f", "qdmp1", "dd12a", "bpmqd", "dd12b", "mqdmp", "dd12c", "qdmp2", "dd2a", "xcdd", "dd2b", "dd2c", "dd3a", "bpmdd", "dd3b", "otrdmp", "dwsdumpa1", "pcebd_drift", "pcebd_aperture", "dwsdumpa2", "rfbdd", "dwsdumpb", "wsdump", "dwsdumpc", "rodmp2h", "dumpface", "ddump", "dmpend", "btmdump", "dbmark38", "enddmph_2"]
+        "cu_hxr": [
+            "dl00",
+            "loadlock",
+            "beggun",
+            "sol1bk",
+            "dbmark80",
+            "cathode",
+            "dl01a",
+            "sol1",
+            "dl01a1",
+            "vv01",
+            "dl01a2",
+            "am00",
+            "dl01a3",
+            "am01",
+            "dl01a4",
+            "yag01",
+            "dl01a5",
+            "fc01",
+            "dl01b",
+            "im01",
+            "dl01c",
+            "xc01",
+            "yc01",
+            "dl01h",
+            "bpm2",
+            "dl01d",
+            "dbmark81",
+            "endgun",
+            "begl0",
+            "dbxg",
+            "dl01e",
+            "bpm3",
+            "dl01f",
+            "cr01",
+            "dl01f2",
+            "yag02",
+            "dl01g",
+            "zlin00",
+            "l0a",
+            "l0awake",
+            "l0bbeg",
+            "dl02a1",
+            "yag03",
+            "dl02a2",
+            "dl02a3",
+            "qa01",
+            "dl02b1",
+            "ph01",
+            "dl02b2",
+            "qa02",
+            "dl02c",
+            "l0b",
+            "endl0",
+            "begdl1_1",
+            "emat",
+            "de00",
+            "de00a",
+            "qe01",
+            "de01a",
+            "im02",
+            "de01b",
+            "vv02",
+            "de01c",
+            "qe02",
+            "dh00",
+            "lhbeg",
+            "bxh1",
+            "dh01",
+            "bxh2",
+            "dh02a",
+            "otrh1",
+            "dh03a",
+            "lh_und",
+            "dh03b",
+            "otrh2",
+            "dh02b",
+            "bxh3",
+            "dh01",
+            "bxh4",
+            "lhend",
+            "dh06",
+            "tcav0",
+            "de02",
+            "qe03",
+            "de03a",
+            "de03b",
+            "xc07",
+            "yc07",
+            "de03c",
+            "qe04",
+            "de04",
+            "ws01",
+            "de05",
+            "otr1",
+            "de05c",
+            "vv03",
+            "de06a",
+            "rst1",
+            "de06b",
+            "ws02",
+            "de05a",
+            "mrk0",
+            "de05a",
+            "otr2",
+            "de06d",
+            "bpm10",
+            "de06e",
+            "ws03",
+            "de05",
+            "otr3",
+            "de07",
+            "qm01",
+            "de08",
+            "xc08",
+            "yc08",
+            "de08a",
+            "vv04",
+            "de08b",
+            "qm02",
+            "de09",
+            "dbmark82",
+            "enddl1_1",
+            "begdl1_2",
+            "bx01",
+            "db00a",
+            "otr4",
+            "db00b",
+            "xc09",
+            "yc09",
+            "db00c",
+            "qb",
+            "db00d",
+            "ws04",
+            "db00e",
+            "bx02",
+            "cnt0",
+            "dbmark83",
+            "dm00",
+            "xc10",
+            "yc10",
+            "dm00a",
+            "qm03",
+            "dm01",
+            "dm01a",
+            "qm04",
+            "dm02",
+            "im03",
+            "dm02a",
+            "enddl1_2",
+            "begl1",
+            "zlin01",
+            "k21_1b",
+            "daqa1",
+            "qa11",
+            "daqa2",
+            "k21_1c",
+            "daqa3",
+            "qa12",
+            "daqa4",
+            "k21_1d",
+            "endl1",
+            "begbc1",
+            "dl1xa",
+            "vvx1",
+            "dl1xb",
+            "l1x",
+            "dm10a",
+            "vvx2",
+            "dm10c",
+            "q21201",
+            "dm10x",
+            "imbc1i",
+            "dm11",
+            "qm11",
+            "dm12",
+            "bc1cbeg",
+            "bx11",
+            "dbq1",
+            "cq11",
+            "d11o",
+            "bx12",
+            "ddg1",
+            "bpms11",
+            "ddg2",
+            "ce11_drift",
+            "ce11_aperture",
+            "ddg3",
+            "otr11",
+            "ddg4",
+            "bx13",
+            "d11oa",
+            "sq13",
+            "d11ob",
+            "cq12",
+            "dbq1",
+            "bx14",
+            "cnt1",
+            "bc1cend",
+            "dm13a",
+            "bl11",
+            "dm13b",
+            "qm12",
+            "dm14a",
+            "dm14b",
+            "imbc1o",
+            "dm14c",
+            "qm13",
+            "dm15a",
+            "bl12",
+            "dm15b",
+            "xc21275",
+            "yc21276",
+            "dm15c",
+            "ws11",
+            "dww1a",
+            "ws12",
+            "dww1b",
+            "otr12",
+            "dww1c1",
+            "ph02",
+            "dww1c2",
+            "xc21302",
+            "dww1d",
+            "yc21303",
+            "dww1e",
+            "ws13",
+            "dm16",
+            "q21301",
+            "dm17a",
+            "dm17b",
+            "td11",
+            "dm17c",
+            "qm14",
+            "dm18a",
+            "xc21325",
+            "yc21325",
+            "dm18b",
+            "qm15",
+            "dbmark28",
+            "dm19",
+            "endbc1",
+            "begl2",
+            "li21beg",
+            "zlin04",
+            "k21_3b",
+            "k21_3c",
+            "k21_3d",
+            "daq1",
+            "q21401",
+            "daq2",
+            "k21_4a",
+            "k21_4b",
+            "k21_4c",
+            "k21_4d",
+            "daq1",
+            "q21501",
+            "daq2",
+            "k21_5a",
+            "k21_5b",
+            "k21_5c",
+            "k21_5d",
+            "daq1",
+            "q21601",
+            "daq2",
+            "k21_6a",
+            "k21_6b",
+            "k21_6c",
+            "k21_6d",
+            "daq1",
+            "q21701",
+            "daq2",
+            "k21_7a",
+            "k21_7b",
+            "k21_7c",
+            "k21_7d",
+            "daq1",
+            "q21801",
+            "daq2",
+            "k21_8a",
+            "k21_8b",
+            "k21_8c",
+            "k21_8d",
+            "daq3",
+            "q21901",
+            "d219a",
+            "bky21929",
+            "d219b",
+            "bkx21957",
+            "d219c",
+            "li21end",
+            "li22beg",
+            "zlin05",
+            "k22_1a",
+            "k22_1b",
+            "k22_1c",
+            "k22_1d",
+            "daq1",
+            "q22201",
+            "daq2",
+            "k22_2a",
+            "k22_2b",
+            "k22_2c",
+            "k22_2d",
+            "daq1",
+            "q22301",
+            "daq2",
+            "k22_3a",
+            "k22_3b",
+            "k22_3c",
+            "k22_3d",
+            "daq1",
+            "q22401",
+            "daq2",
+            "k22_4a",
+            "k22_4b",
+            "k22_4c",
+            "k22_4d",
+            "daq1",
+            "q22501",
+            "daq2",
+            "k22_5a",
+            "k22_5b",
+            "k22_5c",
+            "k22_5d",
+            "daq1",
+            "q22601",
+            "daq2",
+            "k22_6a",
+            "k22_6b",
+            "k22_6c",
+            "k22_6d",
+            "daq1",
+            "q22701",
+            "daq2",
+            "k22_7a",
+            "k22_7b",
+            "k22_7c",
+            "k22_7d",
+            "daq1",
+            "q22801",
+            "daq2",
+            "k22_8a",
+            "k22_8b",
+            "k22_8c",
+            "k22_8d",
+            "daq3",
+            "q22901",
+            "d229a",
+            "bky22929",
+            "d229b",
+            "bkx22957",
+            "d229c",
+            "li22end",
+            "li23beg",
+            "zlin06",
+            "k23_1a",
+            "k23_1b",
+            "k23_1c",
+            "k23_1d",
+            "daq1",
+            "q23201",
+            "daq2",
+            "k23_2a",
+            "k23_2b",
+            "k23_2c",
+            "k23_2d",
+            "daq1",
+            "q23301",
+            "daq2",
+            "k23_3a",
+            "k23_3b",
+            "k23_3c",
+            "k23_3d",
+            "daq1",
+            "q23401",
+            "daq2",
+            "k23_4a",
+            "k23_4b",
+            "k23_4c",
+            "k23_4d",
+            "daq1",
+            "q23501",
+            "daq2",
+            "k23_5a",
+            "k23_5b",
+            "k23_5c",
+            "k23_5d",
+            "daq1",
+            "q23601",
+            "daq2",
+            "k23_6a",
+            "k23_6b",
+            "k23_6c",
+            "k23_6d",
+            "daq1",
+            "q23701",
+            "daq2",
+            "k23_7a",
+            "k23_7b",
+            "k23_7c",
+            "k23_7d",
+            "daq1",
+            "q23801",
+            "daq2",
+            "k23_8a",
+            "k23_8b",
+            "k23_8c",
+            "k23_8d",
+            "daq3",
+            "q23901",
+            "daq4",
+            "li23end",
+            "li24beg",
+            "zlin07",
+            "k24_1a",
+            "k24_1b",
+            "k24_1c",
+            "k24_1d",
+            "daq1",
+            "q24201",
+            "daq2",
+            "k24_2a",
+            "k24_2b",
+            "k24_2c",
+            "k24_2d",
+            "daq1",
+            "q24301",
+            "daq2",
+            "k24_3a",
+            "k24_3b",
+            "k24_3c",
+            "k24_3d",
+            "daq1",
+            "q24401",
+            "daq2",
+            "k24_4a",
+            "k24_4b",
+            "k24_4c",
+            "k24_4d",
+            "daq1",
+            "q24501",
+            "daq2",
+            "k24_5a",
+            "k24_5b",
+            "k24_5c",
+            "k24_5d",
+            "daq1",
+            "q24601",
+            "daq2",
+            "k24_6a",
+            "k24_6b",
+            "k24_6c",
+            "k24_6d",
+            "li24term",
+            "endl2",
+            "begbc2",
+            "dm20",
+            "q24701a",
+            "d10cma",
+            "q24701b",
+            "dm21z",
+            "dm21a",
+            "ws24",
+            "dm21h",
+            "imbc2i",
+            "dm21b",
+            "vv21",
+            "dm21c",
+            "qm21",
+            "dm21d",
+            "dm21e",
+            "bc2cbeg",
+            "bx21",
+            "dbq2a",
+            "cq21",
+            "d21oa",
+            "bx22",
+            "ddg0",
+            "ddg1",
+            "bpms21",
+            "ddg2",
+            "ce21_drift",
+            "ce21_aperture",
+            "ddg3",
+            "otr21",
+            "ddg4",
+            "ddga",
+            "bx23",
+            "d21ob",
+            "cq22",
+            "dbq2b",
+            "bx24",
+            "cnt2",
+            "bc2cend",
+            "d21w",
+            "d21x",
+            "bl21",
+            "d21y",
+            "dm23b",
+            "qm22",
+            "dm24a",
+            "vv22",
+            "dm24b",
+            "dm24d",
+            "q24901a",
+            "dm24c",
+            "q24901b",
+            "dm25",
+            "endbc2",
+            "begl3",
+            "li25beg",
+            "zlin09",
+            "k25_1a",
+            "k25_1b",
+            "d25_1c",
+            "k25_1d",
+            "daq1",
+            "q25201",
+            "daq2",
+            "k25_2a",
+            "k25_2b",
+            "k25_2c",
+            "d255a",
+            "imbc2o",
+            "d255b",
+            "d255c",
+            "tcav3",
+            "d255d",
+            "q25301",
+            "daq2",
+            "k25_3a",
+            "k25_3b",
+            "k25_3c",
+            "d256a",
+            "ph03",
+            "d256b",
+            "bl22",
+            "d256c",
+            "bxkik",
+            "d256d",
+            "daq1",
+            "q25401",
+            "daq2",
+            "k25_4a",
+            "k25_4b",
+            "k25_4c",
+            "k25_4d",
+            "daq1",
+            "q25501",
+            "daq2",
+            "k25_5a",
+            "k25_5b",
+            "k25_5c",
+            "k25_5d",
+            "daq1",
+            "q25601",
+            "daq2",
+            "k25_6a",
+            "k25_6b",
+            "k25_6c",
+            "k25_6d",
+            "daq1",
+            "q25701",
+            "daq2",
+            "k25_7a",
+            "k25_7b",
+            "k25_7c",
+            "k25_7d",
+            "daq1",
+            "q25801",
+            "daq2",
+            "k25_8a",
+            "k25_8b",
+            "k25_8c",
+            "k25_8d",
+            "daq7",
+            "q25901",
+            "daq8a",
+            "otr_tcav",
+            "daq8b",
+            "li25end",
+            "li26beg",
+            "zlin10",
+            "k26_1a",
+            "k26_1b",
+            "k26_1c",
+            "k26_1d",
+            "daq1",
+            "q26201",
+            "daq2",
+            "k26_2a",
+            "k26_2b",
+            "k26_2c",
+            "k26_2d",
+            "daq1",
+            "q26301",
+            "daq2",
+            "k26_3a",
+            "k26_3b",
+            "k26_3c",
+            "k26_3d",
+            "daq1",
+            "q26401",
+            "daq2",
+            "k26_4a",
+            "k26_4b",
+            "k26_4c",
+            "k26_4d",
+            "daq1",
+            "q26501",
+            "daq2",
+            "k26_5a",
+            "k26_5b",
+            "k26_5c",
+            "k26_5d",
+            "daq1",
+            "q26601",
+            "daq2",
+            "k26_6a",
+            "k26_6b",
+            "k26_6c",
+            "k26_6d",
+            "daq1",
+            "q26701",
+            "daq2",
+            "k26_7a",
+            "k26_7b",
+            "k26_7c",
+            "k26_7d",
+            "daq1",
+            "q26801",
+            "daq2",
+            "k26_8a",
+            "k26_8b",
+            "k26_8c",
+            "k26_8d",
+            "daq7",
+            "q26901",
+            "daq8",
+            "li26end",
+            "li27beg",
+            "zlin11",
+            "k27_1a",
+            "k27_1b",
+            "k27_1c",
+            "k27_1d",
+            "daq1",
+            "q27201",
+            "daq2",
+            "k27_2a",
+            "k27_2b",
+            "k27_2c",
+            "k27_2d",
+            "daq1",
+            "q27301",
+            "daq2",
+            "k27_3a",
+            "k27_3b",
+            "k27_3c",
+            "k27_3d",
+            "daq1",
+            "q27401",
+            "daq2",
+            "k27_4a",
+            "k27_4b",
+            "k27_4c",
+            "k27_4d",
+            "daq1",
+            "q27501",
+            "daq2",
+            "k27_5a",
+            "k27_5b",
+            "k27_5c",
+            "k27_5d",
+            "daq1",
+            "q27601",
+            "daq2",
+            "k27_6a",
+            "k27_6b",
+            "k27_6c",
+            "daq5a",
+            "ws27644",
+            "daq6a",
+            "q27701",
+            "daq2",
+            "k27_7a",
+            "k27_7b",
+            "k27_7c",
+            "k27_7d",
+            "daq1",
+            "q27801",
+            "daq2",
+            "k27_8a",
+            "k27_8b",
+            "k27_8c",
+            "k27_8d",
+            "daq7",
+            "q27901",
+            "daq8",
+            "li27end",
+            "li28beg",
+            "zlin12",
+            "k28_1a",
+            "k28_1b",
+            "k28_1c",
+            "daq5b1",
+            "xc29092",
+            "daq5b2",
+            "yc29092",
+            "daq5b3",
+            "ws28144",
+            "daq6b",
+            "q28201",
+            "daq2",
+            "k28_2a",
+            "k28_2b",
+            "k28_2c",
+            "k28_2d",
+            "daq1",
+            "q28301",
+            "daq2",
+            "k28_3a",
+            "k28_3b",
+            "k28_3c",
+            "k28_3d",
+            "daq1",
+            "q28401",
+            "daq2",
+            "k28_4a",
+            "k28_4b",
+            "k28_4c",
+            "daq5c1",
+            "xc29095",
+            "daq5c2",
+            "yc29095",
+            "daq5c3",
+            "ws28444",
+            "daq6c",
+            "q28501",
+            "daq2",
+            "k28_5a",
+            "k28_5b",
+            "k28_5c",
+            "d28_5d",
+            "daq1",
+            "q28601",
+            "daq2",
+            "k28_6a",
+            "k28_6b",
+            "k28_6c",
+            "k28_6d",
+            "daq1",
+            "q28701",
+            "daq2",
+            "k28_7a",
+            "k28_7b",
+            "k28_7c",
+            "daq5d",
+            "ws28744",
+            "daq6d",
+            "q28801",
+            "daq2",
+            "k28_8a",
+            "k28_8b",
+            "k28_8c",
+            "k28_8d",
+            "daq7",
+            "q28901",
+            "daq8c",
+            "c29096_drift",
+            "c29096_aperture",
+            "daq8d1",
+            "st28950",
+            "daq8d2",
+            "st28960",
+            "daq8d3",
+            "li28end",
+            "li29beg",
+            "zlin13",
+            "k29_1a",
+            "k29_1b",
+            "k29_1c",
+            "d10ca",
+            "c29146_drift",
+            "c29146_aperture",
+            "d10cb",
+            "daq1",
+            "q29201",
+            "daq2",
+            "k29_2a",
+            "k29_2b",
+            "k29_2c",
+            "k29_2d",
+            "daq1",
+            "q29301",
+            "daq2",
+            "k29_3a",
+            "k29_3b",
+            "k29_3c",
+            "k29_3d",
+            "daq1",
+            "q29401",
+            "daq2",
+            "k29_4a",
+            "k29_4b",
+            "k29_4c",
+            "d10cc",
+            "c29446_drift",
+            "c29446_aperture",
+            "d10cd",
+            "daq1",
+            "q29501",
+            "daq2",
+            "k29_5a",
+            "k29_5b",
+            "k29_5c",
+            "d10ce",
+            "c29546_drift",
+            "c29546_aperture",
+            "d10cf",
+            "daq1",
+            "q29601",
+            "daq2",
+            "k29_6a",
+            "k29_6b",
+            "k29_6c",
+            "k29_6d",
+            "daq1",
+            "q29701",
+            "daq2",
+            "k29_7a",
+            "k29_7b",
+            "k29_7c",
+            "k29_7d",
+            "daq9a",
+            "pk297",
+            "daq9b",
+            "q29801",
+            "daq2",
+            "k29_8a",
+            "k29_8b",
+            "k29_8c",
+            "k29_8d",
+            "daq3",
+            "q29901",
+            "daq4a",
+            "p30013",
+            "daq4b",
+            "p30014",
+            "daq4c",
+            "c29956_drift",
+            "c29956_aperture",
+            "daq4d",
+            "pk299",
+            "daq4e",
+            "li29end",
+            "li30beg",
+            "zlin14",
+            "k30_1a",
+            "k30_1b",
+            "k30_1c",
+            "k30_1d",
+            "daq10a",
+            "p30143",
+            "daq10b",
+            "p30144",
+            "daq10c",
+            "c30146_drift",
+            "c30146_aperture",
+            "daq10d",
+            "q30201",
+            "daq2",
+            "k30_2a",
+            "k30_2b",
+            "k30_2c",
+            "k30_2d",
+            "daq1",
+            "q30301",
+            "daq2",
+            "k30_3a",
+            "k30_3b",
+            "k30_3c",
+            "k30_3d",
+            "daq10e",
+            "pk303",
+            "daq10f",
+            "q30401",
+            "daq2",
+            "k30_4a",
+            "k30_4b",
+            "k30_4c",
+            "k30_4d",
+            "daq10g",
+            "p30443",
+            "daq10h",
+            "p30444",
+            "daq10i",
+            "c30446_drift",
+            "c30446_aperture",
+            "daq10j",
+            "pk304",
+            "daq10k",
+            "q30501",
+            "daq2",
+            "k30_5a",
+            "k30_5b",
+            "k30_5c",
+            "k30_5d",
+            "daq11a",
+            "p30543",
+            "daq11b",
+            "p30544",
+            "daq11c",
+            "c30546_drift",
+            "c30546_aperture",
+            "daq11d",
+            "q30601",
+            "daq12",
+            "k30_6a",
+            "k30_6b",
+            "k30_6c",
+            "k30_6d",
+            "daq13",
+            "q30701",
+            "daq14",
+            "k30_7a",
+            "k30_7b",
+            "k30_7c",
+            "k30_7d",
+            "daq15",
+            "q30801",
+            "daq16",
+            "k30_8a",
+            "k30_8b",
+            "k30_8c",
+            "daq17",
+            "li30term",
+            "dbmark29",
+            "endl3",
+            "begclth_0",
+            "bsybeg",
+            "bsy1beg",
+            "dbsy01a",
+            "imbsy1",
+            "dbsy01b",
+            "imbsy2",
+            "dbsy01c",
+            "imbsy3",
+            "dbsy01d",
+            "imbsy34",
+            "dbsy01e",
+            "imbsy1b",
+            "dbsy01f",
+            "imbsy2b",
+            "dbsy01g",
+            "imbsy3b",
+            "dbsy01h",
+            "fftborgn",
+            "dbsy01i",
+            "s100",
+            "zlin15",
+            "dbsy50a",
+            "ycbsyq1",
+            "dbsy50b",
+            "q50q1",
+            "dbsy02a",
+            "wooddoor",
+            "endclth_0",
+            "begclth_1",
+            "dbsy02b",
+            "bpmbsyq1",
+            "dbsy51a",
+            "xcbsyq2",
+            "dbsy51b",
+            "q50q2",
+            "dbsy52a",
+            "bpmbsyq2",
+            "dbsy52b",
+            "endclth_1",
+            "begclth_2",
+            "dbrcusdc1a",
+            "dbrcusdc1b",
+            "dckdc1",
+            "dbkrcusa",
+            "dbkrcusb",
+            "dckdc2",
+            "dbrcusdc2a",
+            "dbrcusdc2b",
+            "dcusblra",
+            "bpmcus",
+            "dcusblrb",
+            "dblrcusa",
+            "dblrcusb",
+            "dbsy52c",
+            "dbxsp1ha",
+            "dbxsp1hb",
+            "bsy1end",
+            "endclth_2",
+            "begbsyh_1",
+            "dbsy52d",
+            "q50q3",
+            "dbsy53a",
+            "bpmbsyq3",
+            "rfbbsyq3",
+            "dbsy53b",
+            "dbsy53c",
+            "xcbsyq3",
+            "dbsy53d",
+            "ycbsyq4",
+            "dbsy53f",
+            "q4",
+            "dbsy53ga",
+            "pcbsy3",
+            "dbsy53gb",
+            "mrgaline",
+            "endbsyh_1",
+            "begbsyh_2",
+            "dbkrapm1a",
+            "dbkrapm1b",
+            "dzapm1",
+            "pcapm1_drift",
+            "pcapm1_aperture",
+            "dzapm1",
+            "dbkrapm2a",
+            "dbkrapm2b",
+            "dzapm2a",
+            "xcapm2",
+            "ycapm2",
+            "dzapm2b",
+            "pcapm2_drift",
+            "pcapm2_aperture",
+            "dzapm2",
+            "dbkrapm3a",
+            "dbkrapm3b",
+            "dzapm3",
+            "pcapm3_drift",
+            "pcapm3_aperture",
+            "dzapm3",
+            "dbkrapm4a",
+            "dbkrapm4b",
+            "dzapm4",
+            "pcapm4_drift",
+            "pcapm4_aperture",
+            "dza01",
+            "dza02",
+            "pcbsyh",
+            "dbsy53h",
+            "q5",
+            "dbsy54a",
+            "xcbsyq5",
+            "dbsy54b",
+            "dbsy54c",
+            "q6",
+            "drfb",
+            "rfbbsyq6",
+            "dbsy55a",
+            "ycbsyq6",
+            "dbsy55b",
+            "pc90_drift",
+            "pc90_aperture",
+            "dbsy55c",
+            "pcbsy4",
+            "dbsy55d",
+            "pc119_drift",
+            "pc119_aperture",
+            "dbsy55e",
+            "d2",
+            "dm3",
+            "st60",
+            "dm4a",
+            "dm60",
+            "dm4b",
+            "cc31beg",
+            "bcx311",
+            "dcc31o",
+            "bcx312",
+            "dcc31i",
+            "bcx313",
+            "dcc31o",
+            "bcx314",
+            "cc31end",
+            "dm4c",
+            "cxq6_drift",
+            "cxq6_aperture",
+            "dm4da",
+            "pcbsy5",
+            "dm4db",
+            "xca0",
+            "dxca0",
+            "yca0",
+            "dyca0",
+            "st61",
+            "dm5",
+            "qa0",
+            "dm6",
+            "dmoni",
+            "dmoni",
+            "muwall",
+            "dwalla",
+            "dumpbsyh",
+            "dwallb",
+            "bsyend",
+            "rwwake3h",
+            "endbsyh_2",
+            "begltuh",
+            "dycvm1",
+            "ycvm1",
+            "dqvm1",
+            "qvm1",
+            "dqvm2a",
+            "xcvm2",
+            "dqvm2b",
+            "qvm2",
+            "dwsvm2a",
+            "wsvm2",
+            "dwsvm2b",
+            "vbin",
+            "by1",
+            "dvb1",
+            "qvb1",
+            "d40cmc",
+            "ycvb1",
+            "dvb2m80cm",
+            "xcvb2",
+            "d40cmc",
+            "qvb2",
+            "dvb2ha",
+            "pc01",
+            "btm01",
+            "dvb2hb",
+            "qvb3",
+            "d40cmc",
+            "ycvb3",
+            "dvb1m40cm",
+            "by2",
+            "cntlt1h",
+            "vbout",
+            "dvb25cmc",
+            "xcvm3",
+            "d25cm",
+            "qvm3",
+            "dvbem25cm",
+            "ycvm4",
+            "d25cm",
+            "qvm4",
+            "dvbem15cm",
+            "im31",
+            "d10cmb",
+            "imbcs1",
+            "d25cma",
+            "mm1",
+            "dbmark34",
+            "bx31",
+            "ddl10wa",
+            "pc02",
+            "btm02",
+            "ddl10wb",
+            "dwsdl31a",
+            "wsdl31",
+            "dwsdl31b",
+            "ddl10x",
+            "xcdl1",
+            "d31a",
+            "qdl31",
+            "drfb",
+            "rfbdl1",
+            "d31b",
+            "ycdl1",
+            "d32cmb",
+            "cedl1_drift",
+            "cedl1_aperture",
+            "d31c",
+            "wig1h",
+            "dwgh",
+            "wig2h",
+            "dwgh",
+            "wig3h",
+            "cntwigh",
+            "ddl10em80cma",
+            "pc22",
+            "ddl10em80cmb",
+            "cybx32_drift",
+            "cybx32_aperture",
+            "dcb32",
+            "bx32",
+            "cntlt2h",
+            "ddl20e",
+            "qt11",
+            "ddl30em40cm",
+            "xcqt12",
+            "d40cmb",
+            "qt12",
+            "d40cmb",
+            "ycqt12",
+            "ddl30em40cm",
+            "qt13",
+            "ddl20e",
+            "ss1",
+            "dx33a",
+            "cc32beg",
+            "bcx321",
+            "dcc32o",
+            "bcx322",
+            "dcc32i",
+            "bcx323",
+            "dcc32o",
+            "bcx324",
+            "cc32end",
+            "dx33b",
+            "pc03",
+            "btm03",
+            "ddl1ab",
+            "bykik1",
+            "ddl1d",
+            "ddl1d",
+            "bykik2",
+            "ddl1e",
+            "xcdl2",
+            "d32a",
+            "qdl32",
+            "d32b",
+            "ycdl2",
+            "dsplr",
+            "spoiler",
+            "ddl1cm40cm",
+            "tdkik",
+            "d30cma",
+            "pctdkik1_drift",
+            "pctdkik1_aperture",
+            "dpc1",
+            "pctdkik2_drift",
+            "pctdkik2_aperture",
+            "dpc2",
+            "pctdkik3_drift",
+            "pctdkik3_aperture",
+            "dpc3",
+            "pctdkik4_drift",
+            "pctdkik4_aperture",
+            "dpc4",
+            "dspontua",
+            "dspontub",
+            "ddl1dm30cm",
+            "dx34a",
+            "cc35beg",
+            "bcx351",
+            "dcc35o",
+            "bcx352",
+            "dcc35i",
+            "bcx353",
+            "dcc35o",
+            "bcx354",
+            "cc35end",
+            "dx34b",
+            "ycqt21",
+            "ddl20",
+            "qt21",
+            "ddl30em40cm",
+            "xcqt22",
+            "d40cmb",
+            "qt22",
+            "d46cm",
+            "cxqt22_drift",
+            "cxqt22_aperture",
+            "d46cm",
+            "qt23",
+            "ddl20",
+            "dl23beg",
+            "bx35",
+            "dcq31aa",
+            "pc04",
+            "btm04",
+            "dcq31ab",
+            "cq31",
+            "dcq31ba",
+            "pc42",
+            "btm42",
+            "dcq31bb",
+            "otr30",
+            "d29cma",
+            "xcdl3",
+            "d33a",
+            "qdl33",
+            "d33b",
+            "ycdl3",
+            "d32cmd",
+            "cedl3_drift",
+            "cedl3_aperture",
+            "dcq32a",
+            "cq32",
+            "dcq32b",
+            "cybx36_drift",
+            "cybx36_aperture",
+            "dcb36",
+            "bx36",
+            "cntlt3h",
+            "ddl20e",
+            "qt31",
+            "ddl30em40cma",
+            "xcqt32",
+            "d40cmd",
+            "qt32",
+            "d40cme",
+            "ycqt32",
+            "ddl30em40cmb",
+            "qt33",
+            "ddl20e",
+            "ss3",
+            "d37a",
+            "cc36beg",
+            "bcx361",
+            "dcc36o",
+            "bcx362",
+            "dcc36i",
+            "bcx363",
+            "dcc36o",
+            "bcx364",
+            "cc36end",
+            "d37ba",
+            "pc43",
+            "btm43",
+            "d37bb",
+            "imbcs2",
+            "d37c",
+            "pc05",
+            "btm05",
+            "d37d",
+            "wsdl4",
+            "d37e",
+            "dchirpv",
+            "d37f",
+            "qdl34",
+            "d38a",
+            "dchirph",
+            "d38b",
+            "xcdl4",
+            "d38c",
+            "ycdl4",
+            "d38da",
+            "pc06",
+            "btm06",
+            "d38db",
+            "ddl20",
+            "qt41",
+            "ddl30em40cmc",
+            "xcqt42",
+            "d40cmf",
+            "qt42",
+            "d40cmb",
+            "ycqt42",
+            "ddl30em40cm",
+            "qt43",
+            "ddl20",
+            "mm2",
+            "d25cmb",
+            "im36",
+            "d25cmc",
+            "dmm1m90cm",
+            "ycem1",
+            "dem1a",
+            "qem1",
+            "dem1c",
+            "qem2",
+            "dem2b",
+            "xcem2",
+            "dmm3ma",
+            "pc07",
+            "btm07",
+            "dmm3mb",
+            "ycem3",
+            "dem3a",
+            "qem3",
+            "dem3b",
+            "qem3v",
+            "dmm4m90cm",
+            "xcem4",
+            "dem4a",
+            "qem4",
+            "drfb",
+            "rfbem4",
+            "dmm5a",
+            "pc08",
+            "btm08",
+            "dmm5b",
+            "dbmark36",
+            "ws31",
+            "d40cm",
+            "de3ma",
+            "pc09",
+            "btm09",
+            "de3mb",
+            "xce31",
+            "dqea",
+            "qe31",
+            "dqebx",
+            "dcx31",
+            "dqebx2",
+            "de3a",
+            "yce32",
+            "dqeaa",
+            "qe32",
+            "drfb",
+            "rfbe32",
+            "dqeby1",
+            "dcy32",
+            "dqeby2",
+            "ws32",
+            "d40cm",
+            "de3m80cmb",
+            "xce33",
+            "dqeab",
+            "qe33",
+            "dqeca",
+            "yagpsi",
+            "dqecb",
+            "otr33",
+            "de3m40cm",
+            "yce34",
+            "dqea",
+            "qe34",
+            "drfb",
+            "rfbe34",
+            "dqec1",
+            "ws33",
+            "d40cm",
+            "de3m80cm",
+            "xce35",
+            "dqeac",
+            "qe35",
+            "dqebx",
+            "dcx35",
+            "dqebx2",
+            "de3",
+            "yce36",
+            "dqea",
+            "qe36",
+            "drfb",
+            "rfbe36",
+            "dqeby1",
+            "dcy36",
+            "dqeby2",
+            "ws34",
+            "d40cmg",
+            "dws35",
+            "d40cmh",
+            "du1m80cma",
+            "dws36",
+            "du1m80cmb",
+            "dcx37",
+            "d32cmc",
+            "xcum1",
+            "dum1a",
+            "qum1",
+            "dum1b",
+            "d32cm",
+            "du2m120cm",
+            "dcy38",
+            "d32cma",
+            "ycum2",
+            "dum2a",
+            "qum2",
+            "dum2b",
+            "du3m80cm",
+            "xcum3",
+            "dum3a",
+            "qum3",
+            "dum3b",
+            "d40cma",
+            "eoblm",
+            "du4m120cm",
+            "ycum4",
+            "dum4a",
+            "qum4",
+            "dum4b",
+            "rfb07",
+            "du5m80cm",
+            "imundi",
+            "d40cmwa",
+            "bltof",
+            "d40cmwb",
+            "muhwall1",
+            "duhwall1",
+            "duhvesta",
+            "rfb08",
+            "duhvestb",
+            "muhwall2",
+            "duhwall2",
+            "dw2tdund",
+            "dtdund1",
+            "tdund",
+            "dtdund2",
+            "dpcmuon",
+            "pcmuon_drift",
+            "pcmuon_aperture",
+            "dmuon1",
+            "vv999",
+            "dmuon2",
+            "rwwake4h",
+            "endltuh",
+            "begundh",
+            "dmuon3",
+            "rfbhx12",
+            "dmuon4",
+            "mm3",
+            "pfilt1",
+            "dbmark37",
+            "du0h",
+            "du8h",
+            "hxrstart",
+            "du1h",
+            "du2h",
+            "hxrcb1beg",
+            "d0cb1",
+            "bcxcbx11",
+            "d1cb1a",
+            "mcbx4",
+            "d1cb1b",
+            "bodcbx42",
+            "d1cb1c",
+            "bcxcbx12",
+            "dchcb1",
+            "center1",
+            "dchcb1",
+            "bcxcbx13",
+            "d2cb",
+            "bcxcbx14",
+            "d3cb1",
+            "hxrcb1end",
+            "du3hcb1",
+            "qhxh13",
+            "du4hcb1",
+            "rfbhx13",
+            "du5hcb1",
+            "dpshx13",
+            "du6h",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh14",
+            "dthxu",
+            "du3h",
+            "mblmh14",
+            "du3h",
+            "qhxh14",
+            "du4h",
+            "rfbhx14",
+            "du5h",
+            "pshxh14",
+            "du6h",
+            "vvhxu14",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh15",
+            "dthxu",
+            "du3h",
+            "mblmh15",
+            "du3h",
+            "qhxh15",
+            "du4h",
+            "rfbhx15",
+            "du5h",
+            "pshxh15",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh16",
+            "dthxu",
+            "du3h",
+            "mblmh16",
+            "du3h",
+            "qhxh16",
+            "du4h",
+            "rfbhx16",
+            "du5h",
+            "pshxh16",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh17",
+            "dthxu",
+            "du3h",
+            "mblmh17",
+            "du3h",
+            "qhxh17",
+            "du4h",
+            "rfbhx17",
+            "du5h",
+            "pshxh17",
+            "du6h",
+            "vvhxu17",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh18",
+            "dthxu",
+            "du3h",
+            "mblmh18",
+            "du3h",
+            "qhxh18",
+            "du4h",
+            "rfbhx18",
+            "du5h",
+            "pshxh18",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh19",
+            "dthxu",
+            "du3h",
+            "mblmh19",
+            "du3h",
+            "qhxh19",
+            "du4h",
+            "rfbhx19",
+            "du5h",
+            "pshxh19",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh20",
+            "dthxu",
+            "du3h",
+            "mblmh20",
+            "du3h",
+            "qhxh20",
+            "du4h",
+            "rfbhx20",
+            "du5h",
+            "pshxh20",
+            "du6h",
+            "vvhxu20",
+            "du7h",
+            "du1h",
+            "du2h",
+            "hxrcb2beg",
+            "d0cb2",
+            "bcxcbx21",
+            "d1cb2a",
+            "dsscbx11",
+            "d1cb2b",
+            "mcbx1",
+            "d1cb2c",
+            "bcxcbx22",
+            "dchcb2",
+            "center2",
+            "dchcb2",
+            "bcxcbx23",
+            "d2cb",
+            "bcxcbx24",
+            "d3cb2",
+            "hxrcb2end",
+            "du3hcb2",
+            "qhxh21",
+            "du4hcb2",
+            "rfbhx21",
+            "du5hcb2",
+            "dpshx21",
+            "du6h",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh22",
+            "dthxu",
+            "du3h",
+            "mblmh22",
+            "du3h",
+            "qhxh22",
+            "du4h",
+            "rfbhx22",
+            "du5h",
+            "pshxh22",
+            "du6h",
+            "vvhxu22",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh23",
+            "dthxu",
+            "du3h",
+            "mblmh23",
+            "du3h",
+            "qhxh23",
+            "du4h",
+            "rfbhx23",
+            "du5h",
+            "pshxh23",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh24",
+            "dthxu",
+            "du3h",
+            "mblmh24",
+            "du3h",
+            "qhxh24",
+            "du4h",
+            "rfbhx24",
+            "du5h",
+            "pshxh24",
+            "du6h",
+            "vvhxu24",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh25",
+            "dthxu",
+            "du3h",
+            "mblmh25",
+            "du3h",
+            "qhxh25",
+            "du4h",
+            "rfbhx25",
+            "du5h",
+            "pshxh25",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh26",
+            "dthxu",
+            "du3h",
+            "mblmh26",
+            "du3h",
+            "qhxh26",
+            "du4h",
+            "rfbhx26",
+            "du5h",
+            "pshxh26",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh27",
+            "dthxu",
+            "du3h",
+            "mblmh27",
+            "du3h",
+            "qhxh27",
+            "du4h",
+            "rfbhx27",
+            "du5h",
+            "pshxh27",
+            "du6h",
+            "vvhxu27",
+            "du7h",
+            "du1h",
+            "du2h",
+            "hxrssbeg",
+            "dmono",
+            "bcxhs1",
+            "d1",
+            "bcxhs2",
+            "dch",
+            "diamond",
+            "dch",
+            "bcxhs3",
+            "d1",
+            "bcxhs4",
+            "dmono",
+            "hxrssend",
+            "du3h",
+            "mblmh28",
+            "du3h",
+            "qhxh28",
+            "du4h",
+            "rfbhx28",
+            "du5h",
+            "dpshx28",
+            "du6h",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh29",
+            "dthxu",
+            "du3h",
+            "mblmh29",
+            "du3h",
+            "qhxh29",
+            "du4h",
+            "rfbhx29",
+            "du5h",
+            "pshxh29",
+            "du6h",
+            "vvhxu29",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh30",
+            "dthxu",
+            "du3h",
+            "mblmh30",
+            "du3h",
+            "qhxh30",
+            "du4h",
+            "rfbhx30",
+            "du5h",
+            "pshxh30",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh31",
+            "dthxu",
+            "du3h",
+            "mblmh31",
+            "du3h",
+            "qhxh31",
+            "du4h",
+            "rfbhx31",
+            "du5h",
+            "pshxh31",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh32",
+            "dthxu",
+            "du3h",
+            "mblmh32",
+            "du3h",
+            "qhxh32",
+            "du4h",
+            "rfbhx32",
+            "du5h",
+            "pshxh32",
+            "du6h",
+            "vvhxu32",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh33",
+            "dthxu",
+            "du3h",
+            "mblmh33",
+            "du3h",
+            "qhxh33",
+            "du4h",
+            "rfbhx33",
+            "du5h",
+            "pshxh33",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh34",
+            "dthxu",
+            "du3h",
+            "mblmh34",
+            "du3h",
+            "qhxh34",
+            "du4h",
+            "rfbhx34",
+            "du5h",
+            "pshxh34",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh35",
+            "dthxu",
+            "du3h",
+            "mblmh35",
+            "du3h",
+            "qhxh35",
+            "du4h",
+            "rfbhx35",
+            "du5h",
+            "pshxh35",
+            "du6h",
+            "vvhxu35",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh36",
+            "dthxu",
+            "du3h",
+            "mblmh36",
+            "du3h",
+            "qhxh36",
+            "du4h",
+            "rfbhx36",
+            "du5h",
+            "pshxh36",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh37",
+            "dthxu",
+            "du3h",
+            "mblmh37",
+            "du3h",
+            "qhxh37",
+            "du4h",
+            "rfbhx37",
+            "du5h",
+            "pshxh37",
+            "du6h",
+            "vvhxu37",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh38",
+            "dthxu",
+            "du3h",
+            "mblmh38",
+            "du3h",
+            "qhxh38",
+            "du4h",
+            "rfbhx38",
+            "du5h",
+            "pshxh38",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh39",
+            "dthxu",
+            "du3h",
+            "mblmh39",
+            "du3h",
+            "qhxh39",
+            "du4h",
+            "rfbhx39",
+            "du5h",
+            "pshxh39",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh40",
+            "dthxu",
+            "du3h",
+            "mblmh40",
+            "du3h",
+            "qhxh40",
+            "du4h",
+            "rfbhx40",
+            "du5h",
+            "pshxh40",
+            "du6h",
+            "vvhxu40",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh41",
+            "dthxu",
+            "du3h",
+            "mblmh41",
+            "du3h",
+            "qhxh41",
+            "du4h",
+            "rfbhx41",
+            "du5h",
+            "pshxh41",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh42",
+            "dthxu",
+            "du3h",
+            "mblmh42",
+            "du3h",
+            "qhxh42",
+            "du4h",
+            "rfbhx42",
+            "du5h",
+            "pshxh42",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh43",
+            "dthxu",
+            "du3h",
+            "mblmh43",
+            "du3h",
+            "qhxh43",
+            "du4h",
+            "rfbhx43",
+            "du5h",
+            "pshxh43",
+            "du6h",
+            "vvhxu43",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh44",
+            "dthxu",
+            "du3h",
+            "mblmh44",
+            "du3h",
+            "qhxh44",
+            "du4h",
+            "rfbhx44",
+            "du5h",
+            "pshxh44",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh45",
+            "dthxu",
+            "du3h",
+            "mblmh45",
+            "du3h",
+            "qhxh45",
+            "du4h",
+            "rfbhx45",
+            "du5h",
+            "pshxh45",
+            "du6h",
+            "vvhxu45",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh46",
+            "dthxu",
+            "du3h",
+            "mblmh46",
+            "du3h",
+            "qhxh46",
+            "du4h",
+            "rfbhx46",
+            "du5h",
+            "pshxh46",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dthxu",
+            "umahxh47",
+            "dthxu",
+            "du3h",
+            "mblmh47",
+            "du3h",
+            "qhxh47",
+            "du4h",
+            "rfbhx47",
+            "du5h",
+            "dpshx47",
+            "du6h",
+            "dvvhxu",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dusegh48",
+            "du3h",
+            "du3h",
+            "dqhx48",
+            "du4h",
+            "drfbh48",
+            "du5h",
+            "dpshx48",
+            "du6h",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dusegh49",
+            "du3h",
+            "du3h",
+            "dqhx49",
+            "du4h",
+            "drfbh49",
+            "du5h",
+            "dpshx49",
+            "du6h",
+            "du7h",
+            "du1h",
+            "du2h",
+            "dusegh50",
+            "du3h",
+            "du3h",
+            "dqhx50",
+            "du4h",
+            "drfbh50",
+            "du5h",
+            "dpshx50",
+            "du6h",
+            "du7h",
+            "rwwake5h",
+            "hxrterm",
+            "due1a",
+            "rfbhx51",
+            "due1e",
+            "endundh",
+            "begdmph_1",
+            "uebeg",
+            "due1d",
+            "vv36",
+            "due1b",
+            "mimundo",
+            "due1c",
+            "due2a",
+            "ycue1",
+            "due2b",
+            "ph31",
+            "due2d",
+            "ph32",
+            "due2d",
+            "ph33",
+            "due2d",
+            "ph34",
+            "due2e",
+            "xcue2",
+            "due2c",
+            "que1",
+            "due3a",
+            "bpmue1",
+            "due3b",
+            "true1",
+            "due3c",
+            "dbkxdmph",
+            "due3c",
+            "pctcx_drift",
+            "pctcx_aperture",
+            "dpcvv",
+            "vvtcx",
+            "dvvtcx",
+            "mtcx01",
+            "tcx01",
+            "dtcx12",
+            "mtcx",
+            "dtcx12",
+            "tcx02",
+            "dtcxsp",
+            "sptcx",
+            "due4",
+            "que2",
+            "due5a",
+            "bpmue2",
+            "due5b",
+            "btmque",
+            "due5c",
+            "pcpm0_drift",
+            "pcpm0_aperture",
+            "due5f",
+            "btm0",
+            "due5d",
+            "mimbcs3",
+            "due5e",
+            "mdlwall",
+            "ddlwall",
+            "ueend",
+            "dlstart",
+            "dsb0a",
+            "ycd3",
+            "dsb0b",
+            "xcd3",
+            "dsb0c",
+            "vv37",
+            "dsb0d",
+            "dsb0e",
+            "enddmph_1",
+            "begdmph_2",
+            "rodmp1h",
+            "bydsh",
+            "ds1",
+            "byd1",
+            "ds",
+            "byd2",
+            "ds",
+            "byd3",
+            "dd1a",
+            "pcpm1l_drift",
+            "pcpm1l_aperture",
+            "btm1l",
+            "dd1b",
+            "mimdump",
+            "dd1c",
+            "mimbcs4",
+            "dd1d",
+            "ycdd",
+            "dd1e",
+            "pcpm2l_drift",
+            "pcpm2l_aperture",
+            "btm2l",
+            "dd1f",
+            "qdmp1",
+            "dd12a",
+            "bpmqd",
+            "dd12b",
+            "mqdmp",
+            "dd12c",
+            "qdmp2",
+            "dd2a",
+            "xcdd",
+            "dd2b",
+            "dd2c",
+            "dd3a",
+            "bpmdd",
+            "dd3b",
+            "otrdmp",
+            "dwsdumpa1",
+            "pcebd_drift",
+            "pcebd_aperture",
+            "dwsdumpa2",
+            "rfbdd",
+            "dwsdumpb",
+            "wsdump",
+            "dwsdumpc",
+            "rodmp2h",
+            "dumpface",
+            "ddump",
+            "dmpend",
+            "btmdump",
+            "dbmark38",
+            "enddmph_2"
+        ]
     }
 }

--- a/cheetah/sc_diag0.json
+++ b/cheetah/sc_diag0.json
@@ -4,236 +4,2286 @@
     "info": "LCLS-II DIAG0 beamline",
     "root": "sc_diag0",
     "elements": {
-        "beam0": ["Marker", {}],
-        "dcm4b": ["Drift", {"length": 0.029999999329447746, "tracking_method": "linear"}],
-        "qcm01": ["Quadrupole", {"length": 0.23000000417232513, "k1": 0.0, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "dcm5": ["Drift", {"length": 0.2368600070476532, "tracking_method": "linear"}],
-        "cm01end": ["Marker", {}],
-        "dcmcm1": ["Drift", {"length": 0.16576999425888062, "tracking_method": "linear"}],
-        "homcm": ["Marker", {}],
-        "dcap0da": ["Drift", {"length": 0.37851300835609436, "tracking_method": "linear"}],
-        "astra": ["Marker", {}],
-        "dcap0db": ["Drift", {"length": 1.3458670377731323, "tracking_method": "linear"}],
-        "fc1": ["Marker", {}],
-        "dmsc0da": ["Drift", {"length": 0.08889999985694885, "tracking_method": "linear"}],
-        "blf1": ["Marker", {}],
-        "dmsc0db": ["Drift", {"length": 1.2318929433822632, "tracking_method": "linear"}],
-        "vgl0bd": ["Marker", {}],
-        "dmsc0dc": ["Drift", {"length": 0.10159999877214432, "tracking_method": "linear"}],
-        "vpl0bd": ["Marker", {}],
-        "dmsc0dd": ["Drift", {"length": 0.15640699863433838, "tracking_method": "linear"}],
-        "msc0d": ["Marker", {}],
-        "vvl0bd": ["Marker", {}],
-        "endl0b": ["Marker", {}],
-        "beghtr": ["Marker", {}],
-        "d0h00a": ["Drift", {"length": 0.2502000033855438, "tracking_method": "linear"}],
-        "rfb0h00": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "d0h00b": ["Drift", {"length": 0.0560000017285347, "tracking_method": "linear"}],
-        "pc0h00_drift": ["Drift", {"length": 0.05999999865889549, "tracking_method": "linear"}],
-        "pc0h00_aperture": ["Aperture", {"x_max": 0.006000000052154064, "y_max": 0.006000000052154064, "shape": "elliptical", "is_active": true}],
-        "d0h00c": ["Drift", {"length": 0.2919749915599823, "tracking_method": "linear"}],
-        "q0h01": ["Quadrupole", {"length": 0.12439999729394913, "k1": -6.525507926940918, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h01a": ["Drift", {"length": 0.21394899487495422, "tracking_method": "linear"}],
-        "yc0h01": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h01b": ["Drift", {"length": 0.21394899487495422, "tracking_method": "linear"}],
-        "q0h02": ["Quadrupole", {"length": 0.12439999729394913, "k1": 6.335021018981934, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h02a": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "xc0h01": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h02b": ["Drift", {"length": 0.9114609956741333, "tracking_method": "linear"}],
-        "dp0h01": ["Marker", {}],
-        "d0h02c": ["Drift", {"length": 0.4856480062007904, "tracking_method": "linear"}],
-        "dp0h02": ["Marker", {}],
-        "d0h02d": ["Drift", {"length": 2.077199935913086, "tracking_method": "linear"}],
-        "dp0h03": ["Marker", {}],
-        "d0h02e": ["Drift", {"length": 0.29509401321411133, "tracking_method": "linear"}],
-        "xc0h03": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h02f": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "q0h03": ["Quadrupole", {"length": 0.12439999729394913, "k1": -0.9477308392524719, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h03a": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "yc0h03": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h03b": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "q0h04": ["Quadrupole", {"length": 0.12439999729394913, "k1": -3.418410301208496, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h04a": ["Drift", {"length": 0.21480000019073486, "tracking_method": "linear"}],
-        "rfb0h04": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "d0h04b": ["Drift", {"length": 0.0333000011742115, "tracking_method": "linear"}],
-        "otr0h04": ["Marker", {}],
-        "otr0h04_yag": ["Marker", {}],
-        "d0h04c": ["Drift", {"length": 0.24369999766349792, "tracking_method": "linear"}],
-        "ws0h04": ["Marker", {}],
-        "d0h04d": ["Drift", {"length": 0.2492000013589859, "tracking_method": "linear"}],
-        "bz0h04": ["Marker", {}],
-        "d0h04e": ["Drift", {"length": 0.35690000653266907, "tracking_method": "linear"}],
-        "q0h05": ["Quadrupole", {"length": 0.12439999729394913, "k1": -7.013523578643799, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h05a": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "yc0h05": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h05b": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "q0h06": ["Quadrupole", {"length": 0.12439999729394913, "k1": 1.4503223896026611, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h06a": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "xc0h05": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h06b": ["Drift", {"length": 0.9562640190124512, "tracking_method": "linear"}],
-        "xc0h07": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h06c": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "q0h07": ["Quadrupole", {"length": 0.12439999729394913, "k1": 7.874726295471191, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h07a": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "yc0h07": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "d0h07b": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "q0h08": ["Quadrupole", {"length": 0.12439999729394913, "k1": -8.293356895446777, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "d0h08a": ["Drift", {"length": 0.19339999556541443, "tracking_method": "linear"}],
-        "rfb0h08": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "d0h08b": ["Drift", {"length": 0.1753000020980835, "tracking_method": "linear"}],
-        "lhbegb": ["Marker", {}],
-        "bcxh1": ["Dipole", {"length": 0.12441013753414154, "angle": 0.022113759070634842, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.022113759070634842, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.388700008392334, "fringe_integral_exit": 0.388700008392334, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dh01a": ["Drift", {"length": 1.5377992391586304, "tracking_method": "linear"}],
-        "bpmh1": ["BPM", {"is_active": true}],
-        "dh01b": ["Drift", {"length": 0.37570858001708984, "tracking_method": "linear"}],
-        "mirlhu": ["Marker", {}],
-        "dh01c": ["Drift", {"length": 1.352224349975586, "tracking_method": "linear"}],
-        "bcxh2": ["Dipole", {"length": 0.12441013753414154, "angle": -0.022113759070634842, "k1": 0.0, "dipole_e1": -0.022113759070634842, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.388700008392334, "fringe_integral_exit": 0.388700008392334, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dh02a": ["Drift", {"length": 0.16261400282382965, "tracking_method": "linear"}],
-        "cehtr_drift": ["Drift", {"length": 0.05999999865889549, "tracking_method": "linear"}],
-        "cehtr_aperture": ["Aperture", {"x_max": 0.003000000026077032, "y_max": Infinity, "shape": "rectangular", "is_active": true}],
-        "dh02b": ["Drift", {"length": 0.268449991941452, "tracking_method": "linear"}],
-        "yagh1": ["Marker", {}],
-        "dh02c": ["Drift", {"length": 0.2896380126476288, "tracking_method": "linear"}],
-        "umhtr": ["Drift", {"length": 0.24300000071525574, "tracking_method": "linear"}],
-        "htrundb": ["Marker", {}],
-        "dh02d": ["Drift", {"length": 0.2826021909713745, "tracking_method": "linear"}],
-        "yagh2": ["Marker", {}],
-        "dh02e": ["Drift", {"length": 0.45999979972839355, "tracking_method": "linear"}],
-        "bcxh3": ["Dipole", {"length": 0.12441013753414154, "angle": -0.022113759070634842, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.022113759070634842, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.388700008392334, "fringe_integral_exit": 0.388700008392334, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "dh03a": ["Drift", {"length": 1.390334129333496, "tracking_method": "linear"}],
-        "mirlhd": ["Marker", {}],
-        "dh03b": ["Drift", {"length": 0.3375988304615021, "tracking_method": "linear"}],
-        "bpmh2": ["BPM", {"is_active": true}],
-        "dh03c": ["Drift", {"length": 1.5377992391586304, "tracking_method": "linear"}],
-        "bcxh4": ["Dipole", {"length": 0.12441013753414154, "angle": 0.022113759070634842, "k1": 0.0, "dipole_e1": 0.022113759070634842, "dipole_e2": 0.0, "tilt": 0.0, "gap": 0.029999999329447746, "gap_exit": 0.029999999329447746, "fringe_integral": 0.388700008392334, "fringe_integral_exit": 0.388700008392334, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "cnthtr": ["Marker", {}],
-        "lhendb": ["Marker", {}],
-        "dhd00a": ["Drift", {"length": 0.28139880299568176, "tracking_method": "linear"}],
-        "rfbhd00": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dhd00b": ["Drift", {"length": 0.10000000149011612, "tracking_method": "linear"}],
-        "qhd01": ["Quadrupole", {"length": 0.12439999729394913, "k1": -8.926305770874023, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "dhd01a": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "ychd01": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dhd01b": ["Drift", {"length": 0.24678799510002136, "tracking_method": "linear"}],
-        "xchd01": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dhd01c": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "qhd02": ["Quadrupole", {"length": 0.12439999729394913, "k1": 6.460615158081055, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "dhd02a1": ["Drift", {"length": 1.2927780151367188, "tracking_method": "linear"}],
-        "imbcsi1": ["Marker", {}],
-        "dhd02a2": ["Drift", {"length": 0.3054099977016449, "tracking_method": "linear"}],
-        "imbcsi2": ["Marker", {}],
-        "dhd02a3": ["Drift", {"length": 0.7772939801216125, "tracking_method": "linear"}],
-        "ychd03": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dhd02b": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "qhd03": ["Quadrupole", {"length": 0.12439999729394913, "k1": -8.534034729003906, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "dhd03a": ["Drift", {"length": 0.2549059987068176, "tracking_method": "linear"}],
-        "xchd03": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dhd03b": ["Drift", {"length": 0.20490600168704987, "tracking_method": "linear"}],
-        "qhd04": ["Quadrupole", {"length": 0.12439999729394913, "k1": 6.807615280151367, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "dhd04a": ["Drift", {"length": 0.12089979648590088, "tracking_method": "linear"}],
-        "rfbhd04": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dhd04b": ["Drift", {"length": 0.24789980053901672, "tracking_method": "linear"}],
-        "endhtr": ["Marker", {}],
-        "begdiag0": ["Marker", {}],
-        "bkrdg0": ["Dipole", {"length": 1.0000115633010864, "angle": -0.008333181031048298, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": -0.008333181031048298, "tilt": 1.7474957704544067, "gap": 0.03500000014901161, "gap_exit": 0.03500000014901161, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "rodg0k": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dkv0a": ["Drift", {"length": 0.6489275097846985, "tracking_method": "linear"}],
-        "bpmdg000": ["BPM", {"is_active": true}],
-        "dkv0b": ["Drift", {"length": 0.6511176228523254, "tracking_method": "linear"}],
-        "m1dg0": ["Marker", {}],
-        "blrdg0": ["Dipole", {"length": 0.40074828267097473, "angle": 0.10488853603601456, "k1": 0.0, "dipole_e1": 0.0, "dipole_e2": 0.10488853603601456, "tilt": 0.1766994446516037, "gap": 0.019999999552965164, "gap_exit": 0.019999999552965164, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "rodg0l": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dqb01a": ["Drift", {"length": 0.15000000596046448, "tracking_method": "linear"}],
-        "rfbdg001": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "dqb01b": ["Drift", {"length": 0.802327036857605, "tracking_method": "linear"}],
-        "xcdg001": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqb01c": ["Drift", {"length": 0.25, "tracking_method": "linear"}],
-        "qdg001": ["Quadrupole", {"length": 0.09849999845027924, "k1": 9.807425498962402, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg001": ["BPM", {"is_active": true}],
-        "dqb02a": ["Drift", {"length": 0.4148208498954773, "tracking_method": "linear"}],
-        "ycdg001": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqb02b": ["Drift", {"length": 0.25, "tracking_method": "linear"}],
-        "qdg002": ["Quadrupole", {"length": 0.09849999845027924, "k1": -7.825140476226807, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg002": ["BPM", {"is_active": true}],
-        "dqb03a": ["Drift", {"length": 0.4148208498954773, "tracking_method": "linear"}],
-        "xcdg002": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqb03b": ["Drift", {"length": 0.25, "tracking_method": "linear"}],
-        "qdg003": ["Quadrupole", {"length": 0.09849999845027924, "k1": 9.807425498962402, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg003": ["BPM", {"is_active": true}],
-        "dqb04a": ["Drift", {"length": 0.7784284949302673, "tracking_method": "linear"}],
-        "ycdg002": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "dqb04b": ["Drift", {"length": 0.45320001244544983, "tracking_method": "linear"}],
-        "bxdg0": ["Dipole", {"length": 0.400182843208313, "angle": -0.10471975803375244, "k1": 0.0, "dipole_e1": -0.05235987901687622, "dipole_e2": -0.05235987901687622, "tilt": 0.0, "gap": 0.019999999552965164, "gap_exit": 0.019999999552965164, "fringe_integral": 0.5, "fringe_integral_exit": 0.5, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "bxdg0t": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "cntdg0": ["Marker", {}],
-        "m2dg0": ["Marker", {}],
-        "ddg003": ["Drift", {"length": 0.37441882491111755, "tracking_method": "linear"}],
-        "qdg004": ["Quadrupole", {"length": 0.05400000140070915, "k1": 8.77167797088623, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg004": ["BPM", {"is_active": true}],
-        "ddg004a": ["Drift", {"length": 0.2705000042915344, "tracking_method": "linear"}],
-        "xcdg003": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ycdg003": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddg004b": ["Drift", {"length": 0.2705000042915344, "tracking_method": "linear"}],
-        "qdg005": ["Quadrupole", {"length": 0.05400000140070915, "k1": -12.053189277648926, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg005": ["BPM", {"is_active": true}],
-        "ddg005a": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "xcdg005": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ycdg005": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddg005b": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "qdg006": ["Quadrupole", {"length": 0.1080000028014183, "k1": 6.830639839172363, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "ddg006a": ["Drift", {"length": 0.7327514290809631, "tracking_method": "linear"}],
-        "tcydg0": ["Drift", {"length": 0.5080000162124634, "tracking_method": "linear"}],
-        "ddg006b": ["Drift", {"length": 0.12714000046253204, "tracking_method": "linear"}],
-        "bpmdg0rf": ["BPM", {"is_active": true}],
-        "ddg006c": ["Drift", {"length": 0.17285999655723572, "tracking_method": "linear"}],
-        "tcxdg0": ["TransverseDeflectingCavity", {"length": 0.2540000081062317, "voltage": 350000.0, "phase": 0.0, "frequency": 2856000000.0, "misalignment": [0.0, 0.0], "tilt": 0.0, "num_steps": 1, "tracking_method": "bmadx"}],
-        "ycdgtcx": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "xcdgtcx": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddg006d": ["Drift", {"length": 0.4869999885559082, "tracking_method": "linear"}],
-        "qdg007": ["Quadrupole", {"length": 0.1080000028014183, "k1": -4.543712615966797, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "ddg007": ["Drift", {"length": 0.5479999780654907, "tracking_method": "linear"}],
-        "qdg008": ["Quadrupole", {"length": 0.05400000140070915, "k1": 11.37702751159668, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg008": ["BPM", {"is_active": true}],
-        "ddg008a": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "xcdg008": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ycdg008": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddg008b": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "qdg009": ["Quadrupole", {"length": 0.05400000140070915, "k1": -11.539229393005371, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg009": ["BPM", {"is_active": true}],
-        "ddg009a": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "otrdg01": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "otrdg01_yag": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "ddg009b": ["Drift", {"length": 0.699999988079071, "tracking_method": "linear"}],
-        "rfbdg002": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "ddg009c": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "otrdg02": ["Screen", {"resolution": [1944, 1472], "pixel_size": [2.3299999156733975e-05, 2.3299999156733975e-05], "binning": 1, "misalignment": [0.0, 0.0], "method": "histogram", "kde_bandwidth": 1.1000000085914508e-05, "is_active": true}],
-        "ddg009d": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "wsdg01": ["Marker", {}],
-        "ddg009e": ["Drift", {"length": 0.699999988079071, "tracking_method": "linear"}],
-        "otrdg03": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "otrdg03_yag": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "ddg009f": ["Drift", {"length": 0.6660000085830688, "tracking_method": "linear"}],
-        "qdg010": ["Quadrupole", {"length": 0.1080000028014183, "k1": 13.016651153564453, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "ddg010a": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "xcdg010": ["HorizontalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ycdg010": ["VerticalCorrector", {"length": 0.0, "angle": 0.0}],
-        "ddg010b": ["Drift", {"length": 0.29600000381469727, "tracking_method": "linear"}],
-        "qdg011": ["Quadrupole", {"length": 0.05400000140070915, "k1": -10.983651161193848, "misalignment": [0.0, 0.0], "tilt": 0.0, "tracking_method": "linear"}],
-        "bpmdg011": ["BPM", {"is_active": true}],
-        "ddg011a": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "rfbdg003": ["Drift", {"length": 0.0, "tracking_method": "linear"}],
-        "ddg011b": ["Drift", {"length": 1.1047999858856201, "tracking_method": "linear"}],
-        "bydg0": ["Dipole", {"length": 0.5435000061988831, "angle": -0.6108652353286743, "k1": 0.0, "dipole_e1": -0.12723450362682343, "dipole_e2": -0.12723450362682343, "tilt": 1.5707963705062866, "gap": 0.03400000184774399, "gap_exit": 0.03400000184774399, "fringe_integral": 0.39100000262260437, "fringe_integral_exit": 0.39100000262260437, "fringe_at": "both", "fringe_type": "linear_edge", "tracking_method": "linear"}],
-        "ddg012a": ["Drift", {"length": 0.3952963054180145, "tracking_method": "linear"}],
-        "bpmdg012": ["BPM", {"is_active": true}],
-        "ddg012b": ["Drift", {"length": 0.23999999463558197, "tracking_method": "linear"}],
-        "otrdg04": ["Screen", {"resolution": [1944, 1472], "pixel_size": [1.748000067891553e-05, 1.748000067891553e-05], "binning": 1, "misalignment": [0.0, 0.0], "method": "histogram", "kde_bandwidth": 1.1000000085914508e-05, "is_active": true}],
-        "ddg012c": ["Drift", {"length": 0.30000001192092896, "tracking_method": "linear"}],
-        "fcdg0du": ["Marker", {}],
-        "enddiag0": ["Marker", {}]
+        "beam0": [
+            "Marker",
+            {}
+        ],
+        "dcm4b": [
+            "Drift",
+            {
+                "length": 0.029999999329447746,
+                "tracking_method": "linear"
+            }
+        ],
+        "qcm01": [
+            "Quadrupole",
+            {
+                "length": 0.23000000417232513,
+                "k1": 0.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:L0B:0185"
+                }
+            }
+        ],
+        "dcm5": [
+            "Drift",
+            {
+                "length": 0.2368600070476532,
+                "tracking_method": "linear"
+            }
+        ],
+        "cm01end": [
+            "Marker",
+            {}
+        ],
+        "dcmcm1": [
+            "Drift",
+            {
+                "length": 0.16576999425888062,
+                "tracking_method": "linear"
+            }
+        ],
+        "homcm": [
+            "Marker",
+            {}
+        ],
+        "dcap0da": [
+            "Drift",
+            {
+                "length": 0.37851300835609436,
+                "tracking_method": "linear"
+            }
+        ],
+        "astra": [
+            "Marker",
+            {}
+        ],
+        "dcap0db": [
+            "Drift",
+            {
+                "length": 1.3458670377731323,
+                "tracking_method": "linear"
+            }
+        ],
+        "fc1": [
+            "Marker",
+            {}
+        ],
+        "dmsc0da": [
+            "Drift",
+            {
+                "length": 0.08889999985694885,
+                "tracking_method": "linear"
+            }
+        ],
+        "blf1": [
+            "Marker",
+            {}
+        ],
+        "dmsc0db": [
+            "Drift",
+            {
+                "length": 1.2318929433822632,
+                "tracking_method": "linear"
+            }
+        ],
+        "vgl0bd": [
+            "Marker",
+            {}
+        ],
+        "dmsc0dc": [
+            "Drift",
+            {
+                "length": 0.10159999877214432,
+                "tracking_method": "linear"
+            }
+        ],
+        "vpl0bd": [
+            "Marker",
+            {}
+        ],
+        "dmsc0dd": [
+            "Drift",
+            {
+                "length": 0.15640699863433838,
+                "tracking_method": "linear"
+            }
+        ],
+        "msc0d": [
+            "Marker",
+            {}
+        ],
+        "vvl0bd": [
+            "Marker",
+            {}
+        ],
+        "endl0b": [
+            "Marker",
+            {}
+        ],
+        "beghtr": [
+            "Marker",
+            {}
+        ],
+        "d0h00a": [
+            "Drift",
+            {
+                "length": 0.2502000033855438,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfb0h00": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:HTR:102"
+                }
+            }
+        ],
+        "d0h00b": [
+            "Drift",
+            {
+                "length": 0.0560000017285347,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc0h00_drift": [
+            "Drift",
+            {
+                "length": 0.05999999865889549,
+                "tracking_method": "linear"
+            }
+        ],
+        "pc0h00_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.006000000052154064,
+                "y_max": 0.006000000052154064,
+                "shape": "elliptical",
+                "is_active": true
+            }
+        ],
+        "d0h00c": [
+            "Drift",
+            {
+                "length": 0.2919749915599823,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h01": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -6.525507926940918,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:120"
+                }
+            }
+        ],
+        "d0h01a": [
+            "Drift",
+            {
+                "length": 0.21394899487495422,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc0h01": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:HTR:129"
+                }
+            }
+        ],
+        "d0h01b": [
+            "Drift",
+            {
+                "length": 0.21394899487495422,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h02": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": 6.335021018981934,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:140"
+                }
+            }
+        ],
+        "d0h02a": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc0h01": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:HTR:148"
+                }
+            }
+        ],
+        "d0h02b": [
+            "Drift",
+            {
+                "length": 0.9114609956741333,
+                "tracking_method": "linear"
+            }
+        ],
+        "dp0h01": [
+            "Marker",
+            {}
+        ],
+        "d0h02c": [
+            "Drift",
+            {
+                "length": 0.4856480062007904,
+                "tracking_method": "linear"
+            }
+        ],
+        "dp0h02": [
+            "Marker",
+            {}
+        ],
+        "d0h02d": [
+            "Drift",
+            {
+                "length": 2.077199935913086,
+                "tracking_method": "linear"
+            }
+        ],
+        "dp0h03": [
+            "Marker",
+            {}
+        ],
+        "d0h02e": [
+            "Drift",
+            {
+                "length": 0.29509401321411133,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc0h03": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:HTR:288"
+                }
+            }
+        ],
+        "d0h02f": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h03": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -0.9477308392524719,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:300"
+                }
+            }
+        ],
+        "d0h03a": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc0h03": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:HTR:309"
+                }
+            }
+        ],
+        "d0h03b": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h04": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -3.418410301208496,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:320"
+                }
+            }
+        ],
+        "d0h04a": [
+            "Drift",
+            {
+                "length": 0.21480000019073486,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfb0h04": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:HTR:325"
+                }
+            }
+        ],
+        "d0h04b": [
+            "Drift",
+            {
+                "length": 0.0333000011742115,
+                "tracking_method": "linear"
+            }
+        ],
+        "otr0h04": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "OTRS:HTR:330"
+                }
+            }
+        ],
+        "otr0h04_yag": [
+            "Marker",
+            {}
+        ],
+        "d0h04c": [
+            "Drift",
+            {
+                "length": 0.24369999766349792,
+                "tracking_method": "linear"
+            }
+        ],
+        "ws0h04": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:HTR:340"
+                }
+            }
+        ],
+        "d0h04d": [
+            "Drift",
+            {
+                "length": 0.2492000013589859,
+                "tracking_method": "linear"
+            }
+        ],
+        "bz0h04": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "BLEN:HTR:350"
+                }
+            }
+        ],
+        "d0h04e": [
+            "Drift",
+            {
+                "length": 0.35690000653266907,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h05": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -7.013523578643799,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:365"
+                }
+            }
+        ],
+        "d0h05a": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc0h05": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:HTR:377"
+                }
+            }
+        ],
+        "d0h05b": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h06": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": 1.4503223896026611,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:385"
+                }
+            }
+        ],
+        "d0h06a": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc0h05": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:HTR:396"
+                }
+            }
+        ],
+        "d0h06b": [
+            "Drift",
+            {
+                "length": 0.9562640190124512,
+                "tracking_method": "linear"
+            }
+        ],
+        "xc0h07": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:HTR:428"
+                }
+            }
+        ],
+        "d0h06c": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h07": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": 7.874726295471191,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:440"
+                }
+            }
+        ],
+        "d0h07a": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "yc0h07": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:HTR:451"
+                }
+            }
+        ],
+        "d0h07b": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "q0h08": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -8.293356895446777,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:460"
+                }
+            }
+        ],
+        "d0h08a": [
+            "Drift",
+            {
+                "length": 0.19339999556541443,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfb0h08": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BMPS:HTR:475"
+                }
+            }
+        ],
+        "d0h08b": [
+            "Drift",
+            {
+                "length": 0.1753000020980835,
+                "tracking_method": "linear"
+            }
+        ],
+        "lhbegb": [
+            "Marker",
+            {}
+        ],
+        "bcxh1": [
+            "Dipole",
+            {
+                "length": 0.12441013753414154,
+                "angle": 0.022113759070634842,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.022113759070634842,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.388700008392334,
+                "fringe_integral_exit": 0.388700008392334,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:HTR:480"
+                }
+            }
+        ],
+        "dh01a": [
+            "Drift",
+            {
+                "length": 1.5377992391586304,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmh1": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:HTR:540"
+                }
+            }
+        ],
+        "dh01b": [
+            "Drift",
+            {
+                "length": 0.37570858001708984,
+                "tracking_method": "linear"
+            }
+        ],
+        "mirlhu": [
+            "Marker",
+            {}
+        ],
+        "dh01c": [
+            "Drift",
+            {
+                "length": 1.352224349975586,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxh2": [
+            "Dipole",
+            {
+                "length": 0.12441013753414154,
+                "angle": -0.022113759070634842,
+                "k1": 0.0,
+                "dipole_e1": -0.022113759070634842,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.388700008392334,
+                "fringe_integral_exit": 0.388700008392334,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:HTR:600"
+                }
+            }
+        ],
+        "dh02a": [
+            "Drift",
+            {
+                "length": 0.16261400282382965,
+                "tracking_method": "linear"
+            }
+        ],
+        "cehtr_drift": [
+            "Drift",
+            {
+                "length": 0.05999999865889549,
+                "tracking_method": "linear"
+            }
+        ],
+        "cehtr_aperture": [
+            "Aperture",
+            {
+                "x_max": 0.003000000026077032,
+                "y_max": Infinity,
+                "shape": "rectangular",
+                "is_active": true
+            }
+        ],
+        "dh02b": [
+            "Drift",
+            {
+                "length": 0.268449991941452,
+                "tracking_method": "linear"
+            }
+        ],
+        "yagh1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "YAGS:HTR:625"
+                }
+            }
+        ],
+        "dh02c": [
+            "Drift",
+            {
+                "length": 0.2896380126476288,
+                "tracking_method": "linear"
+            }
+        ],
+        "umhtr": [
+            "Drift",
+            {
+                "length": 0.24300000071525574,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "USEG:HTR:650"
+                }
+            }
+        ],
+        "htrundb": [
+            "Marker",
+            {}
+        ],
+        "dh02d": [
+            "Drift",
+            {
+                "length": 0.2826021909713745,
+                "tracking_method": "linear"
+            }
+        ],
+        "yagh2": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "YAGS:HTR:675"
+                }
+            }
+        ],
+        "dh02e": [
+            "Drift",
+            {
+                "length": 0.45999979972839355,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxh3": [
+            "Dipole",
+            {
+                "length": 0.12441013753414154,
+                "angle": -0.022113759070634842,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.022113759070634842,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.388700008392334,
+                "fringe_integral_exit": 0.388700008392334,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:HTR:700"
+                }
+            }
+        ],
+        "dh03a": [
+            "Drift",
+            {
+                "length": 1.390334129333496,
+                "tracking_method": "linear"
+            }
+        ],
+        "mirlhd": [
+            "Marker",
+            {}
+        ],
+        "dh03b": [
+            "Drift",
+            {
+                "length": 0.3375988304615021,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmh2": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:HTR:760"
+                }
+            }
+        ],
+        "dh03c": [
+            "Drift",
+            {
+                "length": 1.5377992391586304,
+                "tracking_method": "linear"
+            }
+        ],
+        "bcxh4": [
+            "Dipole",
+            {
+                "length": 0.12441013753414154,
+                "angle": 0.022113759070634842,
+                "k1": 0.0,
+                "dipole_e1": 0.022113759070634842,
+                "dipole_e2": 0.0,
+                "tilt": 0.0,
+                "gap": 0.029999999329447746,
+                "gap_exit": 0.029999999329447746,
+                "fringe_integral": 0.388700008392334,
+                "fringe_integral_exit": 0.388700008392334,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:HTR:820"
+                }
+            }
+        ],
+        "cnthtr": [
+            "Marker",
+            {}
+        ],
+        "lhendb": [
+            "Marker",
+            {}
+        ],
+        "dhd00a": [
+            "Drift",
+            {
+                "length": 0.28139880299568176,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhd00": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:HTR:825"
+                }
+            }
+        ],
+        "dhd00b": [
+            "Drift",
+            {
+                "length": 0.10000000149011612,
+                "tracking_method": "linear"
+            }
+        ],
+        "qhd01": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -8.926305770874023,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:830"
+                }
+            }
+        ],
+        "dhd01a": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "ychd01": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:HTR:841"
+                }
+            }
+        ],
+        "dhd01b": [
+            "Drift",
+            {
+                "length": 0.24678799510002136,
+                "tracking_method": "linear"
+            }
+        ],
+        "xchd01": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:HTR:848"
+                }
+            }
+        ],
+        "dhd01c": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "qhd02": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": 6.460615158081055,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:860"
+                }
+            }
+        ],
+        "dhd02a1": [
+            "Drift",
+            {
+                "length": 1.2927780151367188,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbcsi1": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "ACM:HTR:910"
+                }
+            }
+        ],
+        "dhd02a2": [
+            "Drift",
+            {
+                "length": 0.3054099977016449,
+                "tracking_method": "linear"
+            }
+        ],
+        "imbcsi2": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "ACM:HTR:922"
+                }
+            }
+        ],
+        "dhd02a3": [
+            "Drift",
+            {
+                "length": 0.7772939801216125,
+                "tracking_method": "linear"
+            }
+        ],
+        "ychd03": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:HTR:951"
+                }
+            }
+        ],
+        "dhd02b": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "qhd03": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": -8.534034729003906,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:960"
+                }
+            }
+        ],
+        "dhd03a": [
+            "Drift",
+            {
+                "length": 0.2549059987068176,
+                "tracking_method": "linear"
+            }
+        ],
+        "xchd03": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:HTR:974"
+                }
+            }
+        ],
+        "dhd03b": [
+            "Drift",
+            {
+                "length": 0.20490600168704987,
+                "tracking_method": "linear"
+            }
+        ],
+        "qhd04": [
+            "Quadrupole",
+            {
+                "length": 0.12439999729394913,
+                "k1": 6.807615280151367,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:HTR:980"
+                }
+            }
+        ],
+        "dhd04a": [
+            "Drift",
+            {
+                "length": 0.12089979648590088,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbhd04": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:HTR:990"
+                }
+            }
+        ],
+        "dhd04b": [
+            "Drift",
+            {
+                "length": 0.24789980053901672,
+                "tracking_method": "linear"
+            }
+        ],
+        "endhtr": [
+            "Marker",
+            {}
+        ],
+        "begdiag0": [
+            "Marker",
+            {}
+        ],
+        "bkrdg0": [
+            "Dipole",
+            {
+                "length": 1.0000115633010864,
+                "angle": -0.008333181031048298,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": -0.008333181031048298,
+                "tilt": 1.7474957704544067,
+                "gap": 0.03500000014901161,
+                "gap_exit": 0.03500000014901161,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "KICK:DIAG0:110"
+                }
+            }
+        ],
+        "rodg0k": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "dkv0a": [
+            "Drift",
+            {
+                "length": 0.6489275097846985,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmdg000": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:COL0:135"
+                }
+            }
+        ],
+        "dkv0b": [
+            "Drift",
+            {
+                "length": 0.6511176228523254,
+                "tracking_method": "linear"
+            }
+        ],
+        "m1dg0": [
+            "Marker",
+            {}
+        ],
+        "blrdg0": [
+            "Dipole",
+            {
+                "length": 0.40074828267097473,
+                "angle": 0.10488853603601456,
+                "k1": 0.0,
+                "dipole_e1": 0.0,
+                "dipole_e2": 0.10488853603601456,
+                "tilt": 0.1766994446516037,
+                "gap": 0.019999999552965164,
+                "gap_exit": 0.019999999552965164,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DIAG0:155"
+                }
+            }
+        ],
+        "rodg0l": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "dqb01a": [
+            "Drift",
+            {
+                "length": 0.15000000596046448,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbdg001": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:DIAG0:160"
+                }
+            }
+        ],
+        "dqb01b": [
+            "Drift",
+            {
+                "length": 0.802327036857605,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdg001": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:178"
+                }
+            }
+        ],
+        "dqb01c": [
+            "Drift",
+            {
+                "length": 0.25,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg001": [
+            "Quadrupole",
+            {
+                "length": 0.09849999845027924,
+                "k1": 9.807425498962402,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:190"
+                }
+            }
+        ],
+        "bpmdg001": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:190"
+                }
+            }
+        ],
+        "dqb02a": [
+            "Drift",
+            {
+                "length": 0.4148208498954773,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdg001": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:199"
+                }
+            }
+        ],
+        "dqb02b": [
+            "Drift",
+            {
+                "length": 0.25,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg002": [
+            "Quadrupole",
+            {
+                "length": 0.09849999845027924,
+                "k1": -7.825140476226807,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:210"
+                }
+            }
+        ],
+        "bpmdg002": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:210"
+                }
+            }
+        ],
+        "dqb03a": [
+            "Drift",
+            {
+                "length": 0.4148208498954773,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdg002": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:218"
+                }
+            }
+        ],
+        "dqb03b": [
+            "Drift",
+            {
+                "length": 0.25,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg003": [
+            "Quadrupole",
+            {
+                "length": 0.09849999845027924,
+                "k1": 9.807425498962402,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:230"
+                }
+            }
+        ],
+        "bpmdg003": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:230"
+                }
+            }
+        ],
+        "dqb04a": [
+            "Drift",
+            {
+                "length": 0.7784284949302673,
+                "tracking_method": "linear"
+            }
+        ],
+        "ycdg002": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:247"
+                }
+            }
+        ],
+        "dqb04b": [
+            "Drift",
+            {
+                "length": 0.45320001244544983,
+                "tracking_method": "linear"
+            }
+        ],
+        "bxdg0": [
+            "Dipole",
+            {
+                "length": 0.400182843208313,
+                "angle": -0.10471975803375244,
+                "k1": 0.0,
+                "dipole_e1": -0.05235987901687622,
+                "dipole_e2": -0.05235987901687622,
+                "tilt": 0.0,
+                "gap": 0.019999999552965164,
+                "gap_exit": 0.019999999552965164,
+                "fringe_integral": 0.5,
+                "fringe_integral_exit": 0.5,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DIAG0:260"
+                }
+            }
+        ],
+        "bxdg0t": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0
+            }
+        ],
+        "cntdg0": [
+            "Marker",
+            {}
+        ],
+        "m2dg0": [
+            "Marker",
+            {}
+        ],
+        "ddg003": [
+            "Drift",
+            {
+                "length": 0.37441882491111755,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg004": [
+            "Quadrupole",
+            {
+                "length": 0.05400000140070915,
+                "k1": 8.77167797088623,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:270"
+                }
+            }
+        ],
+        "bpmdg004": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:270"
+                }
+            }
+        ],
+        "ddg004a": [
+            "Drift",
+            {
+                "length": 0.2705000042915344,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdg003": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:280"
+                }
+            }
+        ],
+        "ycdg003": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:280"
+                }
+            }
+        ],
+        "ddg004b": [
+            "Drift",
+            {
+                "length": 0.2705000042915344,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg005": [
+            "Quadrupole",
+            {
+                "length": 0.05400000140070915,
+                "k1": -12.053189277648926,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:285"
+                }
+            }
+        ],
+        "bpmdg005": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:285"
+                }
+            }
+        ],
+        "ddg005a": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdg005": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:290"
+                }
+            }
+        ],
+        "ycdg005": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:290"
+                }
+            }
+        ],
+        "ddg005b": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg006": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 6.830639839172363,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:300"
+                }
+            }
+        ],
+        "ddg006a": [
+            "Drift",
+            {
+                "length": 0.7327514290809631,
+                "tracking_method": "linear"
+            }
+        ],
+        "tcydg0": [
+            "Drift",
+            {
+                "length": 0.5080000162124634,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "ACCL:DIAG0:320"
+                }
+            }
+        ],
+        "ddg006b": [
+            "Drift",
+            {
+                "length": 0.12714000046253204,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmdg0rf": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:330"
+                }
+            }
+        ],
+        "ddg006c": [
+            "Drift",
+            {
+                "length": 0.17285999655723572,
+                "tracking_method": "linear"
+            }
+        ],
+        "tcxdg0": [
+            "TransverseDeflectingCavity",
+            {
+                "length": 0.2540000081062317,
+                "voltage": 350000.0,
+                "phase": 0.0,
+                "frequency": 2856000000.0,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "num_steps": 1,
+                "tracking_method": "bmadx",
+                "metadata": {
+                    "alias": "ACCL:DIAG0:340"
+                }
+            }
+        ],
+        "ycdgtcx": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:340"
+                }
+            }
+        ],
+        "xcdgtcx": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:340"
+                }
+            }
+        ],
+        "ddg006d": [
+            "Drift",
+            {
+                "length": 0.4869999885559082,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg007": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": -4.543712615966797,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:360"
+                }
+            }
+        ],
+        "ddg007": [
+            "Drift",
+            {
+                "length": 0.5479999780654907,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg008": [
+            "Quadrupole",
+            {
+                "length": 0.05400000140070915,
+                "k1": 11.37702751159668,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:370"
+                }
+            }
+        ],
+        "bpmdg008": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:370"
+                }
+            }
+        ],
+        "ddg008a": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdg008": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:380"
+                }
+            }
+        ],
+        "ycdg008": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:380"
+                }
+            }
+        ],
+        "ddg008b": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg009": [
+            "Quadrupole",
+            {
+                "length": 0.05400000140070915,
+                "k1": -11.539229393005371,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:390"
+                }
+            }
+        ],
+        "bpmdg009": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:390"
+                }
+            }
+        ],
+        "ddg009a": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrdg01": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "OTRS:DIAG0:396"
+                }
+            }
+        ],
+        "otrdg01_yag": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "ddg009b": [
+            "Drift",
+            {
+                "length": 0.699999988079071,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbdg002": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:DIAG0:410"
+                }
+            }
+        ],
+        "ddg009c": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrdg02": [
+            "Screen",
+            {
+                "resolution": [
+                    1944,
+                    1472
+                ],
+                "pixel_size": [
+                    2.3299999156733975e-05,
+                    2.3299999156733975e-05
+                ],
+                "binning": 1,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "method": "histogram",
+                "kde_bandwidth": 1.1000000085914508e-05,
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:DIAG0:420"
+                }
+            }
+        ],
+        "ddg009d": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear"
+            }
+        ],
+        "wsdg01": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "WIRE:DIAG0:424"
+                }
+            }
+        ],
+        "ddg009e": [
+            "Drift",
+            {
+                "length": 0.699999988079071,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrdg03": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "OTRS:DIAG0:440"
+                }
+            }
+        ],
+        "otrdg03_yag": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear"
+            }
+        ],
+        "ddg009f": [
+            "Drift",
+            {
+                "length": 0.6660000085830688,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg010": [
+            "Quadrupole",
+            {
+                "length": 0.1080000028014183,
+                "k1": 13.016651153564453,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:455"
+                }
+            }
+        ],
+        "ddg010a": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "xcdg010": [
+            "HorizontalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "XCOR:DIAG0:460"
+                }
+            }
+        ],
+        "ycdg010": [
+            "VerticalCorrector",
+            {
+                "length": 0.0,
+                "angle": 0.0,
+                "metadata": {
+                    "alias": "YCOR:DIAG0:460"
+                }
+            }
+        ],
+        "ddg010b": [
+            "Drift",
+            {
+                "length": 0.29600000381469727,
+                "tracking_method": "linear"
+            }
+        ],
+        "qdg011": [
+            "Quadrupole",
+            {
+                "length": 0.05400000140070915,
+                "k1": -10.983651161193848,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "tilt": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "QUAD:DIAG0:470"
+                }
+            }
+        ],
+        "bpmdg011": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:470"
+                }
+            }
+        ],
+        "ddg011a": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear"
+            }
+        ],
+        "rfbdg003": [
+            "Drift",
+            {
+                "length": 0.0,
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BPMS:DIAG0:480"
+                }
+            }
+        ],
+        "ddg011b": [
+            "Drift",
+            {
+                "length": 1.1047999858856201,
+                "tracking_method": "linear"
+            }
+        ],
+        "bydg0": [
+            "Dipole",
+            {
+                "length": 0.5435000061988831,
+                "angle": -0.6108652353286743,
+                "k1": 0.0,
+                "dipole_e1": -0.12723450362682343,
+                "dipole_e2": -0.12723450362682343,
+                "tilt": 1.5707963705062866,
+                "gap": 0.03400000184774399,
+                "gap_exit": 0.03400000184774399,
+                "fringe_integral": 0.39100000262260437,
+                "fringe_integral_exit": 0.39100000262260437,
+                "fringe_at": "both",
+                "fringe_type": "linear_edge",
+                "tracking_method": "linear",
+                "metadata": {
+                    "alias": "BEND:DIAG0:510"
+                }
+            }
+        ],
+        "ddg012a": [
+            "Drift",
+            {
+                "length": 0.3952963054180145,
+                "tracking_method": "linear"
+            }
+        ],
+        "bpmdg012": [
+            "BPM",
+            {
+                "is_active": true,
+                "metadata": {
+                    "alias": "BPMS:DIAG0:520"
+                }
+            }
+        ],
+        "ddg012b": [
+            "Drift",
+            {
+                "length": 0.23999999463558197,
+                "tracking_method": "linear"
+            }
+        ],
+        "otrdg04": [
+            "Screen",
+            {
+                "resolution": [
+                    1944,
+                    1472
+                ],
+                "pixel_size": [
+                    1.748000067891553e-05,
+                    1.748000067891553e-05
+                ],
+                "binning": 1,
+                "misalignment": [
+                    0.0,
+                    0.0
+                ],
+                "method": "histogram",
+                "kde_bandwidth": 1.1000000085914508e-05,
+                "is_active": true,
+                "metadata": {
+                    "alias": "OTRS:DIAG0:525"
+                }
+            }
+        ],
+        "ddg012c": [
+            "Drift",
+            {
+                "length": 0.30000001192092896,
+                "tracking_method": "linear"
+            }
+        ],
+        "fcdg0du": [
+            "Marker",
+            {
+                "metadata": {
+                    "alias": "FARC:DIAG0:530"
+                }
+            }
+        ],
+        "enddiag0": [
+            "Marker",
+            {}
+        ]
     },
     "lattices": {
-        "sc_diag0": ["beam0", "dcm4b", "qcm01", "dcm5", "cm01end", "dcmcm1", "homcm", "dcap0da", "astra", "dcap0db", "fc1", "dmsc0da", "blf1", "dmsc0db", "vgl0bd", "dmsc0dc", "vpl0bd", "dmsc0dd", "msc0d", "vvl0bd", "endl0b", "beghtr", "d0h00a", "rfb0h00", "d0h00b", "pc0h00_drift", "pc0h00_aperture", "d0h00c", "q0h01", "d0h01a", "yc0h01", "d0h01b", "q0h02", "d0h02a", "xc0h01", "d0h02b", "dp0h01", "d0h02c", "dp0h02", "d0h02d", "dp0h03", "d0h02e", "xc0h03", "d0h02f", "q0h03", "d0h03a", "yc0h03", "d0h03b", "q0h04", "d0h04a", "rfb0h04", "d0h04b", "otr0h04", "otr0h04_yag", "d0h04c", "ws0h04", "d0h04d", "bz0h04", "d0h04e", "q0h05", "d0h05a", "yc0h05", "d0h05b", "q0h06", "d0h06a", "xc0h05", "d0h06b", "xc0h07", "d0h06c", "q0h07", "d0h07a", "yc0h07", "d0h07b", "q0h08", "d0h08a", "rfb0h08", "d0h08b", "lhbegb", "bcxh1", "dh01a", "bpmh1", "dh01b", "mirlhu", "dh01c", "bcxh2", "dh02a", "cehtr_drift", "cehtr_aperture", "dh02b", "yagh1", "dh02c", "umhtr", "htrundb", "umhtr", "dh02d", "yagh2", "dh02e", "bcxh3", "dh03a", "mirlhd", "dh03b", "bpmh2", "dh03c", "bcxh4", "cnthtr", "lhendb", "dhd00a", "rfbhd00", "dhd00b", "qhd01", "dhd01a", "ychd01", "dhd01b", "xchd01", "dhd01c", "qhd02", "dhd02a1", "imbcsi1", "dhd02a2", "imbcsi2", "dhd02a3", "ychd03", "dhd02b", "qhd03", "dhd03a", "xchd03", "dhd03b", "qhd04", "dhd04a", "rfbhd04", "dhd04b", "endhtr", "begdiag0", "bkrdg0", "rodg0k", "dkv0a", "bpmdg000", "dkv0b", "m1dg0", "blrdg0", "rodg0l", "dqb01a", "rfbdg001", "dqb01b", "xcdg001", "dqb01c", "qdg001", "bpmdg001", "qdg001", "dqb02a", "ycdg001", "dqb02b", "qdg002", "bpmdg002", "qdg002", "dqb03a", "xcdg002", "dqb03b", "qdg003", "bpmdg003", "qdg003", "dqb04a", "ycdg002", "dqb04b", "bxdg0", "bxdg0t", "cntdg0", "m2dg0", "ddg003", "qdg004", "bpmdg004", "qdg004", "ddg004a", "xcdg003", "ycdg003", "ddg004b", "qdg005", "bpmdg005", "qdg005", "ddg005a", "xcdg005", "ycdg005", "ddg005b", "qdg006", "ddg006a", "tcydg0", "ddg006b", "bpmdg0rf", "ddg006c", "tcxdg0", "ycdgtcx", "xcdgtcx", "tcxdg0", "ddg006d", "qdg007", "ddg007", "qdg008", "bpmdg008", "qdg008", "ddg008a", "xcdg008", "ycdg008", "ddg008b", "qdg009", "bpmdg009", "qdg009", "ddg009a", "otrdg01", "otrdg01_yag", "ddg009b", "rfbdg002", "ddg009c", "otrdg02", "ddg009d", "wsdg01", "ddg009e", "otrdg03", "otrdg03_yag", "ddg009f", "qdg010", "ddg010a", "xcdg010", "ycdg010", "ddg010b", "qdg011", "bpmdg011", "qdg011", "ddg011a", "rfbdg003", "ddg011b", "bydg0", "ddg012a", "bpmdg012", "ddg012b", "otrdg04", "ddg012c", "fcdg0du", "enddiag0"]
+        "sc_diag0": [
+            "beam0",
+            "dcm4b",
+            "qcm01",
+            "dcm5",
+            "cm01end",
+            "dcmcm1",
+            "homcm",
+            "dcap0da",
+            "astra",
+            "dcap0db",
+            "fc1",
+            "dmsc0da",
+            "blf1",
+            "dmsc0db",
+            "vgl0bd",
+            "dmsc0dc",
+            "vpl0bd",
+            "dmsc0dd",
+            "msc0d",
+            "vvl0bd",
+            "endl0b",
+            "beghtr",
+            "d0h00a",
+            "rfb0h00",
+            "d0h00b",
+            "pc0h00_drift",
+            "pc0h00_aperture",
+            "d0h00c",
+            "q0h01",
+            "d0h01a",
+            "yc0h01",
+            "d0h01b",
+            "q0h02",
+            "d0h02a",
+            "xc0h01",
+            "d0h02b",
+            "dp0h01",
+            "d0h02c",
+            "dp0h02",
+            "d0h02d",
+            "dp0h03",
+            "d0h02e",
+            "xc0h03",
+            "d0h02f",
+            "q0h03",
+            "d0h03a",
+            "yc0h03",
+            "d0h03b",
+            "q0h04",
+            "d0h04a",
+            "rfb0h04",
+            "d0h04b",
+            "otr0h04",
+            "otr0h04_yag",
+            "d0h04c",
+            "ws0h04",
+            "d0h04d",
+            "bz0h04",
+            "d0h04e",
+            "q0h05",
+            "d0h05a",
+            "yc0h05",
+            "d0h05b",
+            "q0h06",
+            "d0h06a",
+            "xc0h05",
+            "d0h06b",
+            "xc0h07",
+            "d0h06c",
+            "q0h07",
+            "d0h07a",
+            "yc0h07",
+            "d0h07b",
+            "q0h08",
+            "d0h08a",
+            "rfb0h08",
+            "d0h08b",
+            "lhbegb",
+            "bcxh1",
+            "dh01a",
+            "bpmh1",
+            "dh01b",
+            "mirlhu",
+            "dh01c",
+            "bcxh2",
+            "dh02a",
+            "cehtr_drift",
+            "cehtr_aperture",
+            "dh02b",
+            "yagh1",
+            "dh02c",
+            "umhtr",
+            "htrundb",
+            "umhtr",
+            "dh02d",
+            "yagh2",
+            "dh02e",
+            "bcxh3",
+            "dh03a",
+            "mirlhd",
+            "dh03b",
+            "bpmh2",
+            "dh03c",
+            "bcxh4",
+            "cnthtr",
+            "lhendb",
+            "dhd00a",
+            "rfbhd00",
+            "dhd00b",
+            "qhd01",
+            "dhd01a",
+            "ychd01",
+            "dhd01b",
+            "xchd01",
+            "dhd01c",
+            "qhd02",
+            "dhd02a1",
+            "imbcsi1",
+            "dhd02a2",
+            "imbcsi2",
+            "dhd02a3",
+            "ychd03",
+            "dhd02b",
+            "qhd03",
+            "dhd03a",
+            "xchd03",
+            "dhd03b",
+            "qhd04",
+            "dhd04a",
+            "rfbhd04",
+            "dhd04b",
+            "endhtr",
+            "begdiag0",
+            "bkrdg0",
+            "rodg0k",
+            "dkv0a",
+            "bpmdg000",
+            "dkv0b",
+            "m1dg0",
+            "blrdg0",
+            "rodg0l",
+            "dqb01a",
+            "rfbdg001",
+            "dqb01b",
+            "xcdg001",
+            "dqb01c",
+            "qdg001",
+            "bpmdg001",
+            "qdg001",
+            "dqb02a",
+            "ycdg001",
+            "dqb02b",
+            "qdg002",
+            "bpmdg002",
+            "qdg002",
+            "dqb03a",
+            "xcdg002",
+            "dqb03b",
+            "qdg003",
+            "bpmdg003",
+            "qdg003",
+            "dqb04a",
+            "ycdg002",
+            "dqb04b",
+            "bxdg0",
+            "bxdg0t",
+            "cntdg0",
+            "m2dg0",
+            "ddg003",
+            "qdg004",
+            "bpmdg004",
+            "qdg004",
+            "ddg004a",
+            "xcdg003",
+            "ycdg003",
+            "ddg004b",
+            "qdg005",
+            "bpmdg005",
+            "qdg005",
+            "ddg005a",
+            "xcdg005",
+            "ycdg005",
+            "ddg005b",
+            "qdg006",
+            "ddg006a",
+            "tcydg0",
+            "ddg006b",
+            "bpmdg0rf",
+            "ddg006c",
+            "tcxdg0",
+            "ycdgtcx",
+            "xcdgtcx",
+            "tcxdg0",
+            "ddg006d",
+            "qdg007",
+            "ddg007",
+            "qdg008",
+            "bpmdg008",
+            "qdg008",
+            "ddg008a",
+            "xcdg008",
+            "ycdg008",
+            "ddg008b",
+            "qdg009",
+            "bpmdg009",
+            "qdg009",
+            "ddg009a",
+            "otrdg01",
+            "otrdg01_yag",
+            "ddg009b",
+            "rfbdg002",
+            "ddg009c",
+            "otrdg02",
+            "ddg009d",
+            "wsdg01",
+            "ddg009e",
+            "otrdg03",
+            "otrdg03_yag",
+            "ddg009f",
+            "qdg010",
+            "ddg010a",
+            "xcdg010",
+            "ycdg010",
+            "ddg010b",
+            "qdg011",
+            "bpmdg011",
+            "qdg011",
+            "ddg011a",
+            "rfbdg003",
+            "ddg011b",
+            "bydg0",
+            "ddg012a",
+            "bpmdg012",
+            "ddg012b",
+            "otrdg04",
+            "ddg012c",
+            "fcdg0du",
+            "enddiag0"
+        ]
     }
 }


### PR DESCRIPTION
This pull request introduces a new script, `cheetah/conversion/add_alias.py`, to automate the injection of `metadata.alias` fields into Cheetah JSON element definitions. The script reads alias mappings from the LCLS element CSV table and updates the corresponding JSON files, with options for dry-run and custom paths.

**New script for alias injection:**

* Adds `add_alias.py`, a command-line tool that reads alias mappings from `lcls_elements.csv` and injects them as `metadata.alias` into element definitions in Cheetah JSON files.
* Supports dry-run mode to preview changes without modifying files, and allows custom paths for both the CSV input and the target JSON directory.
* Handles robust parsing of CSV and JSON, including fallback logic for missing fields and safe updating of nested metadata.
* Provides summary output of matched and updated elements per file, and overall statistics at the end of execution.