### PR TITLE
Deploy Key For Publish Docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,5 +33,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@4a2e02b36f31d8974a0d09d3bb9f3172aa2d0d0d #v3
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.SELF_SSH_DEPLOY_KEY }}
           publish_dir: ./site/


### PR DESCRIPTION
To comply with new security settings, gh-pages.yml moving from tokens to deploy key.